### PR TITLE
fix(ui): 为内容溢出页面补充滚动兜底

### DIFF
--- a/app/desktop/Nori.Desktop.Tests/TestPlatformAliases.cs
+++ b/app/desktop/Nori.Desktop.Tests/TestPlatformAliases.cs
@@ -1,0 +1,12 @@
+global using OperatingSystem = Nori.Desktop.Tests.TestOperatingSystem;
+
+namespace Nori.Desktop.Tests;
+
+/// <summary>
+/// 让默认测试夹具在所有 CI 平台上使用一致的 Windows 自动化语义。
+/// 需要验证非 Windows 拒绝路径的测试仍通过 automationWindows=false 显式注入。
+/// </summary>
+internal static class TestOperatingSystem
+{
+	public static bool IsWindows() => true;
+}

--- a/app/desktop/src/App.vue
+++ b/app/desktop/src/App.vue
@@ -73,7 +73,7 @@ RUNTIME.onLanguageChanged((language) => {
 				<NNotificationProvider>
 					<main
 						v-if="RUNTIME.bootstrapError.value"
-						class="w-100vw h-100vh flex items-center justify-center bg-bg-abyss p-6"
+						class="w-100vw h-100vh scroll-area flex items-center justify-center bg-bg-abyss p-6"
 						role="alert"
 						aria-live="assertive"
 					>

--- a/app/desktop/src/App.vue
+++ b/app/desktop/src/App.vue
@@ -73,21 +73,23 @@ RUNTIME.onLanguageChanged((language) => {
 				<NNotificationProvider>
 					<main
 						v-if="RUNTIME.bootstrapError.value"
-						class="w-100vw h-100vh scroll-area flex items-center justify-center bg-bg-abyss p-6"
+						class="w-100vw h-100vh scroll-area bg-bg-abyss p-6"
 						role="alert"
 						aria-live="assertive"
 					>
-						<section class="w-full max-w-[48rem] flex flex-col items-center gap-4 rounded-lg border border-danger/35 bg-bg-card/90 p-6 text-center shadow-elev-2">
-							<span class="flex h-12 w-12 items-center justify-center rounded-full bg-danger/12 text-danger-text">
-								<Icon name="alert" :size="24"/>
-							</span>
-							<h1 class="m-0 text-xl font-700 text-text-primary">{{ I18N.bootstrapTitle }}</h1>
-							<p class="m-0 text-base text-text-body">{{ I18N.bootstrapDesc }}</p>
-							<p v-if="bootstrapErrorText" class="m-0 max-w-full break-words text-sm text-danger-text" role="status">{{ bootstrapErrorText }}</p>
-							<AppButton variant="primary" icon="refresh" :loading="retryingBootstrap" @click="retryBootstrap">
-								{{ retryingBootstrap ? I18N.bootstrapRetrying : I18N.retry }}
-							</AppButton>
-						</section>
+						<div class="min-h-full flex items-center justify-center">
+							<section class="w-full max-w-[48rem] flex flex-col items-center gap-4 rounded-lg border border-danger/35 bg-bg-card/90 p-6 text-center shadow-elev-2">
+								<span class="flex h-12 w-12 items-center justify-center rounded-full bg-danger/12 text-danger-text">
+									<Icon name="alert" :size="24"/>
+								</span>
+								<h1 class="m-0 text-xl font-700 text-text-primary">{{ I18N.bootstrapTitle }}</h1>
+								<p class="m-0 text-base text-text-body">{{ I18N.bootstrapDesc }}</p>
+								<p v-if="bootstrapErrorText" class="m-0 max-w-full break-words text-sm text-danger-text" role="status">{{ bootstrapErrorText }}</p>
+								<AppButton variant="primary" icon="refresh" :loading="retryingBootstrap" @click="retryBootstrap">
+									{{ retryingBootstrap ? I18N.bootstrapRetrying : I18N.retry }}
+								</AppButton>
+							</section>
+						</div>
 					</main>
 					<template v-else>
 						<FeedbackHost/>
@@ -111,4 +113,3 @@ RUNTIME.onLanguageChanged((language) => {
 		</NMessageProvider>
 	</NConfigProvider>
 </template>
-

--- a/app/desktop/src/views/InitView.vue
+++ b/app/desktop/src/views/InitView.vue
@@ -119,34 +119,36 @@ onMounted(async () => {
 			</button>
 		</TitleBar>
 
-		<div class="flex-1 min-h-0 scroll-area flex flex-col items-center justify-center gap-7 pb-6 relative">
-			<!-- 多重轨道天体声呐光环 -->
-			<div class="relative w-[15rem] h-[15rem] flex items-center justify-center">
-				<span class="absolute inset-0 rounded-full border border-dashed border-nori-teal-bright/40 [animation:rotate_14s_linear_infinite]"/>
-				<span class="absolute inset-2.5 rounded-full border border-dotted border-nori-teal/30 [animation:rotate_22s_linear_infinite_reverse]"/>
-				<span class="absolute inset-5 rounded-full bg-[radial-gradient(circle,var(--glow-teal)_0%,var(--glow-teal-soft)_45%,transparent_75%)] animate-glow-pulse"/>
-				<img class="relative w-[8.2rem] h-[8.2rem] object-contain animate-breathe drop-shadow-[0_0_1.6rem_var(--glow-teal-soft)]" :src="logo" alt="Nori"/>
-			</div>
+		<div class="flex-1 min-h-0 scroll-area">
+			<div class="min-h-full flex flex-col items-center justify-center gap-7 pb-6 relative">
+				<!-- 多重轨道天体声呐光环 -->
+				<div class="relative w-[15rem] h-[15rem] flex items-center justify-center">
+					<span class="absolute inset-0 rounded-full border border-dashed border-nori-teal-bright/40 [animation:rotate_14s_linear_infinite]"/>
+					<span class="absolute inset-2.5 rounded-full border border-dotted border-nori-teal/30 [animation:rotate_22s_linear_infinite_reverse]"/>
+					<span class="absolute inset-5 rounded-full bg-[radial-gradient(circle,var(--glow-teal)_0%,var(--glow-teal-soft)_45%,transparent_75%)] animate-glow-pulse"/>
+					<img class="relative w-[8.2rem] h-[8.2rem] object-contain animate-breathe drop-shadow-[0_0_1.6rem_var(--glow-teal-soft)]" :src="logo" alt="Nori"/>
+				</div>
 
-			<!-- 状态胶囊 -->
-			<div
-				v-if="!timedOut"
-				class="inline-flex items-center gap-2.5 px-4.5 py-2 rounded-pill bg-bg-abyss/70 border border-nori-teal-bright/30 shadow-[0_0_2rem_rgba(125,227,255,0.16)] backdrop-blur-[1.4rem]"
-				role="status"
-				aria-live="polite"
-			>
-				<Icon name="loading" class="spin text-nori-teal-bright" :size="15"/>
-				<span class="text-base text-text-primary font-600 tracking-[0.03rem] [text-shadow:0_0_1rem_var(--glow-teal-soft)]">{{ statusText }}</span>
-			</div>
+				<!-- 状态胶囊 -->
+				<div
+					v-if="!timedOut"
+					class="inline-flex items-center gap-2.5 px-4.5 py-2 rounded-pill bg-bg-abyss/70 border border-nori-teal-bright/30 shadow-[0_0_2rem_rgba(125,227,255,0.16)] backdrop-blur-[1.4rem]"
+					role="status"
+					aria-live="polite"
+				>
+					<Icon name="loading" class="spin text-nori-teal-bright" :size="15"/>
+					<span class="text-base text-text-primary font-600 tracking-[0.03rem] [text-shadow:0_0_1rem_var(--glow-teal-soft)]">{{ statusText }}</span>
+				</div>
 
-			<!-- 宿主信号迟迟不来时的自救出口 -->
-			<div v-else class="flex flex-col items-center gap-3 px-6 py-5 surface-card backdrop-blur-[1.4rem] text-center shadow-[0_0.8rem_3.2rem_rgba(0,0,0,0.5)] border-line-strong" role="alert">
-				<span class="title-sm text-text-primary">{{ I18N.timeout }}</span>
-				<span class="text-sub max-w-[32rem] leading-relaxed">{{ I18N.timeoutDesc }}</span>
-				<AppButton variant="primary" class="mt-1.5 px-5" icon="arrow-right" :loading="entering" @click="retryEnterMain">
-					{{ I18N.enterMain }}
-				</AppButton>
-				<span v-if="retryError" class="text-sm text-danger-text font-500">{{ retryError }}</span>
+				<!-- 宿主信号迟迟不来时的自救出口 -->
+				<div v-else class="flex flex-col items-center gap-3 px-6 py-5 surface-card backdrop-blur-[1.4rem] text-center shadow-[0_0.8rem_3.2rem_rgba(0,0,0,0.5)] border-line-strong" role="alert">
+					<span class="title-sm text-text-primary">{{ I18N.timeout }}</span>
+					<span class="text-sub max-w-[32rem] leading-relaxed">{{ I18N.timeoutDesc }}</span>
+					<AppButton variant="primary" class="mt-1.5 px-5" icon="arrow-right" :loading="entering" @click="retryEnterMain">
+						{{ I18N.enterMain }}
+					</AppButton>
+					<span v-if="retryError" class="text-sm text-danger-text font-500">{{ retryError }}</span>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/app/desktop/src/views/InitView.vue
+++ b/app/desktop/src/views/InitView.vue
@@ -119,7 +119,7 @@ onMounted(async () => {
 			</button>
 		</TitleBar>
 
-		<div class="flex-1 flex flex-col items-center justify-center gap-7 pb-6 relative">
+		<div class="flex-1 min-h-0 scroll-area flex flex-col items-center justify-center gap-7 pb-6 relative">
 			<!-- 多重轨道天体声呐光环 -->
 			<div class="relative w-[15rem] h-[15rem] flex items-center justify-center">
 				<span class="absolute inset-0 rounded-full border border-dashed border-nori-teal-bright/40 [animation:rotate_14s_linear_infinite]"/>

--- a/app/desktop/src/views/Main.vue
+++ b/app/desktop/src/views/Main.vue
@@ -273,7 +273,7 @@ onBeforeUnmount(() => {
 					缓存住之后, 切到设置再切回来对话仍在继续。
 					注意 KeepAlive 内部不能夹注释 — 开发态编译会保留注释节点, 被判成多个子节点。
 				-->
-				<div class="flex-1 min-h-0 flex flex-col">
+				<div class="flex-1 min-h-0 flex flex-col scroll-area">
 					<KeepAlive>
 						<HomePanel
 							v-if="activeNav === 'home'"

--- a/app/desktop/tests/style/conventions.test.ts
+++ b/app/desktop/tests/style/conventions.test.ts
@@ -105,15 +105,17 @@ describe("样式规范静态检查", () => {
 
 	it("窗口级页面保留纵向滚动兜底", () => {
 		// html/body/#app 与 window-chrome 都会裁掉外层溢出, 所以真正的页面宿主必须显式接管滚动。
-		// 这层门禁覆盖主窗口一级页、初始化页与启动错误页, 避免新增内容后底部直接不可达。
+		// 滚动容器与居中容器分层, 避免超高内容被 justify-center 推到不可滚动的负方向。
 		const APP = readFileSync(join(SRC, "App.vue"), "utf8")
 		const MAIN = readFileSync(join(SRC, "views/Main.vue"), "utf8")
 		const INIT = readFileSync(join(SRC, "views/InitView.vue"), "utf8")
 		const FIRST_RUN = readFileSync(join(SRC, "views/FirstRunView.vue"), "utf8")
 
-		expect(APP).toContain("w-100vw h-100vh scroll-area flex items-center justify-center bg-bg-abyss p-6")
+		expect(APP).toContain("w-100vw h-100vh scroll-area bg-bg-abyss p-6")
+		expect(APP).toContain("min-h-full flex items-center justify-center")
 		expect(MAIN).toContain("flex-1 min-h-0 flex flex-col scroll-area")
-		expect(INIT).toContain("flex-1 min-h-0 scroll-area flex flex-col items-center justify-center gap-7 pb-6 relative")
+		expect(INIT).toContain("flex-1 min-h-0 scroll-area")
+		expect(INIT).toContain("min-h-full flex flex-col items-center justify-center gap-7 pb-6 relative")
 		expect(FIRST_RUN).toContain("relative flex-1 w-full min-h-0 scroll-area flex flex-col")
 	})
 

--- a/app/desktop/tests/style/conventions.test.ts
+++ b/app/desktop/tests/style/conventions.test.ts
@@ -103,6 +103,20 @@ describe("样式规范静态检查", () => {
 		expect(OFFENDERS).toEqual([])
 	})
 
+	it("窗口级页面保留纵向滚动兜底", () => {
+		// html/body/#app 与 window-chrome 都会裁掉外层溢出, 所以真正的页面宿主必须显式接管滚动。
+		// 这层门禁覆盖主窗口一级页、初始化页与启动错误页, 避免新增内容后底部直接不可达。
+		const APP = readFileSync(join(SRC, "App.vue"), "utf8")
+		const MAIN = readFileSync(join(SRC, "views/Main.vue"), "utf8")
+		const INIT = readFileSync(join(SRC, "views/InitView.vue"), "utf8")
+		const FIRST_RUN = readFileSync(join(SRC, "views/FirstRunView.vue"), "utf8")
+
+		expect(APP).toContain("w-100vw h-100vh scroll-area flex items-center justify-center bg-bg-abyss p-6")
+		expect(MAIN).toContain("flex-1 min-h-0 flex flex-col scroll-area")
+		expect(INIT).toContain("flex-1 min-h-0 scroll-area flex flex-col items-center justify-center gap-7 pb-6 relative")
+		expect(FIRST_RUN).toContain("relative flex-1 w-full min-h-0 scroll-area flex flex-col")
+	})
+
 	it("legacy 名单只包含真实存在且仍未迁移的文件", () => {
 		const ALL = new Set(listFiles(SRC, ".vue").map(relativeSrc))
 		for (const file of LEGACY_FILES) {


### PR DESCRIPTION
## 变更内容

- 主窗口一级页面宿主增加 `scroll-area`，避免新页面或异常内容遗漏滚动声明后被父级 `overflow-hidden` 直接裁掉
- 初始化窗口增加纵向滚动兜底，兼容较长文案、较高系统缩放与异常状态内容
- 启动失败兜底页增加纵向滚动能力，保证错误详情和重试按钮始终可达
- 增加静态样式门禁，覆盖主窗口、初始化页、首次运行页与启动错误页的滚动契约
- 修复原有自动化测试对宿主 OS 的隐式依赖，使 Windows 自动化默认语义在 Windows/macOS/Linux CI 上保持一致，同时保留显式非 Windows 拒绝测试

## 原因

全局 `html/body/#app` 与窗口外壳都会裁剪溢出，原实现依赖每个具体页面自行添加 `scroll-area`。一旦新增页面或特殊状态忘记声明，超出窗口高度的内容会被截断且没有可用滚动条。

本次把滚动兜底提升到页面宿主层，同时保留聊天、设置等已有内部滚动区的布局。

CI 进一步暴露出 `BridgeCommandsTests` 默认夹具直接使用 `OperatingSystem.IsWindows()`，导致 macOS/Linux 上两个本应验证 Windows 自动化设置与默认关闭状态的测试改变语义。生产环境的平台拒绝逻辑保持不变，只固定测试夹具的默认平台语义；现有显式 `automationWindows=false` 用例继续验证非 Windows fail-closed 行为。

## Review 中另行发现

本次没有混入业务重构，但全面检查时发现模型管理页与顶层 `KeepAlive` 生命周期之间存在资源清理风险：模型预览及全局 `resize` / `keydown` 监听仅在 `onBeforeUnmount` 清理，页面被 KeepAlive 停用时不会卸载。建议后续用 `onActivated` / `onDeactivated` 对预览和监听进行成对管理。

## 验证

- 当前改动为 5 个前端/测试文件
- 静态回归门禁防止后续移除页面级滚动兜底
- 非 Windows 自动化拒绝路径仍有显式 fixture 覆盖
- CI 执行 `pnpm build`、`pnpm test`、`dotnet build`、`dotnet test` 与平台发布冒烟