### PR TITLE
fix(linux): 提供不会被 Dolphin 误识别的可执行入口

### DIFF
--- a/app/desktop/publish.sh
+++ b/app/desktop/publish.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 APP_NAME="Nori.Desktop"
+LINUX_APP_NAME="${APP_NAME}.bin"
 APP_VERSION="${NORI_VERSION:-${NORI_PRODUCT_VERSION:-Dev}}"
 APP_NUMERIC_VERSION="${APP_VERSION%%-*}"
 APP_NUMERIC_VERSION="${APP_NUMERIC_VERSION%%+*}"
@@ -88,13 +89,17 @@ make_linux_package() {
 	local rid="$1" publish_dir="$2"
 	local out_dir="bin/publish/$rid"
 
+	# 保留原 apphost 作为兼容入口，同时提供不会被 Dolphin 按 .desktop 误判的主入口。
+	cp -p "$publish_dir/$APP_NAME" "$publish_dir/$LINUX_APP_NAME"
+	test -x "$publish_dir/$LINUX_APP_NAME"
+
 	cat > "$out_dir/nori.desktop" <<DESKTOP
 [Desktop Entry]
 Type=Application
 Name=Nori Desktop Pet
 Comment=Live2D 桌面陪伴伙伴
 # 安装后请把 /opt/nori 换成实际安装路径
-Exec=/opt/nori/$APP_NAME
+Exec=/opt/nori/$LINUX_APP_NAME
 Icon=/opt/nori/nori.png
 Terminal=false
 Categories=Utility;


### PR DESCRIPTION
## 变更

- Linux 发布时额外生成 `Nori.Desktop.bin`，避免 Dolphin 因 `.Desktop` 后缀把主入口误识别为 Desktop Entry
- `nori.desktop` 模板改为执行 `Nori.Desktop.bin`
- 暂时保留原 `Nori.Desktop` apphost 作为兼容入口，避免破坏既有脚本/Release workflow

## 原因

Linux 下 `Nori.Desktop` 会被部分文件管理器按扩展名误判，导致双击行为不符合预期。正式 Release 的 Linux/macOS 产物本来就通过 `publish.sh` 生成，因此在这里处理可以同时覆盖本地打包和正式发布。

Closes #5