### PR TITLE
fix(ai): 获取模型时复用已保存的 API Key

### DIFF
--- a/app/desktop/src/services/host/invoke.ts
+++ b/app/desktop/src/services/host/invoke.ts
@@ -7,6 +7,19 @@
 import {host} from "./index"
 import type {BridgeCommandArgs, BridgeCommandName, BridgeCommandResult} from "./commands"
 
+/** 模型列表探测允许省略 API Key，由宿主读取已安全保存的密钥。 */
+const normalizeArgs = <K extends BridgeCommandName>(
+	cmd: K,
+	args?: BridgeCommandArgs<K>,
+): BridgeCommandArgs<K> | undefined => {
+	if (cmd !== "llm_fetch_models" || !args || typeof args !== "object") return args
+	const NORMALIZED = {...(args as Record<string, unknown>)}
+	if (typeof NORMALIZED.apiKey === "string" && NORMALIZED.apiKey.trim() === "") {
+		delete NORMALIZED.apiKey
+	}
+	return NORMALIZED as BridgeCommandArgs<K>
+}
+
 /**
  * 调用宿主命令。
  * 未显式指定返回泛型时, 命令名会同时推导精确参数和返回值；旧调用可显式保留返回类型。
@@ -19,5 +32,5 @@ export const invoke = async <K extends BridgeCommandName>(
 ): Promise<BridgeCommandResult<K>> => {
 	const HOST = host()
 	if (!HOST) throw new Error(`宿主不可用, 无法调用命令: ${cmd}`)
-	return HOST.invoke(cmd, args)
+	return HOST.invoke(cmd, normalizeArgs(cmd, args))
 }

--- a/app/desktop/tests/host/mock-host.test.ts
+++ b/app/desktop/tests/host/mock-host.test.ts
@@ -26,6 +26,33 @@ describe("Mock Host", () => {
 		])
 	})
 
+	it("模型列表探测的空密钥回退宿主已保存密钥", async () => {
+		mock = new MockHost({llm_fetch_models: () => ["model-a"]})
+		mock.install()
+
+		await invoke("llm_fetch_models", {
+			provider: "openai",
+			baseUrl: "https://api.deepseek.com",
+			apiKey: "",
+		})
+		await invoke("llm_fetch_models", {
+			provider: "openai",
+			baseUrl: "https://api.deepseek.com",
+			apiKey: "temporary-key",
+		})
+
+		expect(mock.calls).toEqual([
+			{
+				command: "llm_fetch_models",
+				args: {provider: "openai", baseUrl: "https://api.deepseek.com"},
+			},
+			{
+				command: "llm_fetch_models",
+				args: {provider: "openai", baseUrl: "https://api.deepseek.com", apiKey: "temporary-key"},
+			},
+		])
+	})
+
 	it("保留宿主事件的订阅与取消语义", async () => {
 		mock = new MockHost({})
 		mock.install()


### PR DESCRIPTION
## 根因

设置页在 API Key 已经安全保存、输入框为空时，仍会调用 `llm_fetch_models` 并显式传入 `apiKey: ""`。

宿主原本支持“没有传 apiKey 时回退到已保存密钥”，但空字符串不是缺失值，因此会覆盖这个回退逻辑。OpenAI-compatible `/models` 请求最终带着空 Bearer 发出并鉴权失败。

Anthropic 模型目录适配器在请求失败时存在内置模型列表回退，所以同一问题会表现成“Anthropic 能获取模型，OpenAI Chat/Responses 不能”，与 #4 的现象一致。

## 修复

- `llm_fetch_models` 调用遇到空白 `apiKey` 时省略该字段，让宿主复用已保存密钥
- 非空临时 API Key 继续原样传入
- 增加 MockHost 回归测试，同时覆盖空 Key 回退和临时 Key 透传

这个改动不影响设置写入命令，因此显式清空/更新密钥的语义保持不变。

Closes #4