### PR TITLE
feat(voice): 添加 MiniMax T2A 原生 TTS 支持

### DIFF
--- a/app/desktop/Nori.Core.Tests/MiniMaxTtsProviderTests.cs
+++ b/app/desktop/Nori.Core.Tests/MiniMaxTtsProviderTests.cs
@@ -1,0 +1,134 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Voice;
+
+namespace Nori.Core.Tests;
+
+/// <summary>MiniMax 同步 T2A 请求映射、hex 解码与错误诊断测试。</summary>
+public class MiniMaxTtsProviderTests : IDisposable
+{
+	private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"nori-minimax-tts-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+
+	public MiniMaxTtsProviderTests()
+	{
+		_database = NoriDatabase.Open(_dbPath);
+		_config = new ConfigStore(_database);
+		_config.InitDefaults("0.1.0");
+		_config.Set("tts_provider", new ConfigValue.Text("minimax"));
+		_config.Set("tts_base_url", new ConfigValue.Text("https://api.minimaxi.com/v1"));
+		_config.Set("tts_api_key", new ConfigValue.Text("test-secret"));
+	}
+
+	[Fact]
+	public async Task 同步T2A正确映射请求并解码Hex音频()
+	{
+		CaptureHandler handler = new(_ => SuccessResponse("494433"));
+		using HttpClient client = new(handler);
+		MiniMaxTtsProvider provider = new(client, _config);
+
+		EncodedAudio audio = await provider.SynthesizeAsync(
+			"你好，Nori",
+			new TtsSynthesizeOptions {Voice = "male-qn-qingse", Speed = 1.2},
+			CancellationToken.None);
+
+		Assert.Equal(new Uri("https://api.minimaxi.com/v1/t2a_v2"), handler.LastUri);
+		Assert.Equal("Bearer", handler.AuthorizationScheme);
+		Assert.Equal("test-secret", handler.AuthorizationParameter);
+		Assert.Equal("audio/mpeg", audio.Mime);
+		Assert.Equal(new byte[] {0x49, 0x44, 0x33}, audio.Bytes);
+
+		JsonNode body = JsonNode.Parse(handler.LastBody!)!;
+		Assert.Equal("speech-2.8-turbo", body["model"]?.GetValue<string>());
+		Assert.Equal("你好，Nori", body["text"]?.GetValue<string>());
+		Assert.False(body["stream"]?.GetValue<bool>() ?? true);
+		Assert.Equal("male-qn-qingse", body["voice_setting"]?["voice_id"]?.GetValue<string>());
+		Assert.Equal(1.2, body["voice_setting"]?["speed"]?.GetValue<double>());
+		Assert.Equal("mp3", body["audio_setting"]?["format"]?.GetValue<string>());
+		Assert.Equal("hex", body["output_format"]?.GetValue<string>());
+	}
+
+	[Fact]
+	public async Task 完整端点不会重复追加T2A路径()
+	{
+		_config.Set("tts_base_url", new ConfigValue.Text("https://api.minimaxi.com/v1/t2a_v2"));
+		CaptureHandler handler = new(_ => SuccessResponse("01"));
+		using HttpClient client = new(handler);
+		MiniMaxTtsProvider provider = new(client, _config);
+
+		await provider.SynthesizeAsync("测试", new TtsSynthesizeOptions(), CancellationToken.None);
+
+		Assert.Equal(new Uri("https://api.minimaxi.com/v1/t2a_v2"), handler.LastUri);
+	}
+
+	[Fact]
+	public async Task 业务错误包含状态消息与TraceId()
+	{
+		CaptureHandler handler = new(_ => JsonResponse("""
+			{
+				"data": null,
+				"trace_id": "trace-123",
+				"base_resp": {"status_code": 1008, "status_msg": "invalid api key"}
+			}
+			"""));
+		using HttpClient client = new(handler);
+		MiniMaxTtsProvider provider = new(client, _config);
+
+		InvalidOperationException error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			provider.SynthesizeAsync("测试", new TtsSynthesizeOptions(), CancellationToken.None));
+
+		Assert.Contains("status_code=1008", error.Message, StringComparison.Ordinal);
+		Assert.Contains("invalid api key", error.Message, StringComparison.Ordinal);
+		Assert.Contains("trace-123", error.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void VoiceService能够创建MiniMaxProvider()
+	{
+		using HttpClient client = new(new CaptureHandler(_ => SuccessResponse("01")));
+		using VoiceService service = new(client, _config, null, () => null);
+
+		Assert.IsType<MiniMaxTtsProvider>(service.CreateProvider("minimax"));
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_dbPath); } catch (IOException) { }
+	}
+
+	private static HttpResponseMessage SuccessResponse(string audioHex) => JsonResponse($$"""
+		{
+			"data": {"audio": "{{audioHex}}", "status": 2},
+			"extra_info": {"audio_format": "mp3"},
+			"trace_id": "trace-ok",
+			"base_resp": {"status_code": 0, "status_msg": "success"}
+		}
+		""");
+
+	private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+	{
+		Content = new StringContent(json, Encoding.UTF8, "application/json"),
+	};
+
+	private sealed class CaptureHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		public Uri? LastUri { get; private set; }
+		public string? AuthorizationScheme { get; private set; }
+		public string? AuthorizationParameter { get; private set; }
+		public string? LastBody { get; private set; }
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			LastUri = request.RequestUri;
+			AuthorizationScheme = request.Headers.Authorization?.Scheme;
+			AuthorizationParameter = request.Headers.Authorization?.Parameter;
+			LastBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+			return responder(request);
+		}
+	}
+}

--- a/app/desktop/Nori.Core/Voice/MiniMaxTtsProvider.cs
+++ b/app/desktop/Nori.Core/Voice/MiniMaxTtsProvider.cs
@@ -1,0 +1,141 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Nori.Core.Configuration;
+
+namespace Nori.Core.Voice;
+
+/// <summary>MiniMax 同步 T2A HTTP 适配器 (/v1/t2a_v2)。</summary>
+public sealed class MiniMaxTtsProvider(HttpClient httpClient, ConfigStore config) : ITtsProvider
+{
+	private const string DefaultBaseUrl = "https://api.minimaxi.com/v1";
+	private const string DefaultModel = "speech-2.8-turbo";
+	private const string DefaultVoice = "male-qn-qingse";
+
+	public string Name => "minimax";
+
+	public async Task<EncodedAudio> SynthesizeAsync(
+		string text,
+		TtsSynthesizeOptions options,
+		CancellationToken cancellationToken)
+	{
+		string baseUrl = (config.GetStringOr("tts_base_url", "") is {Length: > 0} saved ? saved : DefaultBaseUrl)
+			.Trim().TrimEnd('/');
+		string endpoint = FormatEndpoint(baseUrl);
+		string apiKey = config.GetStringOr("tts_api_key", "");
+		if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("未配置 MiniMax TTS API Key");
+
+		JsonObject payload = new()
+		{
+			["model"] = DefaultModel,
+			["text"] = text,
+			["stream"] = false,
+			["voice_setting"] = new JsonObject
+			{
+				["voice_id"] = options.Voice is {Length: > 0} ? options.Voice : DefaultVoice,
+				["speed"] = options.Speed,
+			},
+			["audio_setting"] = new JsonObject
+			{
+				["format"] = "mp3",
+			},
+			["output_format"] = "hex",
+		};
+
+		using HttpRequestMessage request = new(HttpMethod.Post, endpoint)
+		{
+			Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json"),
+		};
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+		using HttpResponseMessage response = await httpClient.SendAsync(
+			request,
+			HttpCompletionOption.ResponseHeadersRead,
+			cancellationToken);
+
+		byte[] responseBytes = await VoiceHttpContent.ReadBytesAsync(response.Content, cancellationToken, allowEmpty: true);
+		string raw = Encoding.UTF8.GetString(responseBytes);
+		JsonNode? body = TryParse(raw);
+
+		if (!response.IsSuccessStatusCode)
+		{
+			throw new HttpRequestException(
+				$"MiniMax TTS 请求失败: HTTP {(int)response.StatusCode}{DiagnosticSuffix(body, raw)}");
+		}
+
+		int statusCode = ReadStatusCode(body);
+		if (statusCode != 0)
+		{
+			throw new InvalidOperationException($"MiniMax TTS 返回错误: status_code={statusCode}{DiagnosticSuffix(body, raw)}");
+		}
+
+		string? audioHex = body?["data"]?["audio"]?.GetValue<string>();
+		if (string.IsNullOrWhiteSpace(audioHex))
+		{
+			throw new InvalidOperationException($"MiniMax TTS 响应缺少 data.audio{DiagnosticSuffix(body, raw)}");
+		}
+		if (audioHex.Length > VoiceAudioLimits.MaxBytes * 2)
+		{
+			throw new InvalidOperationException("MiniMax TTS 音频超过 32MiB 限制");
+		}
+
+		byte[] audioBytes;
+		try
+		{
+			audioBytes = Convert.FromHexString(audioHex);
+		}
+		catch (FormatException exception)
+		{
+			throw new InvalidOperationException($"MiniMax TTS data.audio 不是有效的 hex 数据{DiagnosticSuffix(body, raw)}", exception);
+		}
+
+		string format = body?["extra_info"]?["audio_format"]?.GetValue<string>()?.Trim().ToLowerInvariant() ?? "mp3";
+		string mime = format switch
+		{
+			"mp3" => "audio/mpeg",
+			"wav" => "audio/wav",
+			"flac" => "audio/flac",
+			_ => throw new InvalidOperationException($"MiniMax TTS 返回了不支持的音频格式: {format}"),
+		};
+		return AudioMime.ValidateEncoded(audioBytes, mime);
+	}
+
+	private static string FormatEndpoint(string baseUrl)
+	{
+		if (baseUrl.Length == 0) throw new InvalidOperationException("MiniMax TTS Base URL 不能为空");
+		if (baseUrl.EndsWith("/t2a_v2", StringComparison.OrdinalIgnoreCase)) return baseUrl;
+		if (baseUrl.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)) return $"{baseUrl}/t2a_v2";
+		return $"{baseUrl}/v1/t2a_v2";
+	}
+
+	private static JsonNode? TryParse(string raw)
+	{
+		if (string.IsNullOrWhiteSpace(raw)) return null;
+		try { return JsonNode.Parse(raw); }
+		catch (JsonException) { return null; }
+	}
+
+	private static int ReadStatusCode(JsonNode? body)
+	{
+		if (body?["base_resp"]?["status_code"] is not JsonValue value) return 0;
+		if (value.TryGetValue(out int intValue)) return intValue;
+		if (value.TryGetValue(out long longValue) && longValue is >= int.MinValue and <= int.MaxValue) return (int)longValue;
+		return -1;
+	}
+
+	private static string DiagnosticSuffix(JsonNode? body, string raw)
+	{
+		string? statusMsg = body?["base_resp"]?["status_msg"]?.GetValue<string>();
+		string? traceId = body?["trace_id"]?.GetValue<string>();
+		List<string> details = [];
+		if (!string.IsNullOrWhiteSpace(statusMsg)) details.Add($"message={statusMsg}");
+		if (!string.IsNullOrWhiteSpace(traceId)) details.Add($"trace_id={traceId}");
+		if (details.Count == 0 && !string.IsNullOrWhiteSpace(raw))
+		{
+			string compact = raw.Replace('\r', ' ').Replace('\n', ' ').Trim();
+			details.Add(compact.Length > 200 ? compact[..200] : compact);
+		}
+		return details.Count == 0 ? "" : $", {string.Join(", ", details)}";
+	}
+}

--- a/app/desktop/Nori.Core/Voice/VoiceService.cs
+++ b/app/desktop/Nori.Core/Voice/VoiceService.cs
@@ -244,9 +244,14 @@ public sealed class VoiceService : IDisposable
 
 	private string ResolveProviderEndpoint(string providerName)
 	{
-		string endpoint = providerName.Equals("gpt_sovits", StringComparison.OrdinalIgnoreCase)
-			? _config.GetStringOr("gptsovits_base_url", "http://127.0.0.1:9880")
-			: _config.GetStringOr("tts_base_url", "https://api.openai.com/v1");
+		string endpoint = providerName.ToLowerInvariant() switch
+		{
+			"gpt_sovits" => _config.GetStringOr("gptsovits_base_url", "http://127.0.0.1:9880"),
+			"minimax" => _config.GetStringOr("tts_base_url", "") is {Length: > 0} minimaxUrl
+				? minimaxUrl
+				: "https://api.minimaxi.com/v1",
+			_ => _config.GetStringOr("tts_base_url", "https://api.openai.com/v1"),
+		};
 		return $"{providerName}:{endpoint.Trim().TrimEnd('/') }";
 	}
 
@@ -255,10 +260,11 @@ public sealed class VoiceService : IDisposable
 	{
 		if (RetiredProviders.Contains(name))
 		{
-			throw new InvalidOperationException($"语音提供商 {name} 依赖浏览器能力, 已在纯后端版本中停用, 请改用 OpenAI / 自定义 HTTP / GPT-SoVITS");
+			throw new InvalidOperationException($"语音提供商 {name} 依赖浏览器能力, 已在纯后端版本中停用, 请改用 OpenAI / MiniMax / 自定义 HTTP / GPT-SoVITS");
 		}
 		return name switch
 		{
+			"minimax" => new MiniMaxTtsProvider(_httpClient, _config),
 			"gpt_sovits" => new GptSoVitsTtsProvider(_httpClient, _config),
 			"custom" => new CustomHttpTtsProvider(_httpClient, _config),
 			_ => new OpenAiTtsProvider(_httpClient, _config),

--- a/app/desktop/src/components/settings/VoiceSettings.vue
+++ b/app/desktop/src/components/settings/VoiceSettings.vue
@@ -30,13 +30,17 @@ const volumeField = defineField(
 )
 const volume = volumeField.value
 
-// TTS 配置 (云端路径: openai / custom / gpt_sovits)
-type TtsProvider = "openai" | "custom" | "gpt_sovits"
+// TTS 配置 (云端路径: openai / minimax / custom / gpt_sovits)
+type TtsProvider = "openai" | "minimax" | "custom" | "gpt_sovits"
+const TTS_DEFAULT_BASE_URLS: Partial<Record<TtsProvider, string>> = {
+	openai: "https://api.openai.com/v1",
+	minimax: "https://api.minimaxi.com/v1",
+}
 const ttsProviderField = defineField<TtsProvider>(
 	"ttsProvider",
 	snapshot => {
 		const VALUE = snapshot.voice.ttsProvider
-		return (["openai", "custom", "gpt_sovits"] as string[]).includes(VALUE) ? VALUE as TtsProvider : "openai"
+		return (["openai", "minimax", "custom", "gpt_sovits"] as string[]).includes(VALUE) ? VALUE as TtsProvider : "openai"
 	},
 	"openai",
 	val => RUNTIME.updateVoice({ttsProvider: val}),
@@ -135,8 +139,29 @@ const onVolumeChange = (value: number) => {
 }
 
 const onTtsProviderChange = (value: TtsProvider) => {
+	const PREVIOUS_BASE_URL = ttsBaseUrl.value.trim()
+	const KNOWN_DEFAULTS = Object.values(TTS_DEFAULT_BASE_URLS)
 	ttsProvider.value = value
 	void ttsProviderField.saveNow()
+
+	if (!PREVIOUS_BASE_URL || KNOWN_DEFAULTS.includes(PREVIOUS_BASE_URL)) {
+		const NEXT_BASE_URL = TTS_DEFAULT_BASE_URLS[value]
+		if (NEXT_BASE_URL && NEXT_BASE_URL !== PREVIOUS_BASE_URL) {
+			ttsBaseUrl.value = NEXT_BASE_URL
+			ttsBaseUrlField.touch()
+			void ttsBaseUrlField.saveNow()
+		}
+	}
+
+	if (value === "minimax" && (!ttsVoice.value.trim() || ttsVoice.value === "nova")) {
+		ttsVoice.value = "male-qn-qingse"
+		ttsVoiceField.touch()
+		void ttsVoiceField.saveNow()
+	} else if (value === "openai" && ttsVoice.value === "male-qn-qingse") {
+		ttsVoice.value = "nova"
+		ttsVoiceField.touch()
+		void ttsVoiceField.saveNow()
+	}
 }
 
 const onTtsBaseUrlBlur = () => ttsBaseUrlField.save()
@@ -264,6 +289,14 @@ const testVoice = async () => {
 						</label>
 						<label
 							class="pill-choice focus-ring-within gap-1.5 px-3.5 py-1.5 text-xs"
+							:class="ttsProvider === 'minimax' ? 'pill-choice-on' : 'pill-choice-off'"
+						>
+							<input v-model="ttsProvider" type="radio" value="minimax" class="sr-only"
+								@change="onTtsProviderChange('minimax')"/>
+							MiniMax
+						</label>
+						<label
+							class="pill-choice focus-ring-within gap-1.5 px-3.5 py-1.5 text-xs"
 							:class="ttsProvider === 'custom' ? 'pill-choice-on' : 'pill-choice-off'"
 						>
 							<input v-model="ttsProvider" type="radio" value="custom" class="sr-only"
@@ -281,13 +314,13 @@ const testVoice = async () => {
 					</div>
 				</div>
 
-				<template v-if="ttsProvider === 'openai' || ttsProvider === 'custom'">
+				<template v-if="ttsProvider === 'openai' || ttsProvider === 'minimax' || ttsProvider === 'custom'">
 					<label class="field">
 						<span class="field-label font-500">{{ I18N.tts.baseUrl }}</span>
 						<input
 							v-model="ttsBaseUrl"
 							class="input-base"
-							placeholder="https://api.openai.com/v1"
+							:placeholder="ttsProvider === 'minimax' ? 'https://api.minimaxi.com/v1' : 'https://api.openai.com/v1'"
 							@focus="ttsBaseUrlField.focus"
 							@input="ttsBaseUrlField.touch"
 							@blur="onTtsBaseUrlBlur"
@@ -363,7 +396,7 @@ const testVoice = async () => {
 						<input
 							v-model="ttsVoice"
 							class="input-base"
-							placeholder="nova, alloy, shimmer..."
+							:placeholder="ttsProvider === 'minimax' ? 'male-qn-qingse' : 'nova, alloy, shimmer...'"
 							@focus="ttsVoiceField.focus"
 							@input="ttsVoiceField.touch"
 							@blur="onTtsVoiceBlur"


### PR DESCRIPTION
## 实现内容

- 新增 `MiniMaxTtsProvider`，使用官方同步 HTTP `POST /v1/t2a_v2`
- Bearer API Key 鉴权，复用现有 `tts_api_key` 安全持久化
- 请求映射：文本、Voice ID、Speed、MP3、非流式、hex 输出
- 解析 `base_resp.status_code/status_msg`、`trace_id`，错误信息保留可诊断上下文
- `data.audio` hex 解码后进入现有 `EncodedAudio` / `AudioMime` / 有界播放流水线
- `VoiceService.CreateProvider("minimax")` 正式注册 Provider
- 设置页新增 MiniMax 选项；OpenAI ↔ MiniMax 切换时联动官方默认 Base URL，并处理常用默认 Voice
- 增加 Provider 单元测试，覆盖 endpoint、Bearer、请求映射、hex 解码、错误诊断与工厂注册

## 当前 MVP 边界

为保持这次改动聚焦，MiniMax 暂复用现有通用 TTS 配置：

- Base URL：`tts_base_url`
- API Key：`tts_api_key`
- Voice ID：`tts_voice`
- Speed：`tts_speed`

模型当前固定为 `speech-2.8-turbo`。独立 `minimax_tts_*` 配置、可编辑模型、Emotion / Streaming / Language Boost 等高级能力适合作为后续增量；它们需要扩展当前 Bridge / Snapshot 的语音配置契约。

默认 Base URL：`https://api.minimaxi.com/v1`
默认 Voice：`male-qn-qingse`

Closes #3