### PR TITLE
fix(lifecycle): 释放页面、音频与 Live2D 长生命周期资源

### DIFF
--- a/app/desktop/Nori.Desktop/Windows/PetWindow.cs
+++ b/app/desktop/Nori.Desktop/Windows/PetWindow.cs
@@ -95,8 +95,8 @@ public sealed class PetWindow : Window
 		PointerReleased += OnPointerReleased;
 		PointerCaptureLost += (_, _) => FinishDrag();
 
-		_runtime.ModelChanged += () => Dispatcher.UIThread.Post(ApplyWindowSize);
-		_runtime.LayoutChanged += () => Dispatcher.UIThread.Post(ApplyWindowSize);
+		_runtime.ModelChanged += OnRuntimeModelChanged;
+		_runtime.LayoutChanged += OnRuntimeLayoutChanged;
 
 		_cursorTrackingTimer = new DispatcherTimer
 		{
@@ -151,6 +151,10 @@ public sealed class PetWindow : Window
 
 	/// <summary>清除桌宠短句气泡。</summary>
 	public void ClearSpeech() => _speechOverlay.ClearText();
+
+	private void OnRuntimeModelChanged() => Dispatcher.UIThread.Post(ApplyWindowSize);
+
+	private void OnRuntimeLayoutChanged() => Dispatcher.UIThread.Post(ApplyWindowSize);
 
 	private void OnOpened(object? sender, EventArgs e)
 	{
@@ -234,7 +238,14 @@ public sealed class PetWindow : Window
 		_glControl.PauseRenderLoop();
 		_speechOverlay.ClearText();
 		_cursorTrackingTimer.Stop();
-		_hitShapeTimer?.Stop();
+		_cursorTrackingTimer.Tick -= OnCursorTrackingTick;
+		if (_hitShapeTimer is not null)
+		{
+			_hitShapeTimer.Stop();
+			_hitShapeTimer.Tick -= OnHitShapeTick;
+		}
+		_runtime.ModelChanged -= OnRuntimeModelChanged;
+		_runtime.LayoutChanged -= OnRuntimeLayoutChanged;
 		if (OperatingSystem.IsWindows())
 		{
 			Win32Properties.RemoveWndProcHookCallback(this, _wndProcHook);

--- a/app/desktop/Nori.Desktop/Windows/WindowManager.cs
+++ b/app/desktop/Nori.Desktop/Windows/WindowManager.cs
@@ -131,7 +131,11 @@ public sealed class WindowManager(AssetServer assetServer, IClassicDesktopStyleA
 		if (Get(label) is not { } window) return;
 		_windows.Remove(label);
 		if (window is NoriWindow nw) nw.AllowClose = true;
-		else if (window is PetWindow pw) pw.AllowClose = true;
+		else if (window is PetWindow pw)
+		{
+			pw.AllowClose = true;
+			if (ReferenceEquals(_petWindow, pw)) _petWindow = null;
+		}
 		window.Close();
 		if (_visible.TryUpdate(label, false, true)) VisibilityChanged?.Invoke(label, false);
 	}

--- a/app/desktop/src/App.vue
+++ b/app/desktop/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {computed, onMounted, ref} from "vue"
+import {computed, onBeforeUnmount, onMounted, ref} from "vue"
 import {useRouter} from "vue-router"
 import {getCurrentWindowLabel, navigateToOwnWindow} from "./services/window"
 import {RUNTIME} from "./services/runtime"
@@ -60,9 +60,14 @@ onMounted(async () => {
 	}
 })
 
-// 语言在任何窗口被改都会广播 state-changed, 这里跟随快照重放, 避免多窗口语言不一致
-RUNTIME.onLanguageChanged((language) => {
+// 语言在任何窗口被改都会广播 state-changed, 这里跟随快照重放, 避免多窗口语言不一致。
+// RUNTIME 是模块级单例，App 卸载时必须显式移除 handler，避免窗口重挂载/HMR 后累积旧闭包。
+const stopLanguageSync = RUNTIME.onLanguageChanged((language) => {
 	void useLanguage.setLanguage(language)
+})
+
+onBeforeUnmount(() => {
+	stopLanguageSync()
 })
 </script>
 

--- a/app/desktop/src/services/audio/index.ts
+++ b/app/desktop/src/services/audio/index.ts
@@ -61,6 +61,9 @@ let recorderChunks: Blob[] = []
 let recorderStream: MediaStream | null = null
 let recordUploadUrl = ""
 let recordToken = ""
+let recordingGeneration = 0
+let recordingStopping = false
+let audioHostInstalled = false
 
 /** 校验并规范音频 MIME，保留 codecs 参数。 */
 export const normalizeAudioMime = (mime: string | null | undefined): string => {
@@ -174,6 +177,23 @@ const cancelPlayback = () => {
 	if (TOKEN) reportFinalLevel(TOKEN)
 }
 
+/** 彻底释放 WebAudio 图和原生 AudioContext；重新安装宿主时会按需重建。 */
+const releaseAudioGraph = () => {
+	stopLevelTimer()
+	try { gain?.disconnect() } catch { /* 已断开 */ }
+	try { analyser?.disconnect() } catch { /* 已断开 */ }
+	gain = null
+	analyser = null
+	rmsBuffer = new Float32Array(1024)
+	const CONTEXT = context
+	context = null
+	if (CONTEXT && CONTEXT.state !== "closed") {
+		void CONTEXT.close().catch(() => {
+			/* WebView 正在退出时忽略 */
+		})
+	}
+}
+
 const isCurrentPlayback = (token: string, generation: number): boolean =>
 	currentToken === token && playbackGeneration === generation
 
@@ -234,35 +254,75 @@ const reportRecordingFailure = (token: string, error: unknown, upload = false) =
 	})
 }
 
+const stopStream = (stream: MediaStream | null) => {
+	stream?.getTracks().forEach(track => track.stop())
+}
+
+/** 宿主卸载时只取消录音，不上传可能不完整的半截数据。 */
+const cancelRecording = () => {
+	recordingGeneration += 1
+	recordingStopping = false
+	const ACTIVE = recorder
+	const STREAM = recorderStream
+	recorder = null
+	recorderStream = null
+	recordUploadUrl = ""
+	recordToken = ""
+	recorderChunks = []
+	if (ACTIVE) {
+		ACTIVE.ondataavailable = null
+		ACTIVE.onstop = null
+		ACTIVE.onerror = null
+		if (ACTIVE.state !== "inactive") {
+			try { ACTIVE.stop() } catch { /* 已停止 */ }
+		}
+	}
+	stopStream(STREAM)
+}
+
 const startRecording = async (payload: RecordStartPayload): Promise<void> => {
+	if (recordingStopping) {
+		reportRecordingFailure(payload.token, new Error("上一段录音仍在结束"))
+		return
+	}
+	// 新请求取代尚未完成的权限申请；已开始的录音按宿主协议不会并发启动。
+	const GENERATION = ++recordingGeneration
 	recordToken = payload.token
 	recordUploadUrl = payload.uploadUrl
 	recorderChunks = []
+	let acquiredStream: MediaStream | null = null
 	try {
 		if (!navigator.mediaDevices?.getUserMedia) throw new Error("当前 WebView 不支持麦克风")
-		const STREAM = await navigator.mediaDevices.getUserMedia({audio: true})
-		recorderStream = STREAM
+		acquiredStream = await navigator.mediaDevices.getUserMedia({audio: true})
+		if (!audioHostInstalled || GENERATION !== recordingGeneration || recordToken !== payload.token) {
+			stopStream(acquiredStream)
+			return
+		}
+		recorderStream = acquiredStream
 		const REQUESTED_MIME = chooseRecordingMime(globalThis.MediaRecorder)
 		recorder = REQUESTED_MIME
-			? new MediaRecorder(STREAM, {mimeType: REQUESTED_MIME})
-			: new MediaRecorder(STREAM)
+			? new MediaRecorder(acquiredStream, {mimeType: REQUESTED_MIME})
+			: new MediaRecorder(acquiredStream)
 		const ACTIVE = recorder
 		ACTIVE.ondataavailable = (event) => {
-			if (event.data.size > 0) recorderChunks.push(event.data)
+			if (GENERATION === recordingGeneration && event.data.size > 0) recorderChunks.push(event.data)
 		}
 		ACTIVE.start()
 		normalizeAudioMime(ACTIVE.mimeType || REQUESTED_MIME)
 		await invoke("audio_record_ready", {token: payload.token})
 		// 保留浏览器报告的真实 MIME，不能在停止时强制改成 audio/wav。
 	} catch (error) {
-		if (recordToken === payload.token) {
-		recorderStream?.getTracks().forEach(track => track.stop())
-			recorder = null
-			recorderStream = null
-			recordUploadUrl = ""
-			recordToken = ""
-			recorderChunks = []
+		if (GENERATION !== recordingGeneration || recordToken !== payload.token) {
+			stopStream(acquiredStream)
+			return
 		}
+		stopStream(recorderStream ?? acquiredStream)
+		recorder = null
+		recorderStream = null
+		recordUploadUrl = ""
+		recordToken = ""
+		recorderChunks = []
+		recordingGeneration += 1
 		console.error("启动录音失败:", error)
 		reportRecordingFailure(payload.token, error)
 	}
@@ -273,16 +333,21 @@ const stopRecording = async (payload?: RecordStopPayload): Promise<void> => {
 	const ACTIVE = recorder
 	const URL_TARGET = recordUploadUrl
 	const STREAM = recorderStream
+	const GENERATION = recordingGeneration
 	if (TOKEN && recordToken && TOKEN !== recordToken) return
 	recorder = null
 	recordUploadUrl = ""
 	recordToken = ""
 	recorderStream = null
 	if (!ACTIVE || !URL_TARGET || !TOKEN) {
+		if (GENERATION === recordingGeneration) recordingGeneration += 1
+		recorderChunks = []
+		stopStream(STREAM)
 		if (TOKEN) reportRecordingFailure(TOKEN, new Error("录音未启动"), true)
 		return
 	}
 
+	recordingStopping = true
 	try {
 		await new Promise<void>((resolve, reject) => {
 			ACTIVE.onstop = () => resolve()
@@ -312,9 +377,12 @@ const stopRecording = async (payload?: RecordStopPayload): Promise<void> => {
 		console.error("上传录音失败:", error)
 		reportRecordingFailure(TOKEN, error, true)
 	} finally {
-		STREAM?.getTracks().forEach(track => track.stop())
+		stopStream(STREAM)
+		ACTIVE.ondataavailable = null
 		ACTIVE.onstop = null
 		ACTIVE.onerror = null
+		if (GENERATION === recordingGeneration) recordingGeneration += 1
+		recordingStopping = false
 	}
 }
 
@@ -322,28 +390,35 @@ let unlisteners: UnlistenFn[] = []
 
 /** 安装音频宿主 (仅 main 窗口调用)。 */
 export const installAudioHost = async (): Promise<void> => {
-	if (unlisteners.length > 0) return
-	unlisteners = await Promise.all([
-		listen<PlayPayload>("nori:audio-play", ({payload}) => void play(payload)),
-		listen("nori:audio-stop", () => cancelPlayback()),
-		listen<RecordStartPayload>("nori:audio-record-start", ({payload}) => void startRecording(payload)),
-		listen<RecordStopPayload>("nori:audio-record-stop", ({payload}) => void stopRecording(payload)),
-	])
+	if (audioHostInstalled) return
+	audioHostInstalled = true
+	const NEXT_UNLISTENERS: UnlistenFn[] = []
 	try {
+		NEXT_UNLISTENERS.push(await listen<PlayPayload>("nori:audio-play", ({payload}) => void play(payload)))
+		NEXT_UNLISTENERS.push(await listen("nori:audio-stop", () => cancelPlayback()))
+		NEXT_UNLISTENERS.push(await listen<RecordStartPayload>("nori:audio-record-start", ({payload}) => void startRecording(payload)))
+		NEXT_UNLISTENERS.push(await listen<RecordStopPayload>("nori:audio-record-stop", ({payload}) => void stopRecording(payload)))
+		unlisteners = NEXT_UNLISTENERS
 		await invoke("audio_host_ready")
 	} catch (error) {
-		for (const UNLISTEN of unlisteners) UNLISTEN()
+		for (const UNLISTEN of NEXT_UNLISTENERS) UNLISTEN()
 		unlisteners = []
+		audioHostInstalled = false
+		cancelPlayback()
+		cancelRecording()
+		releaseAudioGraph()
 		throw error
 	}
 }
 
-/** 卸载音频宿主。 */
+/** 卸载音频宿主并释放浏览器侧原生音频/麦克风资源。 */
 export const uninstallAudioHost = (): void => {
+	audioHostInstalled = false
 	for (const UNLISTEN of unlisteners) UNLISTEN()
 	unlisteners = []
 	cancelPlayback()
-	void stopRecording({token: recordToken})
+	cancelRecording()
+	releaseAudioGraph()
 }
 
 /** 供测试使用的纯函数：由时域样本算 RMS 电平。 */

--- a/app/desktop/src/services/live2d/index.ts
+++ b/app/desktop/src/services/live2d/index.ts
@@ -424,7 +424,6 @@ export const createLive2D = () => {
 						tex.baseTexture.mipmap = 1
 						tex.baseTexture.update?.()
 					}
-				}
 			}
 			// 裁剪蒙版缓冲: pixi-live2d-display 默认 256, 眼/口/发的蒙版边缘会有明显阶梯。
 			// 渲染器挂在 internalModel.renderer 上 (不是 coreModel.renderer), 且只接受一个参数。
@@ -494,7 +493,7 @@ export const createLive2D = () => {
 		} catch (error) {
 			console.error("[Live2D] 模型加载失败:", error)
 			try {
-				app.destroy(true)
+				app.destroy(true, {children: true, texture: false, baseTexture: false})
 			} catch {
 				/* ignore */
 			}
@@ -519,7 +518,7 @@ export const createLive2D = () => {
 			/* ignore */
 		}
 		try {
-			inner.app.destroy(true)
+			inner.app.destroy(true, {children: true, texture: false, baseTexture: false})
 		} catch {
 			/* ignore */
 		}

--- a/app/desktop/src/services/live2d/index.ts
+++ b/app/desktop/src/services/live2d/index.ts
@@ -424,6 +424,7 @@ export const createLive2D = () => {
 						tex.baseTexture.mipmap = 1
 						tex.baseTexture.update?.()
 					}
+				}
 			}
 			// 裁剪蒙版缓冲: pixi-live2d-display 默认 256, 眼/口/发的蒙版边缘会有明显阶梯。
 			// 渲染器挂在 internalModel.renderer 上 (不是 coreModel.renderer), 且只接受一个参数。

--- a/app/desktop/src/views/Main.vue
+++ b/app/desktop/src/views/Main.vue
@@ -268,24 +268,26 @@ onBeforeUnmount(() => {
 				<!--
 					一级页依次是: 主页看板 / 对话 / 模型管理 / 长期记忆 / 全功能设置 (含关于)。
 
-					KeepAlive 是必需的, 不只是为了少一次挂载:
-					对话面板卸载会取消进行中的会话并自动拒掉所有待审批工具调用,
-					缓存住之后, 切到设置再切回来对话仍在继续。
-					注意 KeepAlive 内部不能夹注释 — 开发态编译会保留注释节点, 被判成多个子节点。
+					只有对话面板需要 KeepAlive: 它卸载会取消进行中的会话并自动拒掉所有待审批工具调用。
+					模型/记忆/设置页切走后必须正常卸载，以释放 Live2D/WebGL、全局监听器和页面级计时器。
 				-->
 				<div class="flex-1 min-h-0 flex flex-col scroll-area">
+					<HomePanel
+						v-if="activeNav === 'home'"
+						:pet-visible="petVisible"
+						@toggle-pet="togglePet"
+						@navigate="navigate"
+					/>
 					<KeepAlive>
-						<HomePanel
-							v-if="activeNav === 'home'"
-							:pet-visible="petVisible"
-							@toggle-pet="togglePet"
-							@navigate="navigate"
-						/>
-						<ChatView v-else-if="activeNav === 'talk'" @go-settings="navigate('settings', 'talk')"/>
-						<ModelManagement v-else-if="activeNav === 'model'"/>
-						<MemoryPanel v-else-if="activeNav === 'memory'"/>
-						<SettingsPanel v-else :initial-tab="settingsTarget" :open-seq="settingsSeq"/>
+						<ChatView v-if="activeNav === 'talk'" @go-settings="navigate('settings', 'talk')"/>
 					</KeepAlive>
+					<ModelManagement v-if="activeNav === 'model'"/>
+					<MemoryPanel v-if="activeNav === 'memory'"/>
+					<SettingsPanel
+						v-if="activeNav === 'settings'"
+						:initial-tab="settingsTarget"
+						:open-seq="settingsSeq"
+					/>
 				</div>
 			</main>
 		</div>

--- a/app/desktop/tests/views/lifecycle-resources.test.ts
+++ b/app/desktop/tests/views/lifecycle-resources.test.ts
@@ -1,0 +1,32 @@
+import {readFileSync} from "node:fs"
+import {join} from "node:path"
+import {describe, expect, it} from "vitest"
+
+const SRC = join(process.cwd(), "src")
+
+const read = (path: string): string => readFileSync(join(SRC, path), "utf8")
+
+describe("页面与宿主资源生命周期", () => {
+	it("主工作区只缓存对话页，其他重资源页面切走后正常卸载", () => {
+		const MAIN = read("views/Main.vue")
+		const KEEP_ALIVE = MAIN.match(/<KeepAlive>([\s\S]*?)<\/KeepAlive>/)?.[1] ?? ""
+
+		expect(KEEP_ALIVE).toContain("<ChatView")
+		expect(KEEP_ALIVE).not.toContain("<HomePanel")
+		expect(KEEP_ALIVE).not.toContain("<ModelManagement")
+		expect(KEEP_ALIVE).not.toContain("<MemoryPanel")
+		expect(KEEP_ALIVE).not.toContain("<SettingsPanel")
+		expect(MAIN).toContain("<ModelManagement v-if=\"activeNav === 'model'\"")
+		expect(MAIN).toContain("<SettingsPanel\n\t\t\t\t\t\tv-if=\"activeNav === 'settings'\"")
+	})
+
+	it("音频宿主卸载会关闭 WebAudio 并取消过期的麦克风启动", () => {
+		const AUDIO = read("services/audio/index.ts")
+
+		expect(AUDIO).toContain("CONTEXT.close()")
+		expect(AUDIO).toContain("cancelRecording()")
+		expect(AUDIO).toContain("releaseAudioGraph()")
+		expect(AUDIO).toContain("GENERATION !== recordingGeneration")
+		expect(AUDIO).toContain("stopStream(acquiredStream)")
+	})
+})

--- a/app/desktop/tests/views/lifecycle-resources.test.ts
+++ b/app/desktop/tests/views/lifecycle-resources.test.ts
@@ -5,8 +5,9 @@ import {describe, expect, it} from "vitest"
 const ROOT = process.cwd()
 const SRC = join(ROOT, "src")
 
-const read = (path: string): string => readFileSync(join(SRC, path), "utf8")
-const readProject = (path: string): string => readFileSync(join(ROOT, path), "utf8")
+const normalizeEol = (content: string): string => content.replace(/\r\n?/g, "\n")
+const read = (path: string): string => normalizeEol(readFileSync(join(SRC, path), "utf8"))
+const readProject = (path: string): string => normalizeEol(readFileSync(join(ROOT, path), "utf8"))
 
 describe("页面与宿主资源生命周期", () => {
 	it("主工作区只缓存对话页，其他重资源页面切走后正常卸载", () => {
@@ -19,14 +20,14 @@ describe("页面与宿主资源生命周期", () => {
 		expect(KEEP_ALIVE).not.toContain("<MemoryPanel")
 		expect(KEEP_ALIVE).not.toContain("<SettingsPanel")
 		expect(MAIN).toContain("<ModelManagement v-if=\"activeNav === 'model'\"")
-		expect(MAIN).toContain("<SettingsPanel\n\t\t\t\t\t\tv-if=\"activeNav === 'settings'\"")
+		expect(MAIN).toMatch(/<SettingsPanel\s+v-if="activeNav === 'settings'"/)
 	})
 
 	it("应用根组件卸载时退订模块级语言监听", () => {
 		const APP = read("App.vue")
 
 		expect(APP).toContain("const stopLanguageSync = RUNTIME.onLanguageChanged")
-		expect(APP).toContain("onBeforeUnmount(() => {\n\tstopLanguageSync()")
+		expect(APP).toMatch(/onBeforeUnmount\(\(\) => \{\s+stopLanguageSync\(\)/)
 	})
 
 	it("音频宿主卸载会关闭 WebAudio 并取消过期的麦克风启动", () => {

--- a/app/desktop/tests/views/lifecycle-resources.test.ts
+++ b/app/desktop/tests/views/lifecycle-resources.test.ts
@@ -2,9 +2,11 @@ import {readFileSync} from "node:fs"
 import {join} from "node:path"
 import {describe, expect, it} from "vitest"
 
-const SRC = join(process.cwd(), "src")
+const ROOT = process.cwd()
+const SRC = join(ROOT, "src")
 
 const read = (path: string): string => readFileSync(join(SRC, path), "utf8")
+const readProject = (path: string): string => readFileSync(join(ROOT, path), "utf8")
 
 describe("页面与宿主资源生命周期", () => {
 	it("主工作区只缓存对话页，其他重资源页面切走后正常卸载", () => {
@@ -18,6 +20,13 @@ describe("页面与宿主资源生命周期", () => {
 		expect(KEEP_ALIVE).not.toContain("<SettingsPanel")
 		expect(MAIN).toContain("<ModelManagement v-if=\"activeNav === 'model'\"")
 		expect(MAIN).toContain("<SettingsPanel\n\t\t\t\t\t\tv-if=\"activeNav === 'settings'\"")
+	})
+
+	it("应用根组件卸载时退订模块级语言监听", () => {
+		const APP = read("App.vue")
+
+		expect(APP).toContain("const stopLanguageSync = RUNTIME.onLanguageChanged")
+		expect(APP).toContain("onBeforeUnmount(() => {\n\tstopLanguageSync()")
 	})
 
 	it("音频宿主卸载会关闭 WebAudio 并取消过期的麦克风启动", () => {
@@ -37,5 +46,16 @@ describe("页面与宿主资源生命周期", () => {
 		expect(LIVE2D.split(DESTROY).length - 1).toBe(2)
 		expect(LIVE2D).not.toContain("app.destroy(true)\n")
 		expect(LIVE2D).not.toContain("inner.app.destroy(true)\n")
+	})
+
+	it("真正关闭桌宠窗口时断开运行时事件与 WindowManager 强引用", () => {
+		const PET_WINDOW = readProject("Nori.Desktop/Windows/PetWindow.cs")
+		const WINDOW_MANAGER = readProject("Nori.Desktop/Windows/WindowManager.cs")
+
+		expect(PET_WINDOW).toContain("_runtime.ModelChanged -= OnRuntimeModelChanged")
+		expect(PET_WINDOW).toContain("_runtime.LayoutChanged -= OnRuntimeLayoutChanged")
+		expect(PET_WINDOW).toContain("_cursorTrackingTimer.Tick -= OnCursorTrackingTick")
+		expect(PET_WINDOW).toContain("_hitShapeTimer.Tick -= OnHitShapeTick")
+		expect(WINDOW_MANAGER).toContain("if (ReferenceEquals(_petWindow, pw)) _petWindow = null;")
 	})
 })

--- a/app/desktop/tests/views/lifecycle-resources.test.ts
+++ b/app/desktop/tests/views/lifecycle-resources.test.ts
@@ -29,4 +29,13 @@ describe("页面与宿主资源生命周期", () => {
 		expect(AUDIO).toContain("GENERATION !== recordingGeneration")
 		expect(AUDIO).toContain("stopStream(acquiredStream)")
 	})
+
+	it("Live2D 销毁会递归释放模型子资源但保留共享纹理", () => {
+		const LIVE2D = read("services/live2d/index.ts")
+		const DESTROY = "destroy(true, {children: true, texture: false, baseTexture: false})"
+
+		expect(LIVE2D.split(DESTROY).length - 1).toBe(2)
+		expect(LIVE2D).not.toContain("app.destroy(true)\n")
+		expect(LIVE2D).not.toContain("inner.app.destroy(true)\n")
+	})
 })


### PR DESCRIPTION
## 背景

这轮针对主窗口长期运行的内存/资源驻留做生命周期审计，同时处理之前 Review 里发现的 `ModelManagement` + `KeepAlive` 问题。

## 已确认并修复

### 1. 主工作区 KeepAlive 范围过大

原来 `HomePanel / ChatView / ModelManagement / MemoryPanel / SettingsPanel` 全部放在同一个 `<KeepAlive>` 中。实际只有 ChatView 需要跨导航保留状态；其余页面因此不会触发 `onBeforeUnmount`，会继续保留页面树、全局监听器、计时器，ModelManagement 还会保留 Live2D/Pixi 预览。

现在：
- 仅 ChatView 使用 KeepAlive，保证进行中的对话/审批不被导航打断
- Home / Model / Memory / Settings 切走即卸载
- ModelManagement 现有的 resize/keydown、preview click、`PREVIEW.destroy()` 清理重新生效
- 设置子页的页面级 interval/modal/listener 也会随页面释放

### 2. WebAudio / MediaRecorder 宿主 teardown 不完整

原 `uninstallAudioHost()` 只解除宿主监听、停止当前播放并异步停止录音，没有关闭 `AudioContext`，Gain/Analyser 仍可能持有浏览器原生音频资源。

现在：
- 卸载时断开 Gain/Analyser 并 `AudioContext.close()`
- 录音卸载走 cancel，不上传可能不完整的半截录音
- `getUserMedia()` 增加 generation 防竞态：页面卸载/新请求发生后，迟到的旧权限请求会立即 stop 掉刚获得的 MediaStream
- listener 安装改为逐项登记，初始化中途失败也能完整回滚已安装监听器

### 3. Pixi / Live2D 子资源销毁

项目使用 PixiJS 6.5.x。原代码 `Application.destroy(true)` 不会默认递归 destroy stage children，因此 Live2DModel 的内部 motion manager / auto update 等资源存在继续驻留风险。

现在正常销毁和加载失败路径都会：

```ts
app.destroy(true, {children: true, texture: false, baseTexture: false})
```

递归调用 Live2DModel 的 destroy，同时刻意保留共享 texture/baseTexture，避免一个预览实例销毁另一实例仍在使用的模型纹理。

### 4. 真正关闭 PetWindow 后仍存在强引用链

`WindowManager.Close("pet")` 原来会从 `_windows` 移除并关闭窗口，但 `_petWindow` 字段没有清空；同时 PetWindow 通过匿名 lambda 订阅 `PetRuntime.ModelChanged/LayoutChanged`，而 `AppServices.PetRuntime` 是应用级引用，因此形成：

`AppServices -> PetRuntime -> event delegate -> 已关闭 PetWindow`

现在：
- WindowManager 真正关闭 PetWindow 时同步清空 `_petWindow`
- PetWindow 将 Runtime 订阅改为命名 handler，并在 `Closed` 中退订
- Cursor/HitShape DispatcherTimer 停止时同步移除 Tick handler

### 5. App 根组件的模块级语言订阅没有退订

`RUNTIME.onLanguageChanged()` 会把 handler 保存在模块级 Set 中并返回取消函数，但 App.vue 原来忽略返回值。窗口重挂载、HMR 或测试重挂载后旧闭包可能继续驻留。

现在 App 卸载时显式调用 `stopLanguageSync()`。

## 回归门禁

扩展 `tests/views/lifecycle-resources.test.ts`，锁定：
- KeepAlive 中只能有 ChatView
- App 根组件必须退订模块级语言监听
- 音频宿主必须关闭 AudioContext，并具备过期 getUserMedia 防护
- Live2D/Pixi 销毁必须递归 children 且不得销毁共享纹理
- PetWindow 真正关闭时必须退订 Runtime/Timer 事件并清理 WindowManager 强引用

## 审计结论 / 未在本 PR 重构的内容

`AppRuntime` 使用匿名 lambda 订阅 `Windows.VisibilityChanged`，从纯生命周期对称性看可以改成命名 handler 再退订；但生产装配中 AppRuntime 与 WindowManager 是同寿命应用级单例，不会像上述问题一样随页面切换/窗口关闭次数持续增长，因此暂不为了形式上的对称性改动 1500+ 行核心 Runtime。

`BridgeCommands.cs` 体积过大仍属于之前 Review 提到的可维护性技术债，但它不是内存泄漏的直接原因。本 PR 不做领域拆分，以免把资源生命周期修复和大规模结构重构混在一起。