### PR TITLE
fix(ui): 修复模型调整面板内容被裁切

### DIFF
--- a/app/desktop/src/components/ui/AppCard.vue
+++ b/app/desktop/src/components/ui/AppCard.vue
@@ -15,7 +15,7 @@ defineProps<{
 </script>
 
 <template>
-	<section class="surface-card relative overflow-hidden flex flex-col gap-3.5 p-4 transition-all duration-250 hover:border-line-strong hover:shadow-[0_0.4rem_2rem_rgba(0,0,0,0.3)]">
+	<section class="surface-card relative overflow-hidden flex shrink-0 flex-col gap-3.5 p-4 transition-all duration-250 hover:border-line-strong hover:shadow-[0_0.4rem_2rem_rgba(0,0,0,0.3)]">
 		<span class="absolute top-0 inset-x-0 h-[0.1rem] bg-gradient-to-r from-transparent via-nori-teal-bright/20 to-transparent pointer-events-none"/>
 
 		<header v-if="title || $slots.header" class="flex items-center gap-2.5 min-h-[2.8rem]">

--- a/app/desktop/tests/style/card-overflow.test.ts
+++ b/app/desktop/tests/style/card-overflow.test.ts
@@ -1,0 +1,14 @@
+import {readFileSync} from "node:fs"
+import {join} from "node:path"
+import {describe, expect, it} from "vitest"
+
+const ROOT = process.cwd()
+
+describe("设置卡片滚动布局", () => {
+	it("AppCard 不被 flex 容器压缩导致内部内容裁切", () => {
+		const CARD = readFileSync(join(ROOT, "src/components/ui/AppCard.vue"), "utf8")
+		const ROOT_CLASS = CARD.match(/<section class="([^"]+)"/)?.[1] ?? ""
+
+		expect(ROOT_CLASS.split(/\s+/)).toContain("shrink-0")
+	})
+})


### PR DESCRIPTION
## 问题

“调整模型”整页面板右侧是受限高度的 `flex-column + scroll-area`。

`AppCard` 作为直接 flex 子项默认允许 shrink；当“基础与行为”或“自定义互动区域”的内容超过可用高度时，卡片会先被压矮。`AppCard` 本身又使用 `overflow-hidden`，因此“表情”和后续行为/互动设置会被卡片内部裁掉，而外层滚动区域也拿不到正确的溢出高度。

## 修复

- `AppCard` 根节点增加 `shrink-0`，卡片保持内容所需的自然高度
- 超出窗口的部分交给外层 `scroll-area` 正常纵向滚动
- 对设置卡统一生效，避免其他 flex 滚动布局出现同类裁切
- 增加回归测试，锁定 `AppCard` 不允许被 flex 压缩

## 影响范围

- 不修改模型、互动区域或 Live2D 逻辑
- 不修改预览舞台几何尺寸
- 仅修正布局和滚动行为
