### PR TITLE
fix(window): 避免跨窗口显示后触发未授权聚焦

### DIFF
--- a/app/desktop/src/services/window/index.ts
+++ b/app/desktop/src/services/window/index.ts
@@ -48,12 +48,16 @@ function getTarget(label: WindowLabel) {
 }
 
 /**
- * 显示并聚焦窗口
+ * 显示窗口。
+ *
+ * Bridge 只允许 WebView 修改自己的窗口属性；主窗口仅额外获准 show/hide pet。
+ * 因此跨窗口显示时不能紧接着调用 window_focus，否则 main → pet 会被权限层拒绝。
+ * 当前窗口仍保留原来的 show + focus 行为。
  */
 export async function showWindow(label: WindowLabel) {
 	const WINDOW = getTarget(label)
 	await WINDOW.show()
-	await WINDOW.setFocus()
+	if (getCurrentWindow().label === label) await WINDOW.setFocus()
 }
 
 /**

--- a/app/desktop/tests/runtime/window-scheduling.test.ts
+++ b/app/desktop/tests/runtime/window-scheduling.test.ts
@@ -1,0 +1,38 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const CURRENT = vi.hoisted(() => ({label: "main"}))
+const SHOW = vi.hoisted(() => vi.fn())
+const FOCUS = vi.hoisted(() => vi.fn())
+const HIDE = vi.hoisted(() => vi.fn())
+const CLOSE = vi.hoisted(() => vi.fn())
+
+vi.mock("../../src/services/host/window", () => ({
+	getCurrentWindow: () => ({label: CURRENT.label, close: CLOSE}),
+	getWindowByLabel: (label: string) => ({label, show: SHOW, setFocus: FOCUS, hide: HIDE, close: CLOSE}),
+}))
+
+import {showWindow} from "../../src/services/window"
+
+describe("窗口调度", () => {
+	beforeEach(() => {
+		CURRENT.label = "main"
+		SHOW.mockReset().mockResolvedValue(undefined)
+		FOCUS.mockReset().mockResolvedValue(undefined)
+		HIDE.mockReset().mockResolvedValue(undefined)
+		CLOSE.mockReset().mockResolvedValue(undefined)
+	})
+
+	it("跨窗口显示桌宠时不请求未授权的焦点操作", async () => {
+		await showWindow("pet")
+
+		expect(SHOW).toHaveBeenCalledOnce()
+		expect(FOCUS).not.toHaveBeenCalled()
+	})
+
+	it("显示当前窗口时仍会恢复焦点", async () => {
+		await showWindow("main")
+
+		expect(SHOW).toHaveBeenCalledOnce()
+		expect(FOCUS).toHaveBeenCalledOnce()
+	})
+})


### PR DESCRIPTION
## 问题

主窗口“唤出 Nori”调用 `showWindow("pet")`。前端公共 helper 会先 `window_show`，再无条件执行 `window_focus`。

后端权限模型只允许 WebView 操作自身窗口属性；`main` 仅额外获准 show/hide `pet`。因此：

1. `window_show {label:"pet"}` 成功
2. `window_focus {label:"pet"}` 进入 `Target()`
3. `AuthorizedWindowLabel()` 判定为跨窗口操作并抛出 `InvalidOperationException("不能操作其它窗口")`

这与 Sentry 堆栈 `AuthorizedWindowLabel -> Target -> window_focus` 一致。

## 修复

- `showWindow()` 显示目标窗口后，仅当目标就是当前窗口时调用 `setFocus()`
- `main -> pet` 现在只执行 show，不再请求未授权的跨窗口 focus
- 保留 Bridge 原有窗口隔离，不扩大 main 对 pet 的尺寸、位置、拖动、关闭等权限

## 测试

新增窗口调度单测：
- `main -> pet`：调用 show，不调用 focus
- `main -> main`：仍保持 show + focus

## 影响

修复主窗口唤出桌宠时上报的未处理 `System.InvalidOperationException`，同时避免桌宠窗口抢占主窗口键盘焦点。