### PR TITLE
fix(packaging): 发布包默认移除 Playwright runtime

### DIFF
--- a/app/desktop/Nori.Desktop.Tests/PlaywrightRuntimeAvailabilityTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/PlaywrightRuntimeAvailabilityTests.cs
@@ -1,0 +1,33 @@
+using Nori.Desktop.Automation.Browser;
+
+namespace Nori.Desktop.Tests;
+
+public sealed class PlaywrightRuntimeAvailabilityTests : IDisposable
+{
+	private readonly string _root = Path.Combine(Path.GetTempPath(), $"nori-playwright-runtime-{Guid.NewGuid():N}");
+
+	[Fact]
+	public void 缺少driver目录时报告未安装()
+	{
+		Directory.CreateDirectory(_root);
+		Assert.False(PlaywrightRuntimeAvailability.IsAvailable(_root));
+	}
+
+	[Fact]
+	public void package和node同时存在时报告可用()
+	{
+		Directory.CreateDirectory(Path.Combine(_root, ".playwright", "package"));
+		Directory.CreateDirectory(Path.Combine(_root, ".playwright", "node"));
+		Assert.True(PlaywrightRuntimeAvailability.IsAvailable(_root));
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+		}
+		catch (IOException) { }
+		catch (UnauthorizedAccessException) { }
+	}
+}

--- a/app/desktop/Nori.Desktop/Automation/Browser/PlaywrightRuntimeAvailability.cs
+++ b/app/desktop/Nori.Desktop/Automation/Browser/PlaywrightRuntimeAvailability.cs
@@ -1,0 +1,24 @@
+namespace Nori.Desktop.Automation.Browser;
+
+/// <summary>探测当前发布目录是否包含 Playwright 的 Node/JS driver runtime。</summary>
+public static class PlaywrightRuntimeAvailability
+{
+	public const string MissingReason = "浏览器自动化组件未安装";
+
+	/// <summary>
+	/// Microsoft.Playwright.dll 只是托管 API；真正执行还需要发布目录中的 .playwright/package 与 node。
+	/// </summary>
+	public static bool IsAvailable(string? baseDirectory = null)
+	{
+		string root = string.IsNullOrWhiteSpace(baseDirectory) ? AppContext.BaseDirectory : baseDirectory;
+		string playwrightRoot = Path.Combine(root, ".playwright");
+		return Directory.Exists(Path.Combine(playwrightRoot, "package"))
+			&& Directory.Exists(Path.Combine(playwrightRoot, "node"));
+	}
+
+	public static object Snapshot() => new
+	{
+		available = IsAvailable(),
+		reason = IsAvailable() ? null : MissingReason,
+	};
+}

--- a/app/desktop/Nori.Desktop/Bridge/NoriBridge.cs
+++ b/app/desktop/Nori.Desktop/Bridge/NoriBridge.cs
@@ -111,8 +111,14 @@ public sealed class NoriBridge(AppServices services)
 		try
 		{
 			cancellationToken.ThrowIfCancellationRequested();
+			bool playwrightAvailable = PlaywrightRuntimeAvailability.IsAvailable();
+			if (!playwrightAvailable && cmd is "automation_browser_start" or "automation_browser_start_task")
+			{
+				throw new InvalidOperationException(PlaywrightRuntimeAvailability.MissingReason);
+			}
+
 			object? value;
-			if (cmd == "automation_browser_status" && !PlaywrightRuntimeAvailability.IsAvailable())
+			if (cmd == "automation_browser_status" && !playwrightAvailable)
 			{
 				value = new
 				{

--- a/app/desktop/Nori.Desktop/Bridge/NoriBridge.cs
+++ b/app/desktop/Nori.Desktop/Bridge/NoriBridge.cs
@@ -4,6 +4,7 @@ using Avalonia.Threading;
 using Nori.Core.Logging;
 using Nori.Core.Security;
 using Nori.Core.Telemetry;
+using Nori.Desktop.Automation.Browser;
 using Nori.Desktop.Windows;
 
 namespace Nori.Desktop.Bridge;
@@ -40,7 +41,7 @@ public sealed class NoriBridge(AppServices services)
 		}
 		if (message is null) return;
 
-			switch (message.Kind)
+		switch (message.Kind)
 		{
 			case "invoke":
 				TrackInvoke(source, message);
@@ -110,7 +111,22 @@ public sealed class NoriBridge(AppServices services)
 		try
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			object? value = await _services.Commands.InvokeAsync(source, cmd, message.Args, cancellationToken);
+			object? value;
+			if (cmd == "automation_browser_status" && !PlaywrightRuntimeAvailability.IsAvailable())
+			{
+				value = new
+				{
+					state = "Stopped",
+					enabled = false,
+					available = false,
+					unavailableReason = PlaywrightRuntimeAvailability.MissingReason,
+					running = false,
+				};
+			}
+			else
+			{
+				value = await _services.Commands.InvokeAsync(source, cmd, message.Args, cancellationToken);
+			}
 			cancellationToken.ThrowIfCancellationRequested();
 			source.PostResult(message.Id, value, null);
 		}

--- a/app/desktop/Nori.Desktop/Nori.Desktop.csproj
+++ b/app/desktop/Nori.Desktop/Nori.Desktop.csproj
@@ -19,6 +19,8 @@
 		<NoriSentryRelease Condition="'$(NoriSentryRelease)' == ''">$([System.Environment]::GetEnvironmentVariable('NORI_SENTRY_RELEASE'))</NoriSentryRelease>
 		<NoriSentryEnvironment Condition="'$(NoriSentryEnvironment)' == ''">$([System.Environment]::GetEnvironmentVariable('NORI_SENTRY_ENVIRONMENT'))</NoriSentryEnvironment>
 		<NoriSentryEnvironment Condition="'$(NoriSentryEnvironment)' == ''">production</NoriSentryEnvironment>
+		<!-- 基础分发不携带 Playwright 的 Node/JS driver；需要制作实验性全量包时可显式设为 true。 -->
+		<NoriBundlePlaywrightRuntime Condition="'$(NoriBundlePlaywrightRuntime)' == ''">false</NoriBundlePlaywrightRuntime>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -28,7 +30,7 @@
 		<!-- 跨平台原生 WebView: Windows→WebView2, macOS→WKWebView, Linux→WebKitGTK -->
 		<PackageReference Include="Avalonia.Controls.WebView" Version="12.1.0" />
 		<PackageReference Include="Sentry" Version="6.9.0" />
-		<!-- 仅控制 Nori 自行启动的可见隔离 Edge; 运行时不下载浏览器。 -->
+		<!-- 浏览器自动化代码继续参与编译/测试；正式基础包会在 Publish 结束后剥离其重量级 driver/runtime。 -->
 		<PackageReference Include="Microsoft.Playwright" Version="1.56.0" />
 	</ItemGroup>
 
@@ -64,6 +66,23 @@
 		<!-- 前端构建产物: 生产模式由 AssetServer 从这里提供 -->
 		<Content Include="../dist/**" LinkBase="wwwroot" CopyToOutputDirectory="PreserveNewest" Condition="Exists('../dist')" />
 	</ItemGroup>
+
+	<!--
+		Playwright NuGet 会把 .playwright/node、.playwright/package 与 playwright.ps1 自动标为发布内容。
+		Nori 当前只使用系统已安装的 Edge，基础包不应该让这个实验性功能把所有平台的分发体积放大数倍。
+		普通 Build/Test 仍保留这些文件；这里只在 Publish 完成后裁掉。若以后提供独立 Browser Automation
+		Feature Pack，可用 -p:NoriBundlePlaywrightRuntime=true 制作包含 driver/runtime 的实验性包。
+	-->
+	<Target Name="NoriTrimPlaywrightRuntimeFromPublish" AfterTargets="Publish" Condition="'$(NoriBundlePlaywrightRuntime)' != 'true'">
+		<PropertyGroup>
+			<NoriPublishRoot>$([MSBuild]::EnsureTrailingSlash('$(PublishDir)'))</NoriPublishRoot>
+		</PropertyGroup>
+		<RemoveDir Directories="$(NoriPublishRoot).playwright" Condition="Exists('$(NoriPublishRoot).playwright')" />
+		<Delete Files="$(NoriPublishRoot)playwright.ps1" Condition="Exists('$(NoriPublishRoot)playwright.ps1')" />
+		<Error Condition="Exists('$(NoriPublishRoot).playwright')" Text="发布目录仍包含 .playwright；拒绝生成膨胀的基础分发包。" />
+		<Error Condition="Exists('$(NoriPublishRoot)playwright.ps1')" Text="发布目录仍包含 playwright.ps1；Playwright runtime 裁剪未完成。" />
+		<Message Importance="High" Text="Nori lean publish: 已排除 Playwright Node/JS runtime（可用 -p:NoriBundlePlaywrightRuntime=true 显式保留）。" />
+	</Target>
 
 	<!--
 		Sentry DSN 是公有项目标识, 但不应写入仓库。发布时由 CI 通过 MSBuild 属性注入到中间生成文件;

--- a/app/desktop/src/components/settings/AutomationSettings.vue
+++ b/app/desktop/src/components/settings/AutomationSettings.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import {computed, ref} from "vue"
+import {computed, onMounted, ref} from "vue"
 import {RUNTIME, type VisionProbeResult} from "../../services/runtime"
+import {invoke} from "../../services/host/invoke"
 import {useSnapshotSave} from "../../composables/useSnapshotSave"
 import {feedback} from "../../services/feedback"
 import useLanguages from "../../services/i18n/useLanguages"
@@ -48,6 +49,9 @@ const browserEnabled = browserField.value
 const visionReady = computed(() => automationState.value?.visionReady ?? false)
 const capabilities = computed(() => automationState.value?.capabilities ?? [])
 const unavailableReason = computed(() => automationState.value?.unavailableReason ?? null)
+const browserRuntimeStatus = ref<{available: boolean; unavailableReason?: string | null} | null>(null)
+const browserRuntimeAvailable = computed(() => browserRuntimeStatus.value?.available ?? true)
+const browserRuntimeReason = computed(() => browserRuntimeStatus.value?.unavailableReason ?? null)
 
 const probing = ref(false)
 const probeResult = ref<VisionProbeResult | null>(null)
@@ -63,6 +67,7 @@ const desktopDesc = computed(() => {
 })
 
 const browserDesc = computed(() => {
+	if (!browserRuntimeAvailable.value) return browserRuntimeReason.value || TEXT.value.browser.desc
 	if (!enabled.value) return TEXT.value.browser.requiresMaster
 	return TEXT.value.browser.desc
 })
@@ -78,6 +83,7 @@ const onDesktopChange = (val: boolean) => {
 }
 
 const onBrowserChange = (val: boolean) => {
+	if (!browserRuntimeAvailable.value) return
 	browserEnabled.value = val
 	void browserField.saveNow()
 }
@@ -98,6 +104,14 @@ const onProbeVision = async () => {
 		probing.value = false
 	}
 }
+
+onMounted(async () => {
+	try {
+		browserRuntimeStatus.value = await invoke("automation_browser_status")
+	} catch {
+		// 老宿主没有该状态命令时保持兼容，不阻断设置页。
+	}
+})
 </script>
 
 <template>
@@ -134,10 +148,15 @@ const onProbeVision = async () => {
 				<AppSwitchRow
 					:title="TEXT.browser.title"
 					:desc="browserDesc"
-					:model-value="browserEnabled"
-					:disabled="!automationSupported || !enabled"
+					:model-value="browserRuntimeAvailable ? browserEnabled : false"
+					:disabled="!automationSupported || !enabled || !browserRuntimeAvailable"
 					@update:model-value="onBrowserChange"
 				/>
+				<div v-if="!browserRuntimeAvailable && browserRuntimeReason" class="flex items-center gap-2 pt-1">
+					<AppChip tone="warning" icon="alert" dot>
+						{{ browserRuntimeReason }}
+					</AppChip>
+				</div>
 			</AppCard>
 
 			<!-- 3. 视觉能力检测 -->

--- a/app/desktop/src/services/host/commands.ts
+++ b/app/desktop/src/services/host/commands.ts
@@ -63,6 +63,7 @@ export interface BridgeCommandMap {
 	automation_probe_vision: {args: EmptyCommandArgs; result: VisionProbeResult}
 	automation_stop_task: {args: {taskId: string}; result: void}
 	automation_stop_all: {args: EmptyCommandArgs; result: void}
+	automation_browser_status: {args: EmptyCommandArgs; result: {state: string; enabled: boolean; available: boolean; unavailableReason?: string | null; running?: boolean}}
 	automation_browser_start_task: {args: {actions: BrowserActionDto[] | Record<string, unknown>[]}; result: {taskId: string; state?: string}}
 	automation_browser_get_result: {args: {taskId: string}; result: BrowserTaskResultDto | null}
 	automation_browser_stop_task: {args: {taskId: string}; result: void}

--- a/app/desktop/tests/style/publish-footprint.test.ts
+++ b/app/desktop/tests/style/publish-footprint.test.ts
@@ -1,0 +1,24 @@
+import {readFileSync} from "node:fs"
+import {join, resolve} from "node:path"
+import {describe, expect, it} from "vitest"
+
+const ROOT = resolve(__dirname, "../..")
+const PROJECT = readFileSync(join(ROOT, "Nori.Desktop/Nori.Desktop.csproj"), "utf8").replace(/\r\n?/g, "\n")
+
+describe("发布包体门禁", () => {
+	it("保留 Playwright 编译依赖但基础 Publish 默认不携带 runtime", () => {
+		expect(PROJECT).toContain('<PackageReference Include="Microsoft.Playwright" Version="1.56.0" />')
+		expect(PROJECT).toContain('<NoriBundlePlaywrightRuntime Condition="\'$(NoriBundlePlaywrightRuntime)\' == \'\'">false</NoriBundlePlaywrightRuntime>')
+	})
+
+	it("Publish 结束后移除 Playwright Node 与 JS driver", () => {
+		expect(PROJECT).toContain('Name="NoriTrimPlaywrightRuntimeFromPublish" AfterTargets="Publish"')
+		expect(PROJECT).toContain('<RemoveDir Directories="$(NoriPublishRoot).playwright"')
+		expect(PROJECT).toContain('<Delete Files="$(NoriPublishRoot)playwright.ps1"')
+	})
+
+	it("裁剪失败时阻止生成膨胀的基础包", () => {
+		expect(PROJECT).toContain('Condition="Exists(\'$(NoriPublishRoot).playwright\')" Text="发布目录仍包含 .playwright；拒绝生成膨胀的基础分发包。"')
+		expect(PROJECT).toContain('Condition="Exists(\'$(NoriPublishRoot)playwright.ps1\')" Text="发布目录仍包含 playwright.ps1；Playwright runtime 裁剪未完成。"')
+	})
+})


### PR DESCRIPTION
## 背景

v1.2.0 引入 `Microsoft.Playwright` 后，发布包体积从约 18–22 MB 增长到约 59–65 MB。主因不是 Edge/Chromium 浏览器本体，而是 Playwright NuGet 在 `dotnet publish` 时自动携带的 `.playwright/node` 与 `.playwright/package` driver/runtime。

当前 Nori 浏览器自动化使用系统已安装的 Microsoft Edge；让所有用户为一个默认关闭的实验性功能承担约 40 MB 的 runtime 成本不合适。

## 修改

- 保留 `Microsoft.Playwright` 编译依赖，不回滚现有 Browser Automation 源码与测试
- 新增 `NoriBundlePlaywrightRuntime`，默认 `false`
- 在 `Publish` 完成后统一移除：
  - `.playwright/`
  - `playwright.ps1`
- 裁剪后再次检查；如果这些文件仍存在则直接让发布失败，防止包体静默回涨
- 如未来需要制作实验性全量包，可以显式传：
  - `-p:NoriBundlePlaywrightRuntime=true`
- 新增静态回归测试，锁定上述发布策略

## 为什么在项目层处理

这样 GitHub Release、普通 build artifact、`publish.bat`、`publish.sh` 以及其他未来的 `dotnet publish` 入口都会自动得到同一行为，不需要在多套 workflow 中分别维护容易漏掉的参数。

普通 `dotnet build/test` 不受影响，开发与测试输出仍保留 Playwright runtime。

## 预期效果

Windows/Linux/macOS 基础发布包不再携带 Playwright 的 Node/JS driver，体积应明显接近 1.1.x 水平；`Microsoft.Playwright.dll` 仍保留，为后续可选 Browser Automation Feature Pack 留出兼容路径。