### PR TITLE
fix(ai): 模型发现失败时不再伪装 Anthropic 成功

### DIFF
--- a/app/desktop/Nori.Core.Tests/AnthropicModelDiscoveryTests.cs
+++ b/app/desktop/Nori.Core.Tests/AnthropicModelDiscoveryTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Text;
+using Nori.Core.Chat;
+using Nori.Core.Chat.Adapters;
+
+namespace Nori.Core.Tests;
+
+public sealed class AnthropicModelDiscoveryTests
+{
+	[Fact]
+	public async Task 获取模型接口失败时明确报错而不是返回内置列表()
+	{
+		using HttpClient client = new(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.Unauthorized)
+		{
+			Content = new StringContent("{\"error\":{\"message\":\"denied\"}}", Encoding.UTF8, "application/json"),
+		}));
+		AnthropicAdapter adapter = new(client);
+
+		ChatException exception = await Assert.ThrowsAsync<ChatException>(() =>
+			adapter.FetchModelsAsync("https://example.test", "secret"));
+
+		Assert.Contains("HTTP 401", exception.Message, StringComparison.Ordinal);
+		Assert.Contains("denied", exception.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 空模型列表被视为发现失败()
+	{
+		using HttpClient client = new(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+		{
+			Content = new StringContent("{\"data\":[]}", Encoding.UTF8, "application/json"),
+		}));
+		AnthropicAdapter adapter = new(client);
+
+		ChatException exception = await Assert.ThrowsAsync<ChatException>(() =>
+			adapter.FetchModelsAsync("https://example.test", "secret"));
+
+		Assert.Contains("空模型列表", exception.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 成功时只返回服务端实际模型并排序去重()
+	{
+		using HttpClient client = new(new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+		{
+			Content = new StringContent(
+				"{\"data\":[{\"id\":\"claude-z\"},{\"id\":\"claude-a\"},{\"id\":\"claude-z\"}]}",
+				Encoding.UTF8,
+				"application/json"),
+		}));
+		AnthropicAdapter adapter = new(client);
+
+		IReadOnlyList<string> models = await adapter.FetchModelsAsync("https://example.test/messages", "secret");
+
+		Assert.Equal(["claude-a", "claude-z"], models);
+	}
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+}

--- a/app/desktop/Nori.Core/Chat/Adapters/AnthropicAdapter.cs
+++ b/app/desktop/Nori.Core/Chat/Adapters/AnthropicAdapter.cs
@@ -250,54 +250,58 @@ public sealed class AnthropicAdapter(HttpClient httpClient) : ILlmAdapter
 		request.Headers.Add("anthropic-version", AnthropicVersion);
 		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
 
-		HttpResponseMessage? response = null;
+		HttpResponseMessage response;
 		try
 		{
 			response = await _httpClient.SendAsync(request, cancellationToken);
 		}
-		catch (Exception)
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
 		{
-			// 如果网络或端点请求失败，将使用内置常用模型列表
+			throw;
+		}
+		catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException)
+		{
+			throw new ChatException($"获取模型列表失败: {exception.Message}", exception);
 		}
 
-		if (response is not null)
+		using (response)
 		{
-			using (response)
+			if (!response.IsSuccessStatusCode)
 			{
-				if (response.IsSuccessStatusCode)
+				string errorText = await SafeReadErrorAsync(response, cancellationToken);
+				throw new ChatException($"获取模型列表失败: HTTP {(int)response.StatusCode}{(errorText.Length > 0 ? $", {errorText}" : "")}");
+			}
+
+			JsonNode? body;
+			try
+			{
+				body = JsonNode.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
+			}
+			catch (JsonException exception)
+			{
+				throw new ChatException($"获取模型列表失败: 响应 JSON 无效: {exception.Message}", exception);
+			}
+
+			if (body?["data"] is not JsonArray data)
+			{
+				throw new ChatException("获取模型列表失败: 响应缺少 data 数组");
+			}
+
+			SortedSet<string> models = new(StringComparer.Ordinal);
+			foreach (JsonNode? item in data)
+			{
+				if (item?["id"] is JsonValue idVal && idVal.TryGetValue(out string? id) && !string.IsNullOrWhiteSpace(id))
 				{
-					try
-					{
-						JsonNode? body = JsonNode.Parse(await response.Content.ReadAsStringAsync(cancellationToken));
-						if (body?["data"] is JsonArray data && data.Count > 0)
-						{
-							SortedSet<string> models = new(StringComparer.Ordinal);
-							foreach (JsonNode? item in data)
-							{
-								if (item?["id"] is JsonValue idVal && idVal.TryGetValue(out string? id) && !string.IsNullOrWhiteSpace(id))
-								{
-									models.Add(id);
-								}
-							}
-							if (models.Count > 0) return [.. models];
-						}
-					}
-					catch
-					{
-						// 解析异常回退
-					}
+					models.Add(id);
 				}
 			}
-		}
 
-		// 回退内置常用模型
-		return
-		[
-			"claude-3-7-sonnet-20250219",
-			"claude-3-5-sonnet-20241022",
-			"claude-3-5-haiku-20241022",
-			"claude-3-opus-20240229",
-		];
+			if (models.Count == 0)
+			{
+				throw new ChatException("获取模型列表失败: 服务端返回了空模型列表");
+			}
+			return [.. models];
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
## 问题

`AnthropicAdapter.FetchModelsAsync` 原来在网络错误、HTTP 错误、JSON 解析失败或服务端没有返回有效模型时，会静默回退到一组硬编码 Claude 模型。

这会把真实的 Provider/鉴权/端点故障伪装成“模型获取成功”，也正是之前排查 DeepSeek 协议问题时 Anthropic 看起来正常、实际请求可能已经失败的原因之一。

## 修改

- 网络失败：抛出可诊断的 `ChatException`
- 非 2xx：保留 HTTP 状态码和经过限制的服务端错误信息
- JSON 无效 / 缺少 `data` / 空模型列表：明确报错
- 成功时只返回服务端实际 `data[].id`，继续排序和去重
- 删除硬编码 Claude 模型作为 discovery fallback 的行为

## 测试

新增 `AnthropicModelDiscoveryTests`，覆盖：
- 401 必须显式失败并保留服务端错误
- 空 `data` 不得伪装成功
- 正常返回只使用服务端模型并排序去重

这张 PR 不改变 Anthropic 对话/流式响应协议，只修模型目录发现的错误语义。