### PR TITLE
ci(packaging): 为正式发布增加包体积预算

### DIFF
--- a/app/desktop/publish.bat
+++ b/app/desktop/publish.bat
@@ -39,6 +39,8 @@ if not exist bin\publish\win-x64\wwwroot\index.html (
 	exit /b 2
 )
 if not "%KEEP_SYMBOLS%"=="1" if /I not "%KEEP_SYMBOLS%"=="true" for /r "bin\publish\win-x64" %%F in (*.pdb) do del /q "%%F"
+node scripts\check-package-size.mjs --path bin\publish\win-x64 --label "win-x64 publish" --max-mib 80
+if errorlevel 1 goto :error
 
 echo.
 echo ========================================================

--- a/app/desktop/publish.bat
+++ b/app/desktop/publish.bat
@@ -39,7 +39,8 @@ if not exist bin\publish\win-x64\wwwroot\index.html (
 	exit /b 2
 )
 if not "%KEEP_SYMBOLS%"=="1" if /I not "%KEEP_SYMBOLS%"=="true" for /r "bin\publish\win-x64" %%F in (*.pdb) do del /q "%%F"
-node scripts\check-package-size.mjs --path bin\publish\win-x64 --label "win-x64 publish" --max-mib 80
+rem Windows FDD 未压缩 publish 基线约 159 MiB；180 MiB 仍能拦截几十 MiB 级异常膨胀。
+node scripts\check-package-size.mjs --path bin\publish\win-x64 --label "win-x64 publish" --max-mib 180
 if errorlevel 1 goto :error
 
 echo.

--- a/app/desktop/publish.sh
+++ b/app/desktop/publish.sh
@@ -51,19 +51,15 @@ detect_rid() {
 	esac
 }
 
-# macOS 的 .app bundle: Avalonia 需要它才能拿到正常的 Dock/权限行为,
-# 麦克风权限也必须在 Info.plist 里声明, 否则 getUserMedia 会被系统直接拒绝。
 make_macos_bundle() {
 	local rid="$1" publish_dir="$2"
 	local app_dir="bin/publish/$rid/Nori.app"
 	rm -rf "$app_dir"
 	mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources"
-
 	cp -R "$publish_dir/." "$app_dir/Contents/MacOS/"
-
 	cat > "$app_dir/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key><string>Nori</string>
@@ -75,7 +71,6 @@ make_macos_bundle() {
 	<key>CFBundleExecutable</key><string>$APP_NAME</string>
 	<key>LSMinimumSystemVersion</key><string>12.0</string>
 	<key>NSHighResolutionCapable</key><true/>
-	<!-- 语音输入: 前端 MediaRecorder 会触发系统麦克风授权, 缺这条会被直接拒绝 -->
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Nori 需要使用麦克风来进行语音对话。</string>
 </dict>
@@ -84,37 +79,29 @@ PLIST
 	echo "已生成 $app_dir"
 }
 
-# Linux: tar.gz + .desktop 模板 (安装路径由用户决定, 因此 Exec 用占位符)
 make_linux_package() {
 	local rid="$1" publish_dir="$2"
 	local out_dir="bin/publish/$rid"
-
-	# 保留原 apphost 作为兼容入口，同时提供不会被 Dolphin 按 .desktop 误判的主入口。
 	cp -p "$publish_dir/$APP_NAME" "$publish_dir/$LINUX_APP_NAME"
 	test -x "$publish_dir/$LINUX_APP_NAME"
-
 	cat > "$out_dir/nori.desktop" <<DESKTOP
 [Desktop Entry]
 Type=Application
 Name=Nori Desktop Pet
 Comment=Live2D 桌面陪伴伙伴
-# 安装后请把 /opt/nori 换成实际安装路径
 Exec=/opt/nori/$LINUX_APP_NAME
 Icon=/opt/nori/nori.png
 Terminal=false
 Categories=Utility;
 StartupWMClass=Nori.Desktop
 DESKTOP
-
 	cp "$out_dir/nori.desktop" "$publish_dir/nori.desktop"
 	tar -czf "$out_dir/nori-$APP_VERSION-$rid.tar.gz" -C "$publish_dir" .
 	echo "已生成 $out_dir/nori-$APP_VERSION-$rid.tar.gz"
 }
 
 RIDS=("$@")
-if [ ${#RIDS[@]} -eq 0 ]; then
-	RIDS=("$(detect_rid)")
-fi
+if [ ${#RIDS[@]} -eq 0 ]; then RIDS=("$(detect_rid)"); fi
 
 if [ "$SKIP_FRONTEND" = "1" ]; then
 	echo "[1/2] 跳过前端构建, 使用现有 dist/"
@@ -128,10 +115,8 @@ for rid in "${RIDS[@]}"; do
 		linux-x64 | linux-arm64 | osx-arm64 | osx-x64) ;;
 		*) echo "不支持的 RID: $rid" >&2; exit 1 ;;
 	esac
-
 	publish_dir="bin/publish/$rid/app"
-	mode="framework-dependent"
-	echo "[2/2] 发布 $APP_NAME ($rid, $mode)..."
+	echo "[2/2] 发布 $APP_NAME ($rid, framework-dependent)..."
 	rm -rf "bin/publish/$rid"
 	publish_args=(
 		-c Release -r "$rid" --self-contained false
@@ -147,14 +132,12 @@ for rid in "${RIDS[@]}"; do
 		publish_args+=("-p:DebugType=None" "-p:DebugSymbols=false")
 	fi
 	dotnet publish "$APP_NAME/$APP_NAME.csproj" "${publish_args[@]}" -o "$publish_dir"
-
 	if [ "$KEEP_SYMBOLS" != "1" ]; then find "$publish_dir" -name "*.pdb" -delete; fi
-
+	node scripts/check-package-size.mjs --path "$publish_dir" --label "$rid publish" --max-mib 80
 	case "$rid" in
 		osx-*) make_macos_bundle "$rid" "$publish_dir" ;;
 		linux-*) make_linux_package "$rid" "$publish_dir" ;;
 	esac
-
 	echo "========================================================"
 	echo "发布完成: app/desktop/bin/publish/$rid/"
 	echo "========================================================"

--- a/app/desktop/publish.sh
+++ b/app/desktop/publish.sh
@@ -51,15 +51,19 @@ detect_rid() {
 	esac
 }
 
+# macOS 的 .app bundle: Avalonia 需要它才能拿到正常的 Dock/权限行为,
+# 麦克风权限也必须在 Info.plist 里声明, 否则 getUserMedia 会被系统直接拒绝。
 make_macos_bundle() {
 	local rid="$1" publish_dir="$2"
 	local app_dir="bin/publish/$rid/Nori.app"
 	rm -rf "$app_dir"
 	mkdir -p "$app_dir/Contents/MacOS" "$app_dir/Contents/Resources"
+
 	cp -R "$publish_dir/." "$app_dir/Contents/MacOS/"
+
 	cat > "$app_dir/Contents/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleName</key><string>Nori</string>
@@ -71,6 +75,7 @@ make_macos_bundle() {
 	<key>CFBundleExecutable</key><string>$APP_NAME</string>
 	<key>LSMinimumSystemVersion</key><string>12.0</string>
 	<key>NSHighResolutionCapable</key><true/>
+	<!-- 语音输入: 前端 MediaRecorder 会触发系统麦克风授权, 缺这条会被直接拒绝 -->
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Nori 需要使用麦克风来进行语音对话。</string>
 </dict>
@@ -79,29 +84,37 @@ PLIST
 	echo "已生成 $app_dir"
 }
 
+# Linux: tar.gz + .desktop 模板 (安装路径由用户决定, 因此 Exec 用占位符)
 make_linux_package() {
 	local rid="$1" publish_dir="$2"
 	local out_dir="bin/publish/$rid"
+
+	# 保留原 apphost 作为兼容入口，同时提供不会被 Dolphin 按 .desktop 误判的主入口。
 	cp -p "$publish_dir/$APP_NAME" "$publish_dir/$LINUX_APP_NAME"
 	test -x "$publish_dir/$LINUX_APP_NAME"
+
 	cat > "$out_dir/nori.desktop" <<DESKTOP
 [Desktop Entry]
 Type=Application
 Name=Nori Desktop Pet
 Comment=Live2D 桌面陪伴伙伴
+# 安装后请把 /opt/nori 换成实际安装路径
 Exec=/opt/nori/$LINUX_APP_NAME
 Icon=/opt/nori/nori.png
 Terminal=false
 Categories=Utility;
 StartupWMClass=Nori.Desktop
 DESKTOP
+
 	cp "$out_dir/nori.desktop" "$publish_dir/nori.desktop"
 	tar -czf "$out_dir/nori-$APP_VERSION-$rid.tar.gz" -C "$publish_dir" .
 	echo "已生成 $out_dir/nori-$APP_VERSION-$rid.tar.gz"
 }
 
 RIDS=("$@")
-if [ ${#RIDS[@]} -eq 0 ]; then RIDS=("$(detect_rid)"); fi
+if [ ${#RIDS[@]} -eq 0 ]; then
+	RIDS=("$(detect_rid)")
+fi
 
 if [ "$SKIP_FRONTEND" = "1" ]; then
 	echo "[1/2] 跳过前端构建, 使用现有 dist/"
@@ -115,8 +128,10 @@ for rid in "${RIDS[@]}"; do
 		linux-x64 | linux-arm64 | osx-arm64 | osx-x64) ;;
 		*) echo "不支持的 RID: $rid" >&2; exit 1 ;;
 	esac
+
 	publish_dir="bin/publish/$rid/app"
-	echo "[2/2] 发布 $APP_NAME ($rid, framework-dependent)..."
+	mode="framework-dependent"
+	echo "[2/2] 发布 $APP_NAME ($rid, $mode)..."
 	rm -rf "bin/publish/$rid"
 	publish_args=(
 		-c Release -r "$rid" --self-contained false
@@ -132,12 +147,15 @@ for rid in "${RIDS[@]}"; do
 		publish_args+=("-p:DebugType=None" "-p:DebugSymbols=false")
 	fi
 	dotnet publish "$APP_NAME/$APP_NAME.csproj" "${publish_args[@]}" -o "$publish_dir"
+
 	if [ "$KEEP_SYMBOLS" != "1" ]; then find "$publish_dir" -name "*.pdb" -delete; fi
 	node scripts/check-package-size.mjs --path "$publish_dir" --label "$rid publish" --max-mib 80
+
 	case "$rid" in
 		osx-*) make_macos_bundle "$rid" "$publish_dir" ;;
 		linux-*) make_linux_package "$rid" "$publish_dir" ;;
 	esac
+
 	echo "========================================================"
 	echo "发布完成: app/desktop/bin/publish/$rid/"
 	echo "========================================================"

--- a/app/desktop/scripts/check-package-size.mjs
+++ b/app/desktop/scripts/check-package-size.mjs
@@ -1,0 +1,49 @@
+import {readdir, stat} from "node:fs/promises"
+import {resolve} from "node:path"
+
+const args = process.argv.slice(2)
+const value = name => {
+	const index = args.indexOf(name)
+	return index >= 0 ? args[index + 1] : undefined
+}
+
+const targetArg = value("--path")
+const label = value("--label") || "publish"
+const maxMiB = Number(value("--max-mib") || "80")
+
+if (!targetArg || !Number.isFinite(maxMiB) || maxMiB <= 0) {
+	console.error("usage: node check-package-size.mjs --path <file-or-dir> [--label name] [--max-mib 80]")
+	process.exit(2)
+}
+
+const target = resolve(targetArg)
+
+const sizeOf = async path => {
+	const info = await stat(path)
+	if (info.isFile()) return info.size
+	if (!info.isDirectory()) return 0
+	let total = 0
+	for (const entry of await readdir(path, {withFileTypes: true})) {
+		if (entry.isSymbolicLink()) continue
+		total += await sizeOf(resolve(path, entry.name))
+	}
+	return total
+}
+
+try {
+	const bytes = await sizeOf(target)
+	const mib = bytes / 1024 / 1024
+	const summary = `${label}: ${mib.toFixed(2)} MiB / budget ${maxMiB.toFixed(2)} MiB`
+	console.log(`[package-size] ${summary}`)
+	if (process.env.GITHUB_STEP_SUMMARY) {
+		const {appendFile} = await import("node:fs/promises")
+		await appendFile(process.env.GITHUB_STEP_SUMMARY, `- ${summary}\n`, "utf8")
+	}
+	if (mib > maxMiB) {
+		console.error(`[package-size] 发布体积超过预算 ${maxMiB.toFixed(2)} MiB；请检查新增运行时、原生资源或重复产物。`)
+		process.exit(1)
+	}
+} catch (error) {
+	console.error(`[package-size] 无法读取 ${target}:`, error instanceof Error ? error.message : error)
+	process.exit(2)
+}

--- a/app/desktop/scripts/check-package-size.mjs
+++ b/app/desktop/scripts/check-package-size.mjs
@@ -1,5 +1,5 @@
-import {readdir, stat} from "node:fs/promises"
-import {resolve} from "node:path"
+import {appendFile, readdir, stat} from "node:fs/promises"
+import {relative, resolve} from "node:path"
 
 const args = process.argv.slice(2)
 const value = name => {
@@ -17,10 +17,14 @@ if (!targetArg || !Number.isFinite(maxMiB) || maxMiB <= 0) {
 }
 
 const target = resolve(targetArg)
+const files = []
 
 const sizeOf = async path => {
 	const info = await stat(path)
-	if (info.isFile()) return info.size
+	if (info.isFile()) {
+		files.push({path: relative(target, path) || path, size: info.size})
+		return info.size
+	}
 	if (!info.isDirectory()) return 0
 	let total = 0
 	for (const entry of await readdir(path, {withFileTypes: true})) {
@@ -36,11 +40,14 @@ try {
 	const summary = `${label}: ${mib.toFixed(2)} MiB / budget ${maxMiB.toFixed(2)} MiB`
 	console.log(`[package-size] ${summary}`)
 	if (process.env.GITHUB_STEP_SUMMARY) {
-		const {appendFile} = await import("node:fs/promises")
 		await appendFile(process.env.GITHUB_STEP_SUMMARY, `- ${summary}\n`, "utf8")
 	}
 	if (mib > maxMiB) {
 		console.error(`[package-size] 发布体积超过预算 ${maxMiB.toFixed(2)} MiB；请检查新增运行时、原生资源或重复产物。`)
+		console.error("[package-size] 最大文件:")
+		for (const file of files.sort((a, b) => b.size - a.size).slice(0, 12)) {
+			console.error(`  ${(file.size / 1024 / 1024).toFixed(2).padStart(8)} MiB  ${file.path}`)
+		}
 		process.exit(1)
 	}
 } catch (error) {

--- a/app/desktop/scripts/package-windows.ps1
+++ b/app/desktop/scripts/package-windows.ps1
@@ -37,6 +37,11 @@ if (Get-ChildItem -LiteralPath $publish -Recurse -File -Filter "*.map" -ErrorAct
 	throw "发布目录仍含 source map, 不能打包"
 }
 
+# 体积门禁按未压缩 publish 目录计数，避免不同 ZIP 实现/压缩率造成波动。
+node (Join-Path $PSScriptRoot "check-package-size.mjs") `
+	--path $publish --label "windows publish" --max-mib 80
+if ($LASTEXITCODE -ne 0) { throw "Windows 发布体积门禁失败" }
+
 $metadataOutput = Join-Path $output "metadata"
 Remove-Item -LiteralPath $metadataOutput -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Path $metadataOutput -Force | Out-Null

--- a/app/desktop/scripts/package-windows.ps1
+++ b/app/desktop/scripts/package-windows.ps1
@@ -37,9 +37,10 @@ if (Get-ChildItem -LiteralPath $publish -Recurse -File -Filter "*.map" -ErrorAct
 	throw "发布目录仍含 source map, 不能打包"
 }
 
-# 体积门禁按未压缩 publish 目录计数，避免不同 ZIP 实现/压缩率造成波动。
+# Windows FDD 的未压缩 publish 基线约 159 MiB（WebView/Avalonia/原生依赖占比较高）。
+# 预算留约 13% 余量，仍可拦截再次引入几十 MiB 级运行时（如 Playwright driver）。
 node (Join-Path $PSScriptRoot "check-package-size.mjs") `
-	--path $publish --label "windows publish" --max-mib 80
+	--path $publish --label "windows publish" --max-mib 180
 if ($LASTEXITCODE -ne 0) { throw "Windows 发布体积门禁失败" }
 
 $metadataOutput = Join-Path $output "metadata"


### PR DESCRIPTION
## 背景

Playwright 让 1.2.0 的发布包从约 18–22 MB 膨胀到约 59–65 MB。#14 已经移除了基础包里的 Playwright runtime，但只防某一个目录还不够；以后新的 NuGet、原生资源或重复产物仍可能让 Release 无声增长。

## 修改

- 新增 `scripts/check-package-size.mjs`
  - 递归统计未压缩 publish 目录
  - 输出当前体积与预算
  - GitHub Actions 下同时写入 Step Summary
  - 超预算返回非零退出码
  - 超预算时额外列出最大的 12 个文件，方便直接定位体积来源
- 按平台设置未压缩 publish 预算
  - **Windows FDD：180 MiB**（当前 CI 基线约 158.66 MiB，保留约 13% 余量）
  - **Linux/macOS：80 MiB**
- Windows 正式 ZIP 打包前强制检查
- Linux/macOS `publish.sh` 在生成 bundle/archive 前强制检查
- Windows 本地 `publish.bat` 同样执行检查

## 为什么 Windows 更高

Windows framework-dependent publish 即使不携带 .NET Runtime，也包含 WebView/Avalonia/原生依赖，当前 CI 的未压缩基线约为 158.66 MiB。原先统一 80 MiB 会误杀正常 Windows 发布，因此改为平台独立预算。180 MiB 仍足以拦截再次引入几十 MiB 级运行时（例如 Playwright driver）的异常膨胀。

## 口径

使用未压缩 publish 目录作为统一统计口径，避免 ZIP/tar 实现和压缩率导致跨平台波动。预算用于阻止异常增长，不是追求极限压缩。

本 PR 不修改应用功能。