### PR TITLE
test(ci): 串行化 Desktop 宿主测试降低时序抖动

### DIFF
--- a/app/desktop/Nori.Desktop.Tests/TestAssembly.cs
+++ b/app/desktop/Nori.Desktop.Tests/TestAssembly.cs
@@ -1,0 +1,5 @@
+using Xunit;
+
+// Desktop 宿主测试会共享进程级平台语义、临时配置/目录和自动化生命周期。
+// 并行运行会放大 GitHub runner 调度抖动，使短时序断言偶发超时；保持同一程序集串行。
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## 背景

CI 已出现过 `BridgeCommandsTests.浏览器安全页面暂停可取消并清理隔离profile` 在 Linux runner 上等待约 1 秒后偶发超时，而同一提交重跑即可通过。该程序集包含较多配置、临时目录、Automation task/event 与宿主生命周期测试，并行执行会额外放大 runner 调度抖动。

## 修改

- 对 `Nori.Desktop.Tests` 程序集关闭 xUnit test parallelization
- 不修改生产代码
- 不通过简单扩大所有 timeout 来掩盖问题
- `Nori.Core.Tests` 仍保持原来的并行策略

## 原因

Desktop 宿主测试的主要成本不是 CPU 密集计算，串行化带来的总时长增量有限，但可以避免多个宿主 fixture/自动化生命周期同时争抢线程池和临时资源，让短生命周期/状态切换测试更确定。

后续新增异步测试仍应优先使用明确事件/TaskCompletionSource，而不是新增固定 sleep。