### PR TITLE
refactor(bridge): 引入领域路由边界并简化 NoriBridge

### DIFF
--- a/app/desktop/Nori.Desktop.Tests/BridgeCommandRouterTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/BridgeCommandRouterTests.cs
@@ -1,0 +1,29 @@
+using Nori.Desktop.Bridge;
+
+namespace Nori.Desktop.Tests;
+
+public sealed class BridgeCommandRouterTests
+{
+	[Theory]
+	[InlineData("window_show", BridgeCommandDomain.Window)]
+	[InlineData("automation_browser_status", BridgeCommandDomain.Automation)]
+	[InlineData("llm_fetch_models", BridgeCommandDomain.Ai)]
+	[InlineData("settings_update_voice", BridgeCommandDomain.Voice)]
+	[InlineData("model_select", BridgeCommandDomain.Model)]
+	[InlineData("memory_list", BridgeCommandDomain.Memory)]
+	[InlineData("skills_toggle", BridgeCommandDomain.Skills)]
+	[InlineData("mcp_get_servers", BridgeCommandDomain.Mcp)]
+	[InlineData("tools_set_enabled", BridgeCommandDomain.Tools)]
+	[InlineData("get_diagnostic_info", BridgeCommandDomain.Diagnostics)]
+	[InlineData("chat_start", BridgeCommandDomain.Application)]
+	public void 命令按稳定领域分类(string command, BridgeCommandDomain expected)
+	{
+		Assert.Equal(expected, BridgeCommandRouter.Classify(command));
+	}
+
+	[Fact]
+	public void 未知命令保留Other兜底()
+	{
+		Assert.Equal(BridgeCommandDomain.Other, BridgeCommandRouter.Classify("future_command"));
+	}
+}

--- a/app/desktop/Nori.Desktop/Bridge/BridgeCommandRouter.cs
+++ b/app/desktop/Nori.Desktop/Bridge/BridgeCommandRouter.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+using Nori.Desktop.Automation.Browser;
+
+namespace Nori.Desktop.Bridge;
+
+/// <summary>Bridge 命令所属领域；用于把传输、策略与具体命令实现逐步解耦。</summary>
+public enum BridgeCommandDomain
+{
+	Application,
+	Window,
+	Automation,
+	Ai,
+	Voice,
+	Model,
+	Memory,
+	Skills,
+	Mcp,
+	Tools,
+	Diagnostics,
+	Other,
+}
+
+/// <summary>
+/// Bridge 的领域路由边界。
+///
+/// 当前具体业务实现仍由 BridgeCommands 承担；新路由先把 NoriBridge 的传输职责与
+/// 命令级运行组件策略隔离。后续领域 handler 可以逐个迁出，而不再修改 WebView 传输层。
+/// </summary>
+public sealed class BridgeCommandRouter(AppServices services)
+{
+	private readonly AppServices _services = services;
+
+	public async Task<object?> InvokeAsync(
+		IBridgeSource source,
+		string command,
+		JsonElement args,
+		CancellationToken cancellationToken = default)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+
+		// Browser Automation 是可选 feature pack。发布瘦身包不携带 driver 时，
+		// 在路由边界就明确 fail-closed，而不是让传输层或 Playwright 内部报路径错误。
+		if (Classify(command) == BridgeCommandDomain.Automation
+			&& command.StartsWith("automation_browser_", StringComparison.Ordinal))
+		{
+			bool available = PlaywrightRuntimeAvailability.IsAvailable();
+			if (!available && command is "automation_browser_start" or "automation_browser_start_task")
+			{
+				throw new InvalidOperationException(PlaywrightRuntimeAvailability.MissingReason);
+			}
+			if (!available && command == "automation_browser_status")
+			{
+				return new
+				{
+					state = "Stopped",
+					enabled = false,
+					available = false,
+					unavailableReason = PlaywrightRuntimeAvailability.MissingReason,
+					running = false,
+				};
+			}
+		}
+
+		return await _services.Commands.InvokeAsync(source, command, args, cancellationToken).ConfigureAwait(false);
+	}
+
+	/// <summary>纯命令名分类，不读取用户状态或参数。</summary>
+	public static BridgeCommandDomain Classify(string command)
+	{
+		if (string.IsNullOrWhiteSpace(command)) return BridgeCommandDomain.Other;
+		if (command.StartsWith("window_", StringComparison.Ordinal)) return BridgeCommandDomain.Window;
+		if (command.StartsWith("automation_", StringComparison.Ordinal)) return BridgeCommandDomain.Automation;
+		if (command.StartsWith("llm_", StringComparison.Ordinal)
+			|| command.StartsWith("ai_", StringComparison.Ordinal)
+			|| command.StartsWith("embedding_", StringComparison.Ordinal)
+			|| command.StartsWith("settings_update_ai", StringComparison.Ordinal)
+			|| command.StartsWith("settings_test_ai", StringComparison.Ordinal)
+			|| command.StartsWith("settings_update_embedding", StringComparison.Ordinal)
+			|| command.StartsWith("settings_test_embedding", StringComparison.Ordinal))
+			return BridgeCommandDomain.Ai;
+		if (command.StartsWith("tts_", StringComparison.Ordinal)
+			|| command.StartsWith("stt_", StringComparison.Ordinal)
+			|| command.StartsWith("audio_", StringComparison.Ordinal)
+			|| command.StartsWith("settings_update_voice", StringComparison.Ordinal))
+			return BridgeCommandDomain.Voice;
+		if (command.StartsWith("model_", StringComparison.Ordinal) || command.StartsWith("pet_", StringComparison.Ordinal))
+			return BridgeCommandDomain.Model;
+		if (command.StartsWith("memory_", StringComparison.Ordinal)) return BridgeCommandDomain.Memory;
+		if (command.StartsWith("skills_", StringComparison.Ordinal)) return BridgeCommandDomain.Skills;
+		if (command.StartsWith("mcp_", StringComparison.Ordinal)) return BridgeCommandDomain.Mcp;
+		if (command.StartsWith("tools_", StringComparison.Ordinal)) return BridgeCommandDomain.Tools;
+		if (command is "get_recent_logs" or "clear_recent_logs" or "get_diagnostic_info" or "export_diagnostics" or "open_log_folder" or "run_gc_collect" or "debug_crash_test")
+			return BridgeCommandDomain.Diagnostics;
+		if (command.StartsWith("chat_", StringComparison.Ordinal)
+			|| command.StartsWith("approval_", StringComparison.Ordinal)
+			|| command.StartsWith("reminder_", StringComparison.Ordinal)
+			|| command.StartsWith("settings_", StringComparison.Ordinal)
+			|| command is "ui_get_snapshot" or "exit_app" or "write_log" or "get_system_language" or "complete_first_run" or "init_ready" or "init_enter_main" or "get_init_config" or "clipboard_write_text" or "open_url")
+			return BridgeCommandDomain.Application;
+		return BridgeCommandDomain.Other;
+	}
+}

--- a/app/desktop/Nori.Desktop/Bridge/NoriBridge.cs
+++ b/app/desktop/Nori.Desktop/Bridge/NoriBridge.cs
@@ -4,7 +4,6 @@ using Avalonia.Threading;
 using Nori.Core.Logging;
 using Nori.Core.Security;
 using Nori.Core.Telemetry;
-using Nori.Desktop.Automation.Browser;
 using Nori.Desktop.Windows;
 
 namespace Nori.Desktop.Bridge;
@@ -13,19 +12,18 @@ namespace Nori.Desktop.Bridge;
 /// 前端 ↔ 宿主 桥接内核
 ///
 /// NativeWebView 只提供 JS→宿主的 invokeCSharpAction(string) 与宿主→JS 的 InvokeScript,
-/// 这里在其上实现 invoke 的请求/响应关联与 emit 的事件广播.
+/// 这里仅负责请求/响应关联、事件广播与传输层错误回写；命令策略由 BridgeCommandRouter 处理。
 /// </summary>
 public sealed class NoriBridge(AppServices services)
 {
 	private readonly AppServices _services = services;
+	private readonly BridgeCommandRouter _router = new(services);
 	private readonly CancellationTokenSource _shutdownCts =
 		CancellationTokenSource.CreateLinkedTokenSource(services.ShutdownToken);
 	private readonly ConcurrentDictionary<Task, byte> _pendingInvokes = new();
 	private int _disposed;
 
-	/// <summary>
-	/// 处理页面发来的一条消息
-	/// </summary>
+	/// <summary>处理页面发来的一条消息。</summary>
 	public void Handle(NoriWindow source, string raw)
 	{
 		if (Volatile.Read(ref _disposed) != 0) return;
@@ -47,7 +45,6 @@ public sealed class NoriBridge(AppServices services)
 				TrackInvoke(source, message);
 				break;
 			case "emit":
-				// 前端 emit 与 Tauri 一致: 全局广播给所有窗口
 				if (message.Event is { Length: > 0 } name)
 				{
 					object? payload = message.Payload.ValueKind == JsonValueKind.Undefined ? null : message.Payload.Clone();
@@ -67,8 +64,6 @@ public sealed class NoriBridge(AppServices services)
 
 	private void TrackInvoke(NoriWindow source, BridgeMessage message)
 	{
-		// WebView 消息回调在 UI 线程; 即使某个命令最终是同步实现, 也必须先切到
-		// 后台，避免 SQLite/文件读取等工作占住窗口消息泵。
 		Task task = Task.Run(() => HandleInvokeObservedAsync(source, message), CancellationToken.None);
 		_pendingInvokes.TryAdd(task, 0);
 		_ = task.ContinueWith(
@@ -101,9 +96,6 @@ public sealed class NoriBridge(AppServices services)
 		}
 	}
 
-	/// <summary>
-	/// 执行一次命令调用并把结果回给页面
-	/// </summary>
 	private async Task HandleInvokeAsync(NoriWindow source, BridgeMessage message, CancellationToken cancellationToken)
 	{
 		string cmd = message.Cmd ?? "";
@@ -111,28 +103,7 @@ public sealed class NoriBridge(AppServices services)
 		try
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			bool playwrightAvailable = PlaywrightRuntimeAvailability.IsAvailable();
-			if (!playwrightAvailable && cmd is "automation_browser_start" or "automation_browser_start_task")
-			{
-				throw new InvalidOperationException(PlaywrightRuntimeAvailability.MissingReason);
-			}
-
-			object? value;
-			if (cmd == "automation_browser_status" && !playwrightAvailable)
-			{
-				value = new
-				{
-					state = "Stopped",
-					enabled = false,
-					available = false,
-					unavailableReason = PlaywrightRuntimeAvailability.MissingReason,
-					running = false,
-				};
-			}
-			else
-			{
-				value = await _services.Commands.InvokeAsync(source, cmd, message.Args, cancellationToken);
-			}
+			object? value = await _router.InvokeAsync(source, cmd, message.Args, cancellationToken).ConfigureAwait(false);
 			cancellationToken.ThrowIfCancellationRequested();
 			source.PostResult(message.Id, value, null);
 		}
@@ -143,7 +114,6 @@ public sealed class NoriBridge(AppServices services)
 		catch (Exception exception)
 		{
 			_services.Telemetry.CaptureException(exception, $"bridge.{cmd}");
-			// 命令错误一律以可读字符串回给前端展示, 与 Rust 版 Result<T, String> 等价
 			_services.Logger.Write(LogSource.Backend, "error", $"命令执行失败: {cmd}: {SensitiveDataRedactor.ExceptionSummary(exception)}");
 			source.PostResult(message.Id, null, SensitiveDataRedactor.Redact(exception.Message));
 		}


### PR DESCRIPTION
## 目标

`BridgeCommands.cs` 已经承担过多领域职责。直接一次性搬动 97KB 业务实现风险太高，因此本 PR 先建立可逐步迁移的**领域路由边界**，保持命令协议和现有权限实现不变。

## 修改

- 新增 `BridgeCommandRouter`
  - 将命令按 Application / Window / Automation / AI / Voice / Model / Memory / Skills / MCP / Tools / Diagnostics 分类
  - 未识别命令保留 `Other` 兜底
- Playwright 可选 runtime 的命令级策略从 `NoriBridge` 移入 Router
- `NoriBridge` 回归纯传输层：
  - JSON 消息解析
  - invoke 生命周期与取消
  - emit 广播
  - telemetry / 错误回写
- 具体业务命令仍委托现有 `BridgeCommands.InvokeAsync`，所以本 PR 不改变权限白名单、参数校验和前端命令名
- 新增领域分类测试

## 后续拆分方式

有了 Router 后，后续可以按领域逐个把实现迁移为 `WindowCommands` / `AutomationCommands` / `AiCommands` 等 handler，而不再修改 WebView 传输层。这样每一步都能保持小 diff 和原有 BridgeCommands 测试基线。

这是结构重构，不新增用户功能。