### PR TITLE
refactor(automation): 建立 Browser Desktop Approval 领域入口

### DIFF
--- a/app/desktop/Nori.Desktop/Automation/AutomationDomainFacades.cs
+++ b/app/desktop/Nori.Desktop/Automation/AutomationDomainFacades.cs
@@ -1,0 +1,66 @@
+using Nori.Core.Automation;
+using Nori.Desktop.Automation.Desktop;
+
+namespace Nori.Desktop.Automation;
+
+/// <summary>
+/// Browser Automation 的窄接口。调用方不需要持有整个 AutomationRuntime。
+/// </summary>
+public sealed class BrowserAutomationHost(AutomationRuntime runtime)
+{
+	private readonly AutomationRuntime _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+
+	public AutomationBrowserStatusSnapshot GetStatus() => _runtime.GetBrowserStatus();
+
+	public Task<AutomationBrowserStatusSnapshot> StartAsync(CancellationToken cancellationToken = default) =>
+		_runtime.StartBrowserAsync(cancellationToken);
+
+	public Task<AutomationBrowserTaskStartSnapshot> StartTaskAsync(
+		BrowserAutomationTaskPlan plan,
+		CancellationToken cancellationToken = default) =>
+		_runtime.StartBrowserTaskAsync(plan, cancellationToken);
+
+	public BrowserAutomationTaskResult? GetTaskResult(Guid taskId) => _runtime.GetBrowserTaskResult(taskId);
+
+	public bool StopTask(Guid taskId) => _runtime.StopBrowserTask(taskId);
+
+	public Task<AutomationBrowserStatusSnapshot> StopAsync(CancellationToken cancellationToken = default) =>
+		_runtime.StopBrowserAsync(cancellationToken);
+}
+
+/// <summary>
+/// Desktop Vision Automation 的窄接口。窗口枚举和桌面任务不再要求调用方依赖浏览器生命周期方法。
+/// </summary>
+public sealed class DesktopAutomationHost(AutomationRuntime runtime)
+{
+	private readonly AutomationRuntime _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+
+	public AutomationCapabilitiesSnapshot GetCapabilities() => _runtime.GetCapabilities();
+
+	public AutomationVisionProbeSnapshot ProbeVision() => _runtime.ProbeVision();
+
+	public IReadOnlyList<AutomationDesktopWindowSnapshot> ListWindows() => _runtime.ListDesktopWindows();
+
+	public AutomationDesktopTaskStartSnapshot StartTask(string task, string targetToken) =>
+		_runtime.StartDesktopTask(task, targetToken);
+
+	public bool StopTask(Guid taskId) => _runtime.StopDesktopTask(taskId);
+}
+
+/// <summary>
+/// 自动化审批与审计结果登记的窄接口。
+/// </summary>
+public sealed class AutomationApprovalHost(AutomationRuntime runtime)
+{
+	private readonly AutomationRuntime _runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+
+	public void Set(AutomationApprovalRequest request) => _runtime.SetAutomationApproval(request);
+
+	public void Clear(Guid requestId) => _runtime.ClearAutomationApproval(requestId);
+
+	public void RecordOutcome(AutomationApprovalRequest request, AutomationApprovalOutcome outcome) =>
+		_runtime.RecordApprovalOutcome(request, outcome);
+
+	public void RecordCancellation(AutomationApprovalRequest request) =>
+		_runtime.RecordApprovalCancellation(request);
+}

--- a/app/desktop/Nori.Desktop/Bridge/AppServicesAutomationExtensions.cs
+++ b/app/desktop/Nori.Desktop/Bridge/AppServicesAutomationExtensions.cs
@@ -1,0 +1,22 @@
+using Nori.Desktop.Automation;
+
+namespace Nori.Desktop.Bridge;
+
+/// <summary>从应用服务容器取得自动化领域窄接口，避免新调用方继续依赖整个 AutomationRuntime。</summary>
+public static class AppServicesAutomationExtensions
+{
+	public static BrowserAutomationHost BrowserAutomation(this AppServices services) =>
+		new(RequireRuntime(services));
+
+	public static DesktopAutomationHost DesktopAutomation(this AppServices services) =>
+		new(RequireRuntime(services));
+
+	public static AutomationApprovalHost AutomationApprovals(this AppServices services) =>
+		new(RequireRuntime(services));
+
+	private static AutomationRuntime RequireRuntime(AppServices services)
+	{
+		ArgumentNullException.ThrowIfNull(services);
+		return services.Automation ?? throw new InvalidOperationException("自动化运行时未装配");
+	}
+}


### PR DESCRIPTION
## 目标

`AutomationRuntime` 当前同时暴露 Browser lifecycle、Desktop Vision、审批/审计、任务投影等职责。一次性搬动状态机风险很高，本 PR 先建立领域化调用边界，让新的调用方不再依赖整个大对象。

## 修改

新增三个窄 facade：

- `BrowserAutomationHost`
  - status / start / start task / result / stop
- `DesktopAutomationHost`
  - capabilities / vision probe / window list / desktop task
- `AutomationApprovalHost`
  - approval set / clear / outcome / cancellation

同时新增 `AppServicesAutomationExtensions`，调用方可以从现有 AppServices 获取上述领域入口，而不再直接持有 `AutomationRuntime`。

## 风险控制

- 底层状态、锁、task manager、audit 和生命周期仍由现有 `AutomationRuntime` 实现
- 不复制状态，也不引入第二套 runner
- 不改变 Bridge 命令、配置键或用户可见行为
- 后续迁移可以逐领域把实现从 Runtime 搬进对应 host，每次保持小 diff

这是一张结构边界 PR，不新增功能。