### PR TITLE
ci: 串行执行 .NET 测试项目以避免 Desktop 时序抖动

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,9 @@ jobs:
       - name: 后端门 · 构建
         run: dotnet build Nori.slnx --configuration Release
 
+      # Desktop 宿主测试包含短生命周期异步任务；限制 MSBuild 并行度，避免多个测试项目同时争用 runner 调度。
       - name: 后端门 · 单元测试
-        run: dotnet test Nori.slnx --configuration Release --no-build --no-restore
+        run: dotnet test Nori.slnx --configuration Release --no-build --no-restore -m:1
 
       # -----------------------------------------------------------------------
       # Linux / macOS


### PR DESCRIPTION
## 问题

Linux GitHub Actions 中 `Nori.Core.Tests.dll` 与 `Nori.Desktop.Tests.dll` 会同时启动。`BridgeCommandsTests.浏览器结构化任务执行受限计划且结果不进入快照` 依赖一个约 1 秒的异步状态等待窗口，在 runner 调度竞争时会偶发超时并触发 `Assert.True()`。

此前 #17 已禁用 `Nori.Desktop.Tests` 程序集内部的 xUnit 并行，但 solution 级测试项目仍可并行执行。

## 修复

将 CI 测试命令改为：

```bash
dotnet test Nori.slnx --configuration Release --no-build --no-restore -m:1
```

`-m:1` 将 MSBuild 的并行 worker 限制为 1，避免 Core.Tests 与 Desktop.Tests 同时争用 GitHub runner 调度，同时不改变测试或生产运行时语义。

## 范围

- 仅修改 `.github/workflows/build.yml`
- 不修改生产代码
- 不放宽断言或跳过测试
