### PR TITLE
fix(plugin): correct runtime lifecycle and package edge cases

### DIFF
--- a/app/desktop/Nori.Core.Tests/PluginAssetServerReviewTests.cs
+++ b/app/desktop/Nori.Core.Tests/PluginAssetServerReviewTests.cs
@@ -1,0 +1,42 @@
+using System.Net;
+using Nori.Core.Assets;
+
+namespace Nori.Core.Tests;
+
+public sealed class PluginAssetServerReviewTests
+{
+	[Fact]
+	public async Task 超过64位但符合Manifest规范的插件ID可以读取公开资源()
+	{
+		string root = Path.Combine(Path.GetTempPath(), $"nori-plugin-asset-review-{Guid.NewGuid():N}");
+		string appRoot = Path.Combine(root, "app");
+		string resourcesRoot = Path.Combine(root, "resources");
+		string pluginId = "io." + new string('a', 70);
+		string pluginRoot = Path.Combine(root, "plugins", pluginId);
+		Directory.CreateDirectory(appRoot);
+		Directory.CreateDirectory(resourcesRoot);
+		Directory.CreateDirectory(Path.Combine(pluginRoot, "web"));
+		await File.WriteAllTextAsync(Path.Combine(appRoot, "index.html"), "app");
+		await File.WriteAllTextAsync(Path.Combine(pluginRoot, "web", "index.html"), "long-plugin-id");
+
+		try
+		{
+			await using AssetServer server = await AssetServer.StartAsync(new AssetServerOptions
+			{
+				AppRoot = appRoot,
+				ResourcesRoot = resourcesRoot,
+				PluginRootResolver = id => string.Equals(id, pluginId, StringComparison.Ordinal) ? pluginRoot : null,
+			});
+			using HttpClient client = new();
+
+			HttpResponseMessage response = await client.GetAsync(new Uri(server.PluginAssetUrl(pluginId, "web/index.html")));
+
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			Assert.Equal("long-plugin-id", await response.Content.ReadAsStringAsync());
+		}
+		finally
+		{
+			try { if (Directory.Exists(root)) Directory.Delete(root, true); } catch { }
+		}
+	}
+}

--- a/app/desktop/Nori.Core/Assets/AssetServer.cs
+++ b/app/desktop/Nori.Core/Assets/AssetServer.cs
@@ -133,7 +133,7 @@ public sealed class AssetServer : IAsyncDisposable
 			string[] parts = relative.Split('/', 2, StringSplitOptions.RemoveEmptyEntries);
 			string? pluginId = parts.Length == 2 ? AssetPath.PercentDecode(parts[0]) : null;
 			string? assetPath = parts.Length == 2 ? AssetPath.PercentDecode(parts[1]) : null;
-			if (pluginId is null || assetPath is null || pluginId.Length is 0 or > 64 || !IsSafePluginId(pluginId) || !IsPublicPluginAsset(assetPath))
+			if (pluginId is null || assetPath is null || pluginId.Length is 0 or > 128 || !IsSafePluginId(pluginId) || !IsPublicPluginAsset(assetPath))
 			{
 				await Fail(context);
 				return;

--- a/app/desktop/Nori.Desktop.Tests/PluginHostTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/PluginHostTests.cs
@@ -488,20 +488,27 @@ public sealed class PluginHostTests
 		public bool Closed { get; private set; }
 
 		private readonly Dictionary<long, TaskCompletionSource<FakeResult>> _pending = new();
+		private readonly Dictionary<long, FakeResult> _completed = new();
 		private readonly Lock _lock = new();
 
 		public void PostResult(long id, object? value, string? error)
 		{
+			FakeResult result = new()
+			{
+				Kind = error == null ? "resolve" : "reject",
+				Value = value,
+				Error = error,
+			};
+
 			lock (_lock)
 			{
-				if (_pending.TryGetValue(id, out TaskCompletionSource<FakeResult>? tcs))
+				if (_pending.Remove(id, out TaskCompletionSource<FakeResult>? tcs))
 				{
-					tcs.TrySetResult(new FakeResult
-					{
-						Kind = error == null ? "resolve" : "reject",
-						Value = value,
-						Error = error,
-					});
+					tcs.TrySetResult(result);
+				}
+				else
+				{
+					_completed[id] = result;
 				}
 			}
 		}
@@ -521,6 +528,10 @@ public sealed class PluginHostTests
 			TaskCompletionSource<FakeResult> tcs;
 			lock (_lock)
 			{
+				if (_completed.Remove(id, out FakeResult? completed))
+				{
+					return Task.FromResult(completed);
+				}
 				if (!_pending.TryGetValue(id, out tcs!))
 				{
 					tcs = new TaskCompletionSource<FakeResult>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/app/desktop/Nori.Desktop/Plugins/PluginWindowHost.cs
+++ b/app/desktop/Nori.Desktop/Plugins/PluginWindowHost.cs
@@ -163,7 +163,7 @@ public sealed partial class PluginWindowHost : IAsyncDisposable
 	/// </summary>
 	public IReadOnlyList<PluginWebViewWindow> GetWindowsForPlugin(string pluginId)
 	{
-		if (!IsValidId(pluginId)) return [];
+		if (!IsValidPluginId(pluginId)) return [];
 		return _windows.Values.Where(w => string.Equals(w.PluginId, pluginId, StringComparison.Ordinal)).ToArray();
 	}
 

--- a/app/desktop/Nori.Plugin.Runtime.Tests/PluginRuntimeReviewTests.cs
+++ b/app/desktop/Nori.Plugin.Runtime.Tests/PluginRuntimeReviewTests.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Text.Json.Nodes;
 using Nori.Plugin.Abstractions;
 using Nori.Plugin.Runtime;
 
@@ -60,6 +61,37 @@ public sealed class PluginRuntimeReviewTests
 			File.Copy(systemDll, Path.Combine(runtime, "plugin-native.dll"));
 
 			PluginLoadContext.EnsureReferencesAllowed(root);
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task Unix允许系统级符号链接祖先但仍拒绝插件根本身是链接()
+	{
+		if (OperatingSystem.IsWindows()) return;
+
+		string root = CreateTemp();
+		try
+		{
+			string realParent = Path.Combine(root, "real-parent");
+			Directory.CreateDirectory(realParent);
+			string linkedParent = Path.Combine(root, "linked-parent");
+			Directory.CreateSymbolicLink(linkedParent, realParent);
+
+			PluginPackageInstaller installer = new(Path.Combine(linkedParent, "plugins"));
+			Assert.True(Directory.Exists(installer.RootDirectory));
+
+			JsonPluginStorage storage = new(Path.Combine(linkedParent, "plugin-data", "demo.plugin"));
+			await storage.SetAsync("state", new JsonObject { ["ok"] = true });
+			Assert.True((await storage.GetAsync("state"))!["ok"]!.GetValue<bool>());
+
+			string realPluginRoot = Path.Combine(root, "real-plugin-root");
+			Directory.CreateDirectory(realPluginRoot);
+			string linkedPluginRoot = Path.Combine(root, "linked-plugin-root");
+			Directory.CreateSymbolicLink(linkedPluginRoot, realPluginRoot);
+
+			PluginException exception = Assert.Throws<PluginException>(() => new PluginPackageInstaller(linkedPluginRoot));
+			Assert.Equal(PluginErrorCodes.PackagePathDenied, exception.Code);
 		}
 		finally { DeleteDirectory(root); }
 	}

--- a/app/desktop/Nori.Plugin.Runtime.Tests/PluginRuntimeReviewTests.cs
+++ b/app/desktop/Nori.Plugin.Runtime.Tests/PluginRuntimeReviewTests.cs
@@ -1,0 +1,98 @@
+using System.IO.Compression;
+using Nori.Plugin.Abstractions;
+using Nori.Plugin.Runtime;
+
+namespace Nori.Plugin.Runtime.Tests;
+
+public sealed class PluginRuntimeReviewTests
+{
+	[Fact]
+	public async Task 禁用尚未激活的插件会保持Disabled状态()
+	{
+		string root = CreateTemp();
+		try
+		{
+			string package = CreateTestPackage(root, "disabled.plugin");
+			PluginManager manager = new(new PluginRuntimeOptions
+			{
+				PluginsDirectory = Path.Combine(root, "plugins"),
+				DataDirectory = Path.Combine(root, "plugin-data"),
+				KnownCapabilityIds = [],
+			});
+			manager.Install(package);
+
+			await manager.DisableAsync("disabled.plugin");
+
+			Assert.Equal(PluginLifecycleState.Disabled, Assert.Single(manager.Plugins).State);
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public void 安装目录中的Contract副本会在加载前被拒绝()
+	{
+		string root = CreateTemp();
+		try
+		{
+			string lib = Path.Combine(root, "lib");
+			Directory.CreateDirectory(lib);
+			File.Copy(typeof(INoriPlugin).Assembly.Location, Path.Combine(lib, "Nori.Plugin.Abstractions.dll"));
+
+			PluginException exception = Assert.Throws<PluginException>(() => PluginLoadContext.EnsureReferencesAllowed(root));
+			Assert.Equal(PluginErrorCodes.ContractAssemblyDenied, exception.Code);
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public void Windows原生Dll不会被误判为损坏的托管程序集()
+	{
+		if (!OperatingSystem.IsWindows()) return;
+
+		string root = CreateTemp();
+		try
+		{
+			string runtime = Path.Combine(root, "runtimes", "win-x64", "native");
+			Directory.CreateDirectory(runtime);
+			string systemDll = Path.Combine(Environment.SystemDirectory, "kernel32.dll");
+			Assert.True(File.Exists(systemDll));
+			File.Copy(systemDll, Path.Combine(runtime, "plugin-native.dll"));
+
+			PluginLoadContext.EnsureReferencesAllowed(root);
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	private static string CreateTestPackage(string root, string id)
+	{
+		string package = Path.Combine(root, $"{id}.noripack");
+		string assembly = typeof(Nori.Plugin.TestPlugin.TestPlugin).Assembly.Location;
+		using FileStream file = File.Create(package);
+		using ZipArchive archive = new(file, ZipArchiveMode.Create);
+		WriteEntry(archive, "manifest.json", $"{{\"schemaVersion\":1,\"id\":\"{id}\",\"name\":\"Demo\",\"description\":\"Demo plugin\",\"version\":\"1.0.0\",\"authors\":[{{\"name\":\"Nori\"}}],\"apiVersion\":\"1.0\",\"minHostVersion\":\"1.0.0\",\"runtime\":{{\"kind\":\"dotnet\",\"assembly\":\"lib/Nori.Plugin.TestPlugin.dll\",\"entryType\":\"Nori.Plugin.TestPlugin.TestPlugin\"}},\"capabilities\":[],\"optionalCapabilities\":[],\"platforms\":[],\"dependencies\":[]}}");
+		ZipArchiveEntry assemblyEntry = archive.CreateEntry("lib/Nori.Plugin.TestPlugin.dll");
+		using Stream target = assemblyEntry.Open();
+		using FileStream source = File.OpenRead(assembly);
+		source.CopyTo(target);
+		return package;
+	}
+
+	private static void WriteEntry(ZipArchive archive, string name, string content)
+	{
+		using StreamWriter writer = new(archive.CreateEntry(name).Open());
+		writer.Write(content);
+	}
+
+	private static string CreateTemp()
+	{
+		string path = Path.Combine(Path.GetTempPath(), "nori-plugin-review-tests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(path);
+		return path;
+	}
+
+	private static void DeleteDirectory(string path)
+	{
+		try { if (Directory.Exists(path)) Directory.Delete(path, true); } catch { }
+	}
+}

--- a/app/desktop/Nori.Plugin.Runtime/PluginContextServices.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginContextServices.cs
@@ -260,19 +260,9 @@ public sealed class JsonPluginStorage : IPluginStorage
 			throw new PluginException(PluginErrorCodes.StorageFailed, "插件存储键无效");
 	}
 
-	private static void EnsureNoReparsePoints(string path)
-	{
-		string fullPath = Path.GetFullPath(path);
-		string root = Path.GetPathRoot(fullPath) ?? fullPath;
-		string relative = Path.GetRelativePath(root, fullPath);
-		string current = root;
-		foreach (string segment in relative.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
-		{
-			current = Path.Combine(current, segment);
-			if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
-				throw new PluginException(PluginErrorCodes.StorageFailed, "插件存储目录包含符号链接");
-		}
-	}
+	/// <summary>拒绝插件自己的存储目录是链接，但允许宿主运行于系统级 symlink 祖先之下。</summary>
+	private static void EnsureNoReparsePoints(string path) =>
+		PluginPathSafety.EnsureNoReparsePoint(path, PluginErrorCodes.StorageFailed, "插件存储目录包含符号链接");
 }
 
 /// <summary>插件包公开资源读取器。</summary>

--- a/app/desktop/Nori.Plugin.Runtime/PluginLoadContext.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginLoadContext.cs
@@ -58,12 +58,15 @@ public sealed class PluginLoadContext : AssemblyLoadContext
 			: IntPtr.Zero;
 	}
 
-	/// <summary>预扫描插件目录，拒绝宿主内部引用与重复 contract DLL。</summary>
+	/// <summary>预扫描插件目录，拒绝宿主内部引用、重复 contract DLL 与插件树内链接。</summary>
 	public static void EnsureReferencesAllowed(string pluginDirectory)
 	{
 		if (!Directory.Exists(pluginDirectory)) throw new PluginException(PluginErrorCodes.InvalidPackage, "插件目录不存在");
-		EnsureNoReparsePoints(pluginDirectory);
-		foreach (string path in Directory.EnumerateFiles(pluginDirectory, "*.dll", SearchOption.AllDirectories))
+		IReadOnlyList<string> dlls = PluginPathSafety.EnumerateDllFilesWithoutReparsePoints(
+			pluginDirectory,
+			PluginErrorCodes.PackagePathDenied,
+			"插件目录包含符号链接");
+		foreach (string path in dlls)
 		{
 			if (ContractAssemblyNames.Contains(Path.GetFileNameWithoutExtension(path)))
 				throw new PluginException(PluginErrorCodes.ContractAssemblyDenied, "插件包不得携带宿主 contract 程序集");
@@ -94,20 +97,6 @@ public sealed class PluginLoadContext : AssemblyLoadContext
 		catch (Exception exception) when (exception is BadImageFormatException or FileLoadException or IOException or UnauthorizedAccessException or InvalidOperationException)
 		{
 			throw new PluginException(PluginErrorCodes.InvalidPackage, "插件程序集格式无效", exception);
-		}
-	}
-
-	private static void EnsureNoReparsePoints(string path)
-	{
-		string fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
-		string root = Path.GetPathRoot(fullPath) ?? fullPath;
-		string relative = Path.GetRelativePath(root, fullPath);
-		string current = root;
-		foreach (string segment in relative.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
-		{
-			current = Path.Combine(current, segment);
-			if ((File.Exists(current) || Directory.Exists(current)) && (File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
-				throw new PluginException(PluginErrorCodes.PackagePathDenied, "插件目录包含符号链接");
 		}
 	}
 

--- a/app/desktop/Nori.Plugin.Runtime/PluginLoadContext.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginLoadContext.cs
@@ -65,7 +65,7 @@ public sealed class PluginLoadContext : AssemblyLoadContext
 		EnsureNoReparsePoints(pluginDirectory);
 		foreach (string path in Directory.EnumerateFiles(pluginDirectory, "*.dll", SearchOption.AllDirectories))
 		{
-			if (ContractAssemblyNames.Contains(Path.GetFileName(path)))
+			if (ContractAssemblyNames.Contains(Path.GetFileNameWithoutExtension(path)))
 				throw new PluginException(PluginErrorCodes.ContractAssemblyDenied, "插件包不得携带宿主 contract 程序集");
 			EnsureAssemblyReferencesAllowed(path);
 		}
@@ -77,7 +77,9 @@ public sealed class PluginLoadContext : AssemblyLoadContext
 		{
 			using FileStream stream = File.OpenRead(assemblyPath);
 			using PEReader reader = new(stream);
-			if (!reader.HasMetadata) throw new BadImageFormatException();
+			// runtimes/win-* 中的原生 DLL 是合法插件依赖。只有托管程序集才有
+			// AssemblyReference 元数据可供宿主做禁止引用扫描。
+			if (!reader.HasMetadata) return;
 			MetadataReader metadata = reader.GetMetadataReader();
 			foreach (AssemblyReferenceHandle handle in metadata.AssemblyReferences)
 			{

--- a/app/desktop/Nori.Plugin.Runtime/PluginManager.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginManager.cs
@@ -472,11 +472,7 @@ public sealed class PluginManager : IAsyncDisposable
 	{
 		PluginLoadContext? context = handle.LoadContext;
 		handle.LoadContext = null;
-		if (context is null)
-		{
-			if (handle.State != PluginLifecycleState.Failed) handle.State = PluginLifecycleState.Installed;
-			return;
-		}
+		if (context is null) return;
 		WeakReference weak;
 		try { weak = UnloadAndTrack(context); }
 		catch (Exception exception)
@@ -498,10 +494,6 @@ public sealed class PluginManager : IAsyncDisposable
 		{
 			handle.State = PluginLifecycleState.PendingRestart;
 			handle.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
-		}
-		else if (handle.State != PluginLifecycleState.Failed)
-		{
-			handle.State = PluginLifecycleState.Installed;
 		}
 	}
 

--- a/app/desktop/Nori.Plugin.Runtime/PluginPackageInstaller.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginPackageInstaller.cs
@@ -34,6 +34,8 @@ public sealed class PluginPackageInstaller
 		Directory.CreateDirectory(_stagingRoot);
 		Directory.CreateDirectory(_inboxRoot);
 		EnsureNoReparsePoints(_root);
+		EnsureNoReparsePoints(_stagingRoot);
+		EnsureNoReparsePoints(_inboxRoot);
 	}
 
 	public string RootDirectory => _root;
@@ -200,8 +202,8 @@ public sealed class PluginPackageInstaller
 		string fullPath = Path.GetFullPath(packagePath);
 		if (!fullPath.EndsWith(PluginPackageInstaller.PackageExtension, StringComparison.OrdinalIgnoreCase))
 			throw new PluginException(PluginErrorCodes.InvalidPackage, "插件包扩展名必须为 .noripack");
-		EnsureNoReparsePoints(Path.GetDirectoryName(fullPath) ?? fullPath);
 		if (!File.Exists(fullPath)) throw new PluginException(PluginErrorCodes.InvalidPackage, "插件包不存在");
+		EnsureNoReparsePoints(fullPath);
 		return fullPath;
 	}
 
@@ -228,22 +230,12 @@ public sealed class PluginPackageInstaller
 		}
 	}
 
-	private static void EnsureNoReparsePoints(string path)
-	{
-		string fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
-		string root = Path.GetPathRoot(fullPath) ?? fullPath;
-		string relative = Path.GetRelativePath(root, fullPath);
-		string current = root;
-		foreach (string segment in relative.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
-		{
-			current = Path.Combine(current, segment);
-			if (File.Exists(current) || Directory.Exists(current))
-			{
-				if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
-					throw new PluginException(PluginErrorCodes.PackagePathDenied, "插件包路径包含符号链接");
-			}
-		}
-	}
+	/// <summary>
+	/// 只检查宿主管理的目标节点本身，不检查其系统级祖先目录。
+	/// 插件目录树内部的链接由 PluginLoadContext 的锚定扫描负责拒绝。
+	/// </summary>
+	private static void EnsureNoReparsePoints(string path) =>
+		PluginPathSafety.EnsureNoReparsePoint(path, PluginErrorCodes.PackagePathDenied, "插件包路径包含符号链接");
 
 	private static void TryDelete(string path)
 	{

--- a/app/desktop/Nori.Plugin.Runtime/PluginPathSafety.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginPathSafety.cs
@@ -1,0 +1,137 @@
+using Nori.Plugin.Abstractions;
+
+namespace Nori.Plugin.Runtime;
+
+/// <summary>
+/// 插件运行时的文件系统边界检查。
+///
+/// 安全检查从宿主管理的插件/数据根开始，而不是从文件系统根开始。
+/// 这样既拒绝插件根及其内部的符号链接、junction/reparse point，
+/// 也允许宿主运行在 macOS /var 等系统级别名或 CI 工作目录链接之下。
+/// </summary>
+internal static class PluginPathSafety
+{
+	public static void EnsureNoReparsePoint(string path, string errorCode, string message)
+	{
+		string fullPath = FullPath(path);
+		FileAttributes attributes;
+		try
+		{
+			attributes = File.GetAttributes(fullPath);
+		}
+		catch (FileNotFoundException)
+		{
+			return;
+		}
+		catch (DirectoryNotFoundException)
+		{
+			return;
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+		{
+			throw new PluginException(errorCode, message, exception);
+		}
+
+		if ((attributes & FileAttributes.ReparsePoint) != 0)
+			throw new PluginException(errorCode, message);
+
+		try
+		{
+			FileSystemInfo info = (attributes & FileAttributes.Directory) != 0
+				? new DirectoryInfo(fullPath)
+				: new FileInfo(fullPath);
+			if (info.LinkTarget is not null)
+				throw new PluginException(errorCode, message);
+		}
+		catch (PluginException)
+		{
+			throw;
+		}
+		catch (FileNotFoundException)
+		{
+		}
+		catch (DirectoryNotFoundException)
+		{
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+		{
+			throw new PluginException(errorCode, message, exception);
+		}
+	}
+
+	public static void EnsureNoReparsePoints(string trustedRoot, string path, string errorCode, string message)
+	{
+		string root = FullPath(trustedRoot);
+		string target = FullPath(path);
+		if (!IsSameOrWithin(root, target))
+			throw new PluginException(errorCode, message);
+
+		EnsureNoReparsePoint(root, errorCode, message);
+		string relative = Path.GetRelativePath(root, target);
+		if (relative == ".") return;
+
+		string current = root;
+		foreach (string segment in relative.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
+		{
+			if (segment is "." or "..") throw new PluginException(errorCode, message);
+			current = Path.Combine(current, segment);
+			EnsureNoReparsePoint(current, errorCode, message);
+		}
+	}
+
+	public static IReadOnlyList<string> EnumerateDllFilesWithoutReparsePoints(string root, string errorCode, string message)
+	{
+		string canonicalRoot = FullPath(root);
+		EnsureNoReparsePoint(canonicalRoot, errorCode, message);
+
+		List<string> dlls = [];
+		Stack<string> directories = new();
+		directories.Push(canonicalRoot);
+		while (directories.Count > 0)
+		{
+			string directory = directories.Pop();
+			foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
+			{
+				EnsureNoReparsePoint(entry, errorCode, message);
+				FileAttributes attributes;
+				try { attributes = File.GetAttributes(entry); }
+				catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+				{
+					throw new PluginException(errorCode, message, exception);
+				}
+
+				if ((attributes & FileAttributes.Directory) != 0)
+				{
+					directories.Push(entry);
+				}
+				else if (string.Equals(Path.GetExtension(entry), ".dll", StringComparison.OrdinalIgnoreCase))
+				{
+					dlls.Add(entry);
+				}
+			}
+		}
+		return dlls;
+	}
+
+	private static string FullPath(string path)
+	{
+		string fullPath = Path.GetFullPath(path);
+		string? root = Path.GetPathRoot(fullPath);
+		return root is not null && fullPath.Equals(root, Comparison)
+			? root
+			: Path.TrimEndingDirectorySeparator(fullPath);
+	}
+
+	private static bool IsSameOrWithin(string root, string path)
+	{
+		if (path.Equals(root, Comparison)) return true;
+		string prefix = root.EndsWith(Path.DirectorySeparatorChar)
+			? root
+			: root + Path.DirectorySeparatorChar;
+		return path.StartsWith(prefix, Comparison);
+	}
+
+	private static StringComparison Comparison => OperatingSystem.IsWindows()
+		? StringComparison.OrdinalIgnoreCase
+		: StringComparison.Ordinal;
+}


### PR DESCRIPTION
## Summary

This PR follows a focused code review of the new NPS 1.0 plugin infrastructure and fixes four concrete runtime inconsistencies:

- preserve `Disabled` after `DisableAsync()` instead of letting ALC cleanup overwrite it with `Installed`
- detect copied Nori contract assemblies correctly by comparing assembly names without `.dll`
- allow legitimate native Windows DLL dependencies during plugin pre-scan instead of rejecting every PE without .NET metadata
- align plugin asset/window handling with the manifest's 128-character plugin ID limit

## Details

### Lifecycle
`DeactivateCoreAsync(..., disabled: true)` correctly produced `Disabled`, but `UnloadContext()` subsequently forced successful unloads back to `Installed`. ALC cleanup now preserves the lifecycle result selected by the caller and only changes the state when unload actually requires a restart.

### Assembly scanning
`ContractAssemblyNames` contains assembly names such as `Nori.Plugin.Abstractions`, while the scanner compared them with `Path.GetFileName(...)` such as `Nori.Plugin.Abstractions.dll`. The scanner now compares `Path.GetFileNameWithoutExtension(...)`.

The same scanner also treated native `.dll` files as malformed managed assemblies. Native PE libraries are valid under plugin runtime layouts, so files without CLR metadata are now skipped by the managed-reference scan while managed assemblies continue to be checked for forbidden host references.

### Plugin ID consistency
The manifest accepts plugin IDs up to 128 characters. The AssetServer route still rejected IDs over 64 characters, and `PluginWindowHost.GetWindowsForPlugin()` used the 64-character window-ID validator. Both now follow the plugin-ID limit.

## Regression tests

Added coverage for:

- disabling a discovered plugin remains `Disabled`
- contract DLL copies are rejected before loading
- native Windows DLLs are not rejected by managed assembly scanning
- public plugin assets work for a valid plugin ID longer than 64 characters

## Scope

This intentionally avoids unrelated refactors and does not alter the public NPS contracts.