### PR TITLE
feat(plugin): add NPS 1.0 plugin management vertical slice

### DIFF
--- a/app/desktop/Nori.Desktop.Tests/PluginManagementBridgeTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/PluginManagementBridgeTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Avalonia.Controls;
 using Nori.Desktop.Bridge;
 using Nori.Desktop.Windows;
+using Nori.Plugin.Abstractions;
 using Nori.Plugin.Runtime;
 
 namespace Nori.Desktop.Tests;

--- a/app/desktop/Nori.Desktop.Tests/PluginManagementBridgeTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/PluginManagementBridgeTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using Avalonia.Controls;
+using Nori.Desktop.Bridge;
+using Nori.Desktop.Windows;
+using Nori.Plugin.Runtime;
+
+namespace Nori.Desktop.Tests;
+
+public sealed class PluginManagementBridgeTests : IAsyncDisposable
+{
+	private readonly string _root = Path.Combine(Path.GetTempPath(), "nori-plugin-bridge-tests", Guid.NewGuid().ToString("N"));
+	private readonly HttpClient _http = new();
+
+	private sealed class FakeSource(string label, bool visible = true) : IBridgeSource
+	{
+		public string Label => label;
+		public bool IsVisible => visible;
+		public Window? Self => null;
+		public void PostEvent(string name, object? payload) { }
+		public void PostResult(long id, object? value, string? error) { }
+	}
+
+	private sealed class FakePicker(string? result) : IPluginPackagePicker
+	{
+		public int Calls { get; private set; }
+		public Task<string?> PickAsync(IBridgeSource source, CancellationToken cancellationToken = default)
+		{
+			Calls++;
+			return Task.FromResult(result);
+		}
+	}
+
+	[Fact]
+	public async Task 五个管理命令都拒绝非main和不可见main()
+	{
+		PluginManager manager = CreateManager();
+		AppServices services = Services(manager, new FakePicker(null));
+		PluginManagementBridgeCommands commands = new(services);
+		string[] names = ["plugin_list", "plugin_install_local", "plugin_enable", "plugin_disable", "plugin_uninstall"];
+		foreach (string name in names)
+		{
+			await Assert.ThrowsAsync<UnauthorizedAccessException>(() => commands.InvokeAsync(new FakeSource(WindowLabels.Init), name, Args(new {id = "io.nori.test"})));
+			await Assert.ThrowsAsync<UnauthorizedAccessException>(() => commands.InvokeAsync(new FakeSource(WindowLabels.Main, false), name, Args(new {id = "io.nori.test"})));
+		}
+		await manager.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task plugin_list返回稳定DTO且不泄露安装路径或异常对象()
+	{
+		CreateInstalledLayout("io.nori.dto", "1.2.3");
+		PluginManager manager = CreateManager();
+		AppServices services = Services(manager, new FakePicker(null));
+		PluginManagementBridgeCommands commands = new(services);
+
+		object? result = await commands.InvokeAsync(new FakeSource(WindowLabels.Main), "plugin_list", Args(new { }));
+		string json = JsonSerializer.Serialize(result, BridgeJson.Options);
+		using JsonDocument document = JsonDocument.Parse(json);
+		JsonElement item = document.RootElement.GetProperty("plugins")[0];
+		Assert.Equal("io.nori.dto", item.GetProperty("id").GetString());
+		Assert.Equal("installed", item.GetProperty("state").GetString());
+		Assert.Equal("Nori Test", item.GetProperty("author").GetString());
+		Assert.False(item.TryGetProperty("installPath", out _));
+		Assert.False(item.TryGetProperty("storagePath", out _));
+		Assert.DoesNotContain(_root, json, StringComparison.OrdinalIgnoreCase);
+		Assert.DoesNotContain("stackTrace", json, StringComparison.OrdinalIgnoreCase);
+		await manager.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task 安装取消是正常结果且前端路径参数完全被忽略()
+	{
+		PluginManager manager = CreateManager();
+		FakePicker picker = new(null);
+		AppServices services = Services(manager, picker);
+		PluginManagementBridgeCommands commands = new(services);
+		object? result = await commands.InvokeAsync(
+			new FakeSource(WindowLabels.Main),
+			"plugin_install_local",
+			Args(new {path = Path.Combine(_root, "forged.noripack"), filePath = "C:\\forged.noripack"}));
+		string json = JsonSerializer.Serialize(result, BridgeJson.Options);
+		Assert.Contains("\"cancelled\":true", json, StringComparison.Ordinal);
+		Assert.Equal(1, picker.Calls);
+		await manager.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task SafeMode允许列表禁用卸载并拒绝安装启用()
+	{
+		CreateInstalledLayout("io.nori.safe", "1.0.0");
+		PluginManager manager = CreateManager(safeMode: true);
+		FakePicker picker = new(null);
+		AppServices services = Services(manager, picker, safeMode: true);
+		PluginManagementBridgeCommands commands = new(services);
+		FakeSource main = new(WindowLabels.Main);
+
+		object? list = await commands.InvokeAsync(main, "plugin_list", Args(new { }));
+		Assert.Contains("safe_mode_disabled", JsonSerializer.Serialize(list, BridgeJson.Options), StringComparison.Ordinal);
+		await Assert.ThrowsAsync<PluginException>(() => commands.InvokeAsync(main, "plugin_install_local", Args(new { })));
+		Assert.Equal(0, picker.Calls);
+		await Assert.ThrowsAsync<PluginException>(() => commands.InvokeAsync(main, "plugin_enable", Args(new {id = "io.nori.safe"})));
+
+		object? disabled = await commands.InvokeAsync(main, "plugin_disable", Args(new {id = "io.nori.safe"}));
+		Assert.Contains("\"enabled\":false", JsonSerializer.Serialize(disabled, BridgeJson.Options), StringComparison.Ordinal);
+		object? uninstalled = await commands.InvokeAsync(main, "plugin_uninstall", Args(new {id = "io.nori.safe", deleteData = false}));
+		Assert.Contains("\"success\":true", JsonSerializer.Serialize(uninstalled, BridgeJson.Options), StringComparison.Ordinal);
+		await manager.DisposeAsync();
+	}
+
+	[Fact]
+	public void Router把plugin前缀归到Plugins领域()
+	{
+		Assert.Equal(BridgeCommandDomain.Plugins, BridgeCommandRouter.Classify("plugin_list"));
+		Assert.Equal(BridgeCommandDomain.Plugins, BridgeCommandRouter.Classify("plugin_uninstall"));
+	}
+
+	private PluginManager CreateManager(bool safeMode = false)
+	{
+		Directory.CreateDirectory(_root);
+		return new PluginManager(new PluginRuntimeOptions
+		{
+			PluginsDirectory = Path.Combine(_root, "plugins"),
+			DataDirectory = Path.Combine(_root, "plugin-data"),
+			SafeMode = safeMode,
+		});
+	}
+
+	private AppServices Services(PluginManager manager, IPluginPackagePicker picker, bool safeMode = false) => new()
+	{
+		Database = null!,
+		Config = null!,
+		Logger = null!,
+		Resources = null!,
+		Chat = null!,
+		Memory = null!,
+		Embedding = null!,
+		Llm = null!,
+		Mcp = null!,
+		Http = _http,
+		AgentOperations = null!,
+		Plugins = manager,
+		PluginPackagePicker = picker,
+		SafeMode = safeMode,
+	};
+
+	private void CreateInstalledLayout(string id, string version)
+	{
+		string directory = Path.Combine(_root, "plugins", id, version);
+		Directory.CreateDirectory(directory);
+		File.WriteAllText(Path.Combine(_root, "plugins", id, PluginPackageInstaller.CurrentFileName), JsonSerializer.Serialize(new {Version = version}));
+		File.WriteAllText(Path.Combine(directory, PluginPackageInstaller.ManifestFileName), $"{{\"schemaVersion\":1,\"id\":\"{id}\",\"name\":\"Bridge Test\",\"description\":\"Plugin DTO test\",\"version\":\"{version}\",\"authors\":[{{\"name\":\"Nori Test\"}}],\"homepage\":\"https://example.test\",\"repository\":\"https://example.test/repo\",\"license\":\"MIT\",\"apiVersion\":\"1.0\",\"minHostVersion\":\"1.0.0\",\"runtime\":{{\"kind\":\"dotnet\",\"assembly\":\"lib/missing.dll\",\"entryType\":\"Missing.Entry\"}},\"ui\":{{\"webRoot\":\"web\"}},\"capabilities\":[\"ui.webview\"],\"optionalCapabilities\":[],\"platforms\":[],\"dependencies\":[]}}");
+	}
+
+	private static JsonElement Args(object value) => JsonSerializer.SerializeToElement(value, BridgeJson.Options);
+
+	public async ValueTask DisposeAsync()
+	{
+		_http.Dispose();
+		try { if (Directory.Exists(_root)) Directory.Delete(_root, true); } catch { }
+		await ValueTask.CompletedTask;
+	}
+}

--- a/app/desktop/Nori.Desktop/App.cs
+++ b/app/desktop/Nori.Desktop/App.cs
@@ -187,6 +187,7 @@ public sealed class App : Application
 			AssetUriFactory = (pluginId, path) => assetServer is { } server
 				? new Uri(server.PluginAssetUrl(pluginId, path), UriKind.RelativeOrAbsolute)
 				: throw new InvalidOperationException("插件资源服务尚未启动"),
+			ClosePluginWindowsAsync = (pluginId, cancellation) => pluginWindows.CloseAllWindowsForPluginAsync(pluginId, cancellation),
 			CapabilityFactory = (descriptor, stoppingToken) =>
 			[
 				new PluginWebViewCapability(

--- a/app/desktop/Nori.Desktop/Bridge/AppServices.cs
+++ b/app/desktop/Nori.Desktop/Bridge/AppServices.cs
@@ -65,6 +65,9 @@ public sealed class AppServices : IAsyncDisposable
 	/// <summary>插件动态 WebView 窗口宿主。</summary>
 	public Nori.Desktop.Plugins.PluginWindowHost? PluginWindows { get; set; }
 
+	/// <summary>插件包文件选择器。生产默认走 Avalonia StorageProvider，测试可注入取消/固定结果。</summary>
+	public IPluginPackagePicker? PluginPackagePicker { get; set; }
+
 	/// <summary>本地/模型 HTTP 客户端 (测试可在装配后替换)</summary>
 	public HttpClient Http { get; set; } = null!;
 

--- a/app/desktop/Nori.Desktop/Bridge/BridgeCommandRouter.cs
+++ b/app/desktop/Nori.Desktop/Bridge/BridgeCommandRouter.cs
@@ -16,6 +16,7 @@ public enum BridgeCommandDomain
 	Skills,
 	Mcp,
 	Tools,
+	Plugins,
 	Diagnostics,
 	Other,
 }
@@ -23,12 +24,13 @@ public enum BridgeCommandDomain
 /// <summary>
 /// Bridge 的领域路由边界。
 ///
-/// 当前具体业务实现仍由 BridgeCommands 承担；新路由先把 NoriBridge 的传输职责与
-/// 命令级运行组件策略隔离。后续领域 handler 可以逐个迁出，而不再修改 WebView 传输层。
+/// 当前具体业务实现仍由 BridgeCommands 承担；插件管理是第一个独立领域 handler，
+/// 只服务宿主主 WebView，不改变 PluginBridge 的插件侧白名单。
 /// </summary>
 public sealed class BridgeCommandRouter(AppServices services)
 {
 	private readonly AppServices _services = services;
+	private readonly PluginManagementBridgeCommands _pluginCommands = new(services);
 
 	public async Task<object?> InvokeAsync(
 		IBridgeSource source,
@@ -37,10 +39,14 @@ public sealed class BridgeCommandRouter(AppServices services)
 		CancellationToken cancellationToken = default)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
+		BridgeCommandDomain domain = Classify(command);
+
+		if (domain == BridgeCommandDomain.Plugins)
+			return await _pluginCommands.InvokeAsync(source, command, args, cancellationToken).ConfigureAwait(false);
 
 		// Browser Automation 是可选 feature pack。发布瘦身包不携带 driver 时，
 		// 在路由边界就明确 fail-closed，而不是让传输层或 Playwright 内部报路径错误。
-		if (Classify(command) == BridgeCommandDomain.Automation
+		if (domain == BridgeCommandDomain.Automation
 			&& command.StartsWith("automation_browser_", StringComparison.Ordinal))
 		{
 			bool available = PlaywrightRuntimeAvailability.IsAvailable();
@@ -89,6 +95,7 @@ public sealed class BridgeCommandRouter(AppServices services)
 		if (command.StartsWith("skills_", StringComparison.Ordinal)) return BridgeCommandDomain.Skills;
 		if (command.StartsWith("mcp_", StringComparison.Ordinal)) return BridgeCommandDomain.Mcp;
 		if (command.StartsWith("tools_", StringComparison.Ordinal)) return BridgeCommandDomain.Tools;
+		if (command.StartsWith("plugin_", StringComparison.Ordinal)) return BridgeCommandDomain.Plugins;
 		if (command is "get_recent_logs" or "clear_recent_logs" or "get_diagnostic_info" or "export_diagnostics" or "open_log_folder" or "run_gc_collect" or "debug_crash_test")
 			return BridgeCommandDomain.Diagnostics;
 		if (command.StartsWith("chat_", StringComparison.Ordinal)

--- a/app/desktop/Nori.Desktop/Bridge/PluginManagementBridgeCommands.cs
+++ b/app/desktop/Nori.Desktop/Bridge/PluginManagementBridgeCommands.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Avalonia.Platform.Storage;
 using Nori.Desktop.Windows;
+using Nori.Plugin.Abstractions;
 using Nori.Plugin.Runtime;
 
 namespace Nori.Desktop.Bridge;
@@ -117,7 +118,7 @@ public sealed class PluginManagementBridgeCommands
 		return new PluginUninstallResultDto(result.Success, result.RequiresRestart, result.Plugin is null ? null : ToDto(result.Plugin));
 	}
 
-	private PluginListItemDto Find(PluginManager manager, string id) =>
+	private static PluginInfo Find(PluginManager manager, string id) =>
 		manager.Plugins.Single(item => string.Equals(item.Id, id, StringComparison.Ordinal));
 
 	private PluginListItemDto ToDto(PluginInfo info)

--- a/app/desktop/Nori.Desktop/Bridge/PluginManagementBridgeCommands.cs
+++ b/app/desktop/Nori.Desktop/Bridge/PluginManagementBridgeCommands.cs
@@ -1,0 +1,185 @@
+using System.Text.Json;
+using Avalonia.Platform.Storage;
+using Nori.Desktop.Windows;
+using Nori.Plugin.Runtime;
+
+namespace Nori.Desktop.Bridge;
+
+/// <summary>宿主本地插件包选择器。前端从不提供任意文件系统路径。</summary>
+public interface IPluginPackagePicker
+{
+	Task<string?> PickAsync(IBridgeSource source, CancellationToken cancellationToken = default);
+}
+
+public sealed class AvaloniaPluginPackagePicker(IUiDispatcher dispatcher) : IPluginPackagePicker
+{
+	private readonly IUiDispatcher _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+
+	public Task<string?> PickAsync(IBridgeSource source, CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(source);
+		return _dispatcher.InvokeTaskAsync(async () =>
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			Avalonia.Controls.Window window = source.Self ?? throw new InvalidOperationException("来源窗口不可用");
+			IReadOnlyList<IStorageFile> files = await window.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+			{
+				Title = "选择 Nori 插件包 (.noripack)",
+				AllowMultiple = false,
+				FileTypeFilter =
+				[
+					new FilePickerFileType("Nori 插件包 (*.noripack)") { Patterns = ["*.noripack"] },
+				],
+			});
+			cancellationToken.ThrowIfCancellationRequested();
+			return files.Count == 0 ? null : files[0].Path.LocalPath;
+		});
+	}
+}
+
+/// <summary>
+/// 插件管理命令域。它只接收主 WebView 的宿主请求，并直接委托 PluginManager。
+/// PluginBridge 的插件侧白名单不参与这里的管理命令。
+/// </summary>
+public sealed class PluginManagementBridgeCommands
+{
+	private readonly AppServices _services;
+	private readonly IPluginPackagePicker _picker;
+
+	public PluginManagementBridgeCommands(AppServices services)
+	{
+		_services = services ?? throw new ArgumentNullException(nameof(services));
+		_picker = services.PluginPackagePicker ?? new AvaloniaPluginPackagePicker(AvaloniaUiDispatcher.Instance);
+	}
+
+	public bool CanHandle(string command) => command.StartsWith("plugin_", StringComparison.Ordinal);
+
+	public async Task<object?> InvokeAsync(
+		IBridgeSource source,
+		string command,
+		JsonElement args,
+		CancellationToken cancellationToken = default)
+	{
+		RequireVisibleMain(source);
+		PluginManager manager = _services.Plugins ?? throw new InvalidOperationException("插件运行时尚未就绪");
+
+		return command switch
+		{
+			"plugin_list" => List(manager),
+			"plugin_install_local" => await InstallLocalAsync(manager, source, cancellationToken).ConfigureAwait(false),
+			"plugin_enable" => await EnableAsync(manager, args, cancellationToken).ConfigureAwait(false),
+			"plugin_disable" => await DisableAsync(manager, args, cancellationToken).ConfigureAwait(false),
+			"plugin_uninstall" => await UninstallAsync(manager, args, cancellationToken).ConfigureAwait(false),
+			_ => throw new InvalidOperationException($"未知插件管理命令: {command}"),
+		};
+	}
+
+	private PluginListResultDto List(PluginManager manager)
+	{
+		IReadOnlyCollection<PluginInfo> plugins = manager.Discover();
+		return new PluginListResultDto(plugins.OrderBy(item => item.Manifest.Name, StringComparer.OrdinalIgnoreCase).Select(ToDto).ToArray());
+	}
+
+	private async Task<PluginInstallResultDto> InstallLocalAsync(
+		PluginManager manager,
+		IBridgeSource source,
+		CancellationToken cancellationToken)
+	{
+		if (_services.SafeMode) throw new PluginException(PluginErrorCodes.SafeModeDisabled, "安全模式下不允许安装插件");
+		string? packagePath = await _picker.PickAsync(source, cancellationToken).ConfigureAwait(false);
+		if (string.IsNullOrWhiteSpace(packagePath)) return new PluginInstallResultDto(true, null);
+
+		PluginManifest manifest = await manager.InstallAsync(packagePath, cancellationToken).ConfigureAwait(false);
+		PluginInfo info = manager.Plugins.Single(item => string.Equals(item.Id, manifest.Id, StringComparison.Ordinal));
+		return new PluginInstallResultDto(false, ToDto(info));
+	}
+
+	private async Task<PluginListItemDto> EnableAsync(PluginManager manager, JsonElement args, CancellationToken cancellationToken)
+	{
+		if (_services.SafeMode) throw new PluginException(PluginErrorCodes.SafeModeDisabled, "安全模式下不允许启用插件");
+		string id = RequiredId(args);
+		await manager.EnableAsync(id, cancellationToken).ConfigureAwait(false);
+		return ToDto(Find(manager, id));
+	}
+
+	private async Task<PluginListItemDto> DisableAsync(PluginManager manager, JsonElement args, CancellationToken cancellationToken)
+	{
+		string id = RequiredId(args);
+		await manager.DisableAsync(id, cancellationToken).ConfigureAwait(false);
+		return ToDto(Find(manager, id));
+	}
+
+	private async Task<PluginUninstallResultDto> UninstallAsync(PluginManager manager, JsonElement args, CancellationToken cancellationToken)
+	{
+		string id = RequiredId(args);
+		bool deleteData = OptionalBool(args, "deleteData");
+		PluginUninstallResult result = await manager.UninstallAsync(id, deleteData, cancellationToken).ConfigureAwait(false);
+		return new PluginUninstallResultDto(result.Success, result.RequiresRestart, result.Plugin is null ? null : ToDto(result.Plugin));
+	}
+
+	private PluginListItemDto Find(PluginManager manager, string id) =>
+		manager.Plugins.Single(item => string.Equals(item.Id, id, StringComparison.Ordinal));
+
+	private PluginListItemDto ToDto(PluginInfo info)
+	{
+		string author = string.Join(", ", info.Manifest.Authors.Select(item => item.Name.Trim()).Where(name => name.Length > 0));
+		string? iconUrl = null;
+		string? assetRoot = _services.Plugins?.ResolveAssetRoot(info.Id);
+		if (_services.Assets is { } assets && assetRoot is not null && File.Exists(Path.Combine(assetRoot, "icon.png")))
+			iconUrl = assets.PluginAssetUrl(info.Id, "icon.png");
+
+		return new PluginListItemDto(
+			info.Id,
+			info.Manifest.Name,
+			info.Manifest.Description,
+			info.Manifest.Version,
+			author,
+			info.Manifest.Homepage,
+			info.Manifest.Repository,
+			info.Manifest.License,
+			StateName(info.State),
+			info.UserEnabled,
+			info.Manifest.Capabilities.ToArray(),
+			info.Manifest.OptionalCapabilities.ToArray(),
+			info.CapabilityStatuses.Select(status => new PluginCapabilityStatusDto(status.Id, status.Declared, status.Granted, status.Available)).ToArray(),
+			info.ErrorCode,
+			info.ErrorMessage,
+			info.RequiresRestart,
+			iconUrl);
+	}
+
+	private static string StateName(PluginLifecycleState state) => state switch
+	{
+		PluginLifecycleState.Discovered or PluginLifecycleState.Installed => "installed",
+		PluginLifecycleState.Loading => "loading",
+		PluginLifecycleState.Active => "active",
+		PluginLifecycleState.Stopping => "stopping",
+		PluginLifecycleState.Disabled => "disabled",
+		PluginLifecycleState.Failed => "failed",
+		PluginLifecycleState.Incompatible => "incompatible",
+		PluginLifecycleState.PendingRestart => "pending_restart",
+		_ => "installed",
+	};
+
+	private static string RequiredId(JsonElement args)
+	{
+		if (args.ValueKind != JsonValueKind.Object || !args.TryGetProperty("id", out JsonElement value) || value.ValueKind != JsonValueKind.String)
+			throw new PluginException(PluginManagementErrorCodes.InvalidPluginId, "插件 ID 无效");
+		string id = value.GetString() ?? string.Empty;
+		if (!PluginManifestReader.IsValidPluginId(id))
+			throw new PluginException(PluginManagementErrorCodes.InvalidPluginId, "插件 ID 无效");
+		return id;
+	}
+
+	private static bool OptionalBool(JsonElement args, string name) =>
+		args.ValueKind == JsonValueKind.Object
+		&& args.TryGetProperty(name, out JsonElement value)
+		&& value.ValueKind is JsonValueKind.True or JsonValueKind.False
+		&& value.GetBoolean();
+
+	private static void RequireVisibleMain(IBridgeSource source)
+	{
+		if (!string.Equals(source.Label, WindowLabels.Main, StringComparison.Ordinal) || !source.IsVisible)
+			throw new UnauthorizedAccessException("插件管理仅允许可见的主窗口调用");
+	}
+}

--- a/app/desktop/Nori.Desktop/Bridge/PluginManagementDtos.cs
+++ b/app/desktop/Nori.Desktop/Bridge/PluginManagementDtos.cs
@@ -1,0 +1,32 @@
+namespace Nori.Desktop.Bridge;
+
+public sealed record PluginCapabilityStatusDto(
+	string Id,
+	bool Declared,
+	bool Granted,
+	bool Available);
+
+public sealed record PluginListItemDto(
+	string Id,
+	string Name,
+	string Description,
+	string Version,
+	string Author,
+	string? Homepage,
+	string? Repository,
+	string? License,
+	string State,
+	bool Enabled,
+	IReadOnlyList<string> Capabilities,
+	IReadOnlyList<string> OptionalCapabilities,
+	IReadOnlyList<PluginCapabilityStatusDto> CapabilityStatuses,
+	string? ErrorCode,
+	string? ErrorMessage,
+	bool RequiresRestart,
+	string? IconUrl);
+
+public sealed record PluginListResultDto(IReadOnlyList<PluginListItemDto> Plugins);
+
+public sealed record PluginInstallResultDto(bool Cancelled, PluginListItemDto? Plugin);
+
+public sealed record PluginUninstallResultDto(bool Success, bool RequiresRestart, PluginListItemDto? Plugin);

--- a/app/desktop/Nori.Plugin.Runtime.Tests/PluginManagementTests.cs
+++ b/app/desktop/Nori.Plugin.Runtime.Tests/PluginManagementTests.cs
@@ -1,0 +1,229 @@
+using System.IO.Compression;
+using Nori.Plugin.Abstractions;
+using Nori.Plugin.Runtime;
+
+namespace Nori.Plugin.Runtime.Tests;
+
+public sealed class PluginManagementTests
+{
+	[Fact]
+	public async Task 新安装默认禁用并跨Manager重建保持用户意图()
+	{
+		string root = CreateTemp();
+		try
+		{
+			string package = CreateTestPackage(root, "state.plugin", "1.0.0");
+			PluginManager first = CreateManager(root);
+			await first.InstallAsync(package);
+			PluginInfo installed = Assert.Single(first.Plugins);
+			Assert.False(installed.UserEnabled);
+			Assert.Equal(PluginLifecycleState.Disabled, installed.State);
+			Assert.False(Directory.Exists(Path.Combine(root, "plugin-data", "state.plugin")));
+			await first.DisposeAsync();
+
+			PluginManager second = CreateManager(root);
+			PluginInfo rediscovered = Assert.Single(second.Discover());
+			Assert.False(rediscovered.UserEnabled);
+			Assert.Equal(PluginLifecycleState.Disabled, rediscovered.State);
+			Assert.False(Directory.Exists(Path.Combine(root, "plugin-data", "state.plugin")));
+			await second.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task Enable激活而Disable撤销贡献并持久化禁用()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginManager manager = CreateManager(root);
+			await manager.InstallAsync(CreateTestPackage(root, "toggle.plugin", "1.0.0"));
+			await manager.EnableAsync("toggle.plugin");
+			Assert.Equal(PluginLifecycleState.Active, Assert.Single(manager.Plugins).State);
+			Assert.NotEmpty(manager.GetContributions<IPluginContribution>());
+
+			await manager.DisableAsync("toggle.plugin");
+			PluginInfo disabled = Assert.Single(manager.Plugins);
+			Assert.False(disabled.UserEnabled);
+			Assert.Contains(disabled.State, new[] {PluginLifecycleState.Disabled, PluginLifecycleState.PendingRestart});
+			Assert.Empty(manager.GetContributions<IPluginContribution>());
+			await manager.DisposeAsync();
+
+			PluginManager rebuilt = CreateManager(root);
+			PluginInfo rediscovered = Assert.Single(rebuilt.Discover());
+			Assert.False(rediscovered.UserEnabled);
+			Assert.Equal(PluginLifecycleState.Disabled, rediscovered.State);
+			await rebuilt.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task 激活失败后仍可重试并保持用户启用意图()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginManager manager = CreateManager(root);
+			await manager.InstallAsync(CreateTestPackage(root, "retry.plugin", "1.0.0", entryType: "Nori.Plugin.TestPlugin.ThrowingActivatePlugin"));
+			await Assert.ThrowsAsync<PluginException>(() => manager.EnableAsync("retry.plugin"));
+			PluginInfo failed = Assert.Single(manager.Plugins);
+			Assert.True(failed.UserEnabled);
+			Assert.Contains(failed.State, new[] {PluginLifecycleState.Failed, PluginLifecycleState.Disabled, PluginLifecycleState.PendingRestart});
+			Assert.NotNull(failed.ErrorCode);
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task 卸载删除安装目录默认保留数据而deleteData只删精确插件目录()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginManager manager = CreateManager(root);
+			await manager.InstallAsync(CreateTestPackage(root, "keep.plugin", "1.0.0"));
+			await manager.EnableAsync("keep.plugin");
+			await manager.DisableAsync("keep.plugin");
+			string keepData = Path.Combine(root, "plugin-data", "keep.plugin");
+			Assert.True(Directory.Exists(keepData));
+			PluginUninstallResult keepResult = await manager.UninstallAsync("keep.plugin");
+			if (!keepResult.RequiresRestart)
+			{
+				Assert.False(Directory.Exists(Path.Combine(root, "plugins", "keep.plugin")));
+				Assert.True(Directory.Exists(keepData));
+			}
+
+			await manager.InstallAsync(CreateTestPackage(root, "delete.plugin", "1.0.0"));
+			await manager.EnableAsync("delete.plugin");
+			await manager.DisableAsync("delete.plugin");
+			string deleteData = Path.Combine(root, "plugin-data", "delete.plugin");
+			string otherData = Path.Combine(root, "plugin-data", "other.plugin");
+			Directory.CreateDirectory(otherData);
+			File.WriteAllText(Path.Combine(otherData, "keep.txt"), "keep");
+			PluginUninstallResult deleteResult = await manager.UninstallAsync("delete.plugin", deleteData: true);
+			if (!deleteResult.RequiresRestart)
+			{
+				Assert.False(Directory.Exists(deleteData));
+				Assert.True(File.Exists(Path.Combine(otherData, "keep.txt")));
+			}
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task 非法ID和活动依赖会拒绝卸载()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginManager manager = CreateManager(root);
+			await Assert.ThrowsAsync<PluginException>(() => manager.UninstallAsync("../outside", true));
+
+			manager.Installer.Install(CreateTestPackage(root, "base.plugin", "1.0.0"));
+			manager.Installer.Install(CreateTestPackage(root, "dependent.plugin", "1.0.0", dependencies: "[{\"id\":\"base.plugin\",\"version\":\">=1.0.0 <2.0.0\",\"optional\":false}]"));
+			manager.Discover();
+			await manager.ActivateAsync("base.plugin");
+			await manager.ActivateAsync("dependent.plugin");
+			PluginException inUse = await Assert.ThrowsAsync<PluginException>(() => manager.UninstallAsync("base.plugin"));
+			Assert.Equal(PluginManagementErrorCodes.DependencyInUse, inUse.Code);
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task SafeMode只发现且不创建插件数据或激活DLL()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginPackageInstaller installer = new(Path.Combine(root, "plugins"));
+			installer.Install(CreateTestPackage(root, "safe.plugin", "1.0.0"));
+			PluginManager manager = new(new PluginRuntimeOptions
+			{
+				PluginsDirectory = Path.Combine(root, "plugins"),
+				DataDirectory = Path.Combine(root, "plugin-data"),
+				SafeMode = true,
+			});
+			PluginInfo info = Assert.Single(manager.Discover());
+			Assert.True(info.UserEnabled);
+			Assert.Equal(PluginLifecycleState.Disabled, info.State);
+			Assert.Equal(PluginErrorCodes.SafeModeDisabled, info.ErrorCode);
+			await manager.ActivateAsync("safe.plugin");
+			Assert.False(Directory.Exists(Path.Combine(root, "plugin-data", "safe.plugin")));
+			await Assert.ThrowsAsync<PluginException>(() => manager.EnableAsync("safe.plugin"));
+			await manager.DisableAsync("safe.plugin");
+			Assert.False(Assert.Single(manager.Plugins).UserEnabled);
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task 重复Discover不会把相同current活动版本标成待重启()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginManager manager = CreateManager(root);
+			manager.Installer.Install(CreateTestPackage(root, "discover.plugin", "1.0.0"));
+			manager.Discover();
+			await manager.ActivateAsync("discover.plugin");
+			Assert.Equal(PluginLifecycleState.Active, Assert.Single(manager.Discover()).State);
+			Assert.Equal(PluginLifecycleState.Active, Assert.Single(manager.Discover()).State);
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	private static PluginManager CreateManager(string root) => new(new PluginRuntimeOptions
+	{
+		PluginsDirectory = Path.Combine(root, "plugins"),
+		DataDirectory = Path.Combine(root, "plugin-data"),
+	});
+
+	private static string CreateTestPackage(
+		string root,
+		string id,
+		string version,
+		string entryType = "Nori.Plugin.TestPlugin.TestPlugin",
+		string dependencies = "[]")
+	{
+		string package = Path.Combine(root, $"{id}-{Guid.NewGuid():N}.noripack");
+		string assembly = typeof(Nori.Plugin.TestPlugin.TestPlugin).Assembly.Location;
+		string manifest = $"{{\"schemaVersion\":1,\"id\":\"{id}\",\"name\":\"Demo\",\"description\":\"Demo plugin\",\"version\":\"{version}\",\"authors\":[{{\"name\":\"Nori\"}}],\"homepage\":\"https://example.test\",\"repository\":\"https://example.test/repo\",\"license\":\"MIT\",\"apiVersion\":\"1.0\",\"minHostVersion\":\"1.0.0\",\"runtime\":{{\"kind\":\"dotnet\",\"assembly\":\"lib/Nori.Plugin.TestPlugin.dll\",\"entryType\":\"{entryType}\"}},\"ui\":{{\"webRoot\":\"web\"}},\"capabilities\":[],\"optionalCapabilities\":[],\"platforms\":[],\"dependencies\":{dependencies}}}";
+		using (FileStream file = File.Create(package))
+		using (ZipArchive archive = new(file, ZipArchiveMode.Create))
+		{
+			WriteEntry(archive, "manifest.json", manifest);
+			ZipArchiveEntry assemblyEntry = archive.CreateEntry("lib/Nori.Plugin.TestPlugin.dll");
+			using (Stream target = assemblyEntry.Open())
+			using (FileStream source = File.OpenRead(assembly)) source.CopyTo(target);
+			WriteEntry(archive, "web/index.html", "<!doctype html><title>plugin</title>");
+			WriteEntry(archive, "README.md", "test");
+		}
+		return package;
+	}
+
+	private static void WriteEntry(ZipArchive archive, string name, string content)
+	{
+		using StreamWriter writer = new(archive.CreateEntry(name).Open());
+		writer.Write(content);
+	}
+
+	private static string CreateTemp()
+	{
+		string path = Path.Combine(Path.GetTempPath(), "nori-plugin-management-tests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(path);
+		return path;
+	}
+
+	private static void DeleteDirectory(string path)
+	{
+		try { if (Directory.Exists(path)) Directory.Delete(path, true); } catch { }
+	}
+}

--- a/app/desktop/Nori.Plugin.Runtime.Tests/PluginRuntimeTests.cs
+++ b/app/desktop/Nori.Plugin.Runtime.Tests/PluginRuntimeTests.cs
@@ -221,11 +221,20 @@ public sealed class PluginRuntimeTests
 
 			await manager.DeactivateAsync("test.plugin");
 			Assert.Empty(manager.GetContributions<IPluginContribution>());
-			Assert.Contains(Assert.Single(manager.Plugins).State, new[] { PluginLifecycleState.Installed, PluginLifecycleState.PendingRestart });
+			PluginInfo deactivated = Assert.Single(manager.Plugins);
+			Assert.Contains(deactivated.State, new[] { PluginLifecycleState.Installed, PluginLifecycleState.PendingRestart });
 			Assert.True(File.Exists(Path.Combine(root, "plugin-data", "test.plugin", "storage.json")));
-			await manager.ActivateAsync("test.plugin");
-			await manager.UnloadAsync("test.plugin");
-			Assert.Contains(Assert.Single(manager.Plugins).State, new[] { PluginLifecycleState.Installed, PluginLifecycleState.PendingRestart });
+			if (deactivated.State == PluginLifecycleState.Installed)
+			{
+				await manager.ActivateAsync("test.plugin");
+				await manager.UnloadAsync("test.plugin");
+				Assert.Contains(Assert.Single(manager.Plugins).State, new[] { PluginLifecycleState.Installed, PluginLifecycleState.PendingRestart });
+			}
+			else
+			{
+				PluginException pending = await Assert.ThrowsAsync<PluginException>(() => manager.ActivateAsync("test.plugin"));
+				Assert.Equal(PluginErrorCodes.UnloadPendingRestart, pending.Code);
+			}
 			await manager.DisposeAsync();
 		}
 		finally { DeleteDirectory(root); }

--- a/app/desktop/Nori.Plugin.Runtime/PluginManagementErrorCodes.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginManagementErrorCodes.cs
@@ -1,0 +1,11 @@
+namespace Nori.Plugin.Runtime;
+
+/// <summary>插件管理垂直切片新增的稳定错误码。</summary>
+public static class PluginManagementErrorCodes
+{
+	public const string InvalidPluginId = "plugin.invalid_id";
+	public const string PluginNotFound = "plugin.not_found";
+	public const string UserDisabled = "plugin.user_disabled";
+	public const string DependencyInUse = "plugin.dependency_in_use";
+	public const string UninstallPendingRestart = "plugin.uninstall_pending_restart";
+}

--- a/app/desktop/Nori.Plugin.Runtime/PluginManager.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginManager.cs
@@ -34,18 +34,27 @@ public sealed record PluginRuntimeOptions
 	];
 	public Func<PluginDescriptor, CancellationToken, IEnumerable<IPluginCapability>>? CapabilityFactory { get; init; }
 	public Func<string, string, Uri>? AssetUriFactory { get; init; }
+	public Func<string, CancellationToken, Task>? ClosePluginWindowsAsync { get; init; }
 	public Action<PluginException>? OnError { get; init; }
 	public Action<PluginDescriptor, string, Exception?>? OnLog { get; init; }
 	public TimeSpan ActivationTimeout { get; init; } = TimeSpan.FromSeconds(15);
 	public TimeSpan DeactivationTimeout { get; init; } = TimeSpan.FromSeconds(5);
 }
 
-/// <summary>插件当前状态快照。</summary>
+/// <summary>插件当前状态快照。只包含可安全暴露给宿主 UI 的运行时信息。</summary>
 public sealed record PluginInfo(
 	string Id,
 	PluginManifest Manifest,
 	PluginLifecycleState State,
-	string? ErrorCode);
+	string? ErrorCode)
+{
+	public bool UserEnabled { get; init; } = true;
+	public string? ErrorMessage { get; init; }
+	public bool RequiresRestart { get; init; }
+	public IReadOnlyList<PluginCapabilityStatus> CapabilityStatuses { get; init; } = [];
+}
+
+public sealed record PluginUninstallResult(bool Success, bool RequiresRestart, PluginInfo? Plugin);
 
 /// <summary>一个带全局 ID 的 Harness 工具。</summary>
 public sealed record PluginHarnessTool(string Id, IHarnessTool Tool);
@@ -60,6 +69,7 @@ public sealed class PluginManager : IAsyncDisposable
 	private readonly CancellationTokenSource _shutdownSource = new();
 	private readonly SemaphoreSlim _lifecycleGate = new(1, 1);
 	private readonly PluginStartupRecoveryStore _startupRecovery;
+	private readonly PluginStateStore _stateStore;
 	private int _disposed;
 
 	public PluginManager(PluginRuntimeOptions options)
@@ -75,65 +85,95 @@ public sealed class PluginManager : IAsyncDisposable
 		string runtimeDirectory = Path.Combine(options.DataDirectory, "runtime");
 		Directory.CreateDirectory(runtimeDirectory);
 		_startupRecovery = new PluginStartupRecoveryStore(Path.Combine(runtimeDirectory, "plugin-startup.json"));
+		_stateStore = new PluginStateStore(Path.Combine(runtimeDirectory, "plugin-state.json"));
 		_installer = new PluginPackageInstaller(options.PluginsDirectory);
+		CompletePendingUninstalls();
 	}
 
-	public IReadOnlyCollection<PluginInfo> Plugins => _plugins.Values.Select(handle => handle.Info).ToArray();
+	public IReadOnlyCollection<PluginInfo> Plugins => _plugins.Values.Select(CreateInfo).ToArray();
 	public PluginPackageInstaller Installer => _installer;
+	public bool SafeMode => _options.SafeMode;
 
 	/// <summary>读取当前版本的 manifest。发现阶段不会创建插件 ALC。</summary>
 	public IReadOnlyCollection<PluginInfo> Discover()
 	{
 		EnsureNotDisposed();
+		CompletePendingUninstalls();
 		if (!_options.SafeMode) InstallInboxPackages();
+		HashSet<string> seen = new(StringComparer.Ordinal);
 		foreach (string id in _installer.InstalledIds.Order(StringComparer.Ordinal))
 		{
 			try
 			{
+				if (!PluginManifestReader.IsValidPluginId(id)) continue;
+				seen.Add(id);
 				string? directory = _installer.ResolveCurrentDirectory(id);
 				if (directory is null) throw new PluginException(PluginErrorCodes.InvalidPackage, "current.json 指向的版本不存在");
 				PluginManifest manifest = PluginManifestReader.Read(Path.Combine(directory, PluginPackageInstaller.ManifestFileName));
 				if (!string.Equals(id, manifest.Id, StringComparison.Ordinal))
 					throw new PluginException(PluginErrorCodes.InvalidManifest, "插件目录 ID 与 manifest.json 不一致");
-				PluginLifecycleState state = _options.SafeMode ? PluginLifecycleState.Disabled : PluginLifecycleState.Discovered;
-				string? errorCode = _options.SafeMode ? PluginErrorCodes.SafeModeDisabled : null;
-				if (!_options.SafeMode && _startupRecovery.IsDisabled(manifest.Id))
+
+				(bool compatible, string? compatibilityCode) = Compatibility(manifest);
+				bool userEnabled = _stateStore.IsEnabled(manifest.Id);
+				PluginLifecycleState state;
+				string? errorCode;
+				string? errorMessage;
+
+				if (!compatible)
+				{
+					state = PluginLifecycleState.Incompatible;
+					errorCode = compatibilityCode;
+					errorMessage = FriendlyMessage(compatibilityCode);
+				}
+				else if (_stateStore.TryGetPendingUninstall(manifest.Id, out _))
+				{
+					state = PluginLifecycleState.PendingRestart;
+					errorCode = PluginManagementErrorCodes.UninstallPendingRestart;
+					errorMessage = "插件将在重启后完成卸载";
+				}
+				else if (_options.SafeMode)
+				{
+					state = PluginLifecycleState.Disabled;
+					errorCode = PluginErrorCodes.SafeModeDisabled;
+					errorMessage = "安全模式临时禁用了第三方插件";
+				}
+				else if (!userEnabled)
+				{
+					state = PluginLifecycleState.Disabled;
+					errorCode = PluginManagementErrorCodes.UserDisabled;
+					errorMessage = "插件已由用户禁用";
+				}
+				else if (_startupRecovery.IsDisabled(manifest.Id))
 				{
 					state = PluginLifecycleState.Disabled;
 					errorCode = PluginErrorCodes.StartupRecoveryDisabled;
+					errorMessage = "插件因连续启动失败被保护性禁用";
 				}
-				if (!PluginManifestReader.IsPlatformSupported(manifest.Platforms))
+				else
 				{
-					state = PluginLifecycleState.Incompatible;
-					errorCode = PluginErrorCodes.UnsupportedPlatform;
+					state = PluginLifecycleState.Discovered;
+					errorCode = null;
+					errorMessage = null;
 				}
-				else if (!PluginManifestReader.IsCompatible(_options.HostApiVersion, manifest.Api))
-				{
-					state = PluginLifecycleState.Incompatible;
-					errorCode = PluginErrorCodes.IncompatibleApi;
-				}
-				else if (!_options.DevelopmentHost && !PluginManifestReader.IsHostVersionSupported(_options.HostVersion, manifest.MinHostVersion))
-				{
-					state = PluginLifecycleState.Incompatible;
-					errorCode = PluginErrorCodes.IncompatibleHost;
-				}
-				else if (manifest.Capabilities.Any(capability => !_options.KnownCapabilityIds.Contains(capability, StringComparer.Ordinal)))
-				{
-					state = PluginLifecycleState.Incompatible;
-					errorCode = PluginErrorCodes.UnknownCapability;
-				}
-				Register(directory, manifest, state, errorCode);
+
+				Register(directory, manifest, state, errorCode, errorMessage);
 			}
 			catch (PluginException exception)
 			{
 				Report(exception);
 			}
 		}
+
+		foreach (string stale in _plugins.Keys.Where(id => !seen.Contains(id)).ToArray())
+		{
+			PluginHandle handle = _plugins[stale];
+			if (handle.Instance is null && handle.LoadContext is null) _plugins.Remove(stale);
+		}
 		ValidateDependencies();
 		return Plugins;
 	}
 
-	/// <summary>安装本地 .noripack。安全模式拒绝执行安装。</summary>
+	/// <summary>安装本地 .noripack。新安装默认禁用，安全模式拒绝执行安装。</summary>
 	public async Task<PluginManifest> InstallAsync(string packagePath, CancellationToken cancellationToken = default)
 	{
 		EnsureNotDisposed();
@@ -141,7 +181,10 @@ public sealed class PluginManager : IAsyncDisposable
 		await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 		try
 		{
+			PluginManifest inspected = _installer.InspectPackage(packagePath);
+			bool existed = _installer.ResolveCurrentDirectory(inspected.Id) is not null;
 			PluginManifest manifest = await Task.Run(() => _installer.Install(packagePath, cancellationToken), cancellationToken).ConfigureAwait(false);
+			if (!existed) _stateStore.SetEnabled(manifest.Id, false);
 			Discover();
 			return manifest;
 		}
@@ -151,8 +194,17 @@ public sealed class PluginManager : IAsyncDisposable
 		}
 	}
 
-	/// <summary>同步安装入口，供安装命令之外的本地调用使用。</summary>
-	public PluginManifest Install(string packagePath) => InstallAsync(packagePath).GetAwaiter().GetResult();
+	/// <summary>
+	/// 兼容宿主内部与既有测试的同步安装入口。该入口代表宿主已显式信任包，保持旧行为并启用插件。
+	/// UI 的本地安装只使用 InstallAsync，因此仍然默认不执行第三方 DLL。
+	/// </summary>
+	public PluginManifest Install(string packagePath)
+	{
+		PluginManifest manifest = InstallAsync(packagePath).GetAwaiter().GetResult();
+		_stateStore.SetEnabled(manifest.Id, true);
+		Discover();
+		return manifest;
+	}
 
 	/// <summary>返回依赖优先的插件快照顺序。</summary>
 	public IReadOnlyList<PluginInfo> DependencyOrder()
@@ -194,25 +246,28 @@ public sealed class PluginManager : IAsyncDisposable
 		}
 	}
 
-	/// <summary>加载并激活一个插件。</summary>
-	public async Task ActivateAsync(string pluginId, CancellationToken cancellationToken = default)
+	/// <summary>显式启用并热激活一个插件。</summary>
+	public async Task EnableAsync(string pluginId, CancellationToken cancellationToken = default)
 	{
 		EnsureNotDisposed();
-		if (_options.SafeMode)
-		{
-			DisableAllThirdPartyPlugins();
-			return;
-		}
+		ValidatePluginId(pluginId);
+		if (_options.SafeMode) throw new PluginException(PluginErrorCodes.SafeModeDisabled, "安全模式下不允许启用插件");
 		await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 		try
 		{
-			if (!_plugins.TryGetValue(pluginId, out PluginHandle? handle))
-				throw new PluginException(PluginErrorCodes.InvalidManifest, $"未发现插件: {pluginId}");
-			if (handle.State == PluginLifecycleState.Active) return;
+			Discover();
+			PluginHandle handle = GetRequiredHandle(pluginId);
+			if (_stateStore.TryGetPendingUninstall(pluginId, out _))
+				throw new PluginException(PluginManagementErrorCodes.UninstallPendingRestart, "插件正在等待重启后卸载");
 			if (handle.State == PluginLifecycleState.Incompatible)
 				throw new PluginException(handle.ErrorCode ?? PluginErrorCodes.IncompatibleHost, "插件与当前宿主不兼容");
-			if (handle.State == PluginLifecycleState.Disabled)
-				throw new PluginException(PluginErrorCodes.SafeModeDisabled, "插件已被禁用");
+
+			_stateStore.SetEnabled(pluginId, true);
+			_startupRecovery.Clear(pluginId);
+			if (handle.State == PluginLifecycleState.Active) return;
+			handle.State = PluginLifecycleState.Discovered;
+			handle.ErrorCode = null;
+			handle.ErrorMessage = null;
 			ValidateDependenciesFor(handle);
 			await ActivateCoreAsync(handle, cancellationToken).ConfigureAwait(false);
 		}
@@ -222,10 +277,43 @@ public sealed class PluginManager : IAsyncDisposable
 		}
 	}
 
-	/// <summary>停用一个插件并撤销所有贡献。</summary>
+	/// <summary>加载并激活一个已启用插件。宿主启动流程使用此入口。</summary>
+	public async Task ActivateAsync(string pluginId, CancellationToken cancellationToken = default)
+	{
+		EnsureNotDisposed();
+		ValidatePluginId(pluginId);
+		if (_options.SafeMode)
+		{
+			DisableAllThirdPartyPlugins();
+			return;
+		}
+		await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			PluginHandle handle = GetRequiredHandle(pluginId);
+			if (!_stateStore.IsEnabled(pluginId))
+				throw new PluginException(PluginManagementErrorCodes.UserDisabled, "插件已由用户禁用");
+			if (_startupRecovery.IsDisabled(pluginId))
+				throw new PluginException(PluginErrorCodes.StartupRecoveryDisabled, "插件已被启动失败保护禁用");
+			if (handle.State == PluginLifecycleState.Active) return;
+			if (handle.State == PluginLifecycleState.Incompatible)
+				throw new PluginException(handle.ErrorCode ?? PluginErrorCodes.IncompatibleHost, "插件与当前宿主不兼容");
+			if (handle.State == PluginLifecycleState.PendingRestart)
+				throw new PluginException(handle.ErrorCode ?? PluginErrorCodes.UnloadPendingRestart, "插件需要重启后继续操作");
+			ValidateDependenciesFor(handle);
+			await ActivateCoreAsync(handle, cancellationToken).ConfigureAwait(false);
+		}
+		finally
+		{
+			_lifecycleGate.Release();
+		}
+	}
+
+	/// <summary>停用一个插件并撤销所有贡献，不改变用户启用意图。</summary>
 	public async Task DeactivateAsync(string pluginId, CancellationToken cancellationToken = default)
 	{
 		EnsureNotDisposed();
+		ValidatePluginId(pluginId);
 		await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 		try
 		{
@@ -238,10 +326,11 @@ public sealed class PluginManager : IAsyncDisposable
 		finally { _lifecycleGate.Release(); }
 	}
 
-	/// <summary>停用并卸载一个插件。</summary>
+	/// <summary>停用并卸载一个插件，不改变用户启用意图。</summary>
 	public async Task UnloadAsync(string pluginId, CancellationToken cancellationToken = default)
 	{
 		EnsureNotDisposed();
+		ValidatePluginId(pluginId);
 		await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 		try
 		{
@@ -252,17 +341,82 @@ public sealed class PluginManager : IAsyncDisposable
 		finally { _lifecycleGate.Release(); }
 	}
 
-	/// <summary>禁用插件并保留安装文件与用户数据。</summary>
+	/// <summary>显式禁用插件并保留安装文件与用户数据。</summary>
 	public async Task DisableAsync(string pluginId, CancellationToken cancellationToken = default)
 	{
 		EnsureNotDisposed();
+		ValidatePluginId(pluginId);
 		await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
 		try
 		{
-			if (_plugins.TryGetValue(pluginId, out PluginHandle? handle))
+			Discover();
+			PluginHandle handle = GetRequiredHandle(pluginId);
+			_stateStore.SetEnabled(pluginId, false);
+			try
 			{
-				try { await DeactivateCoreAsync(pluginId, cancellationToken, disabled: true).ConfigureAwait(false); }
-				finally { UnloadContext(handle); }
+				await DeactivateCoreAsync(pluginId, cancellationToken, disabled: true).ConfigureAwait(false);
+			}
+			finally
+			{
+				bool unloaded = UnloadContext(handle);
+				if (unloaded)
+				{
+					handle.State = PluginLifecycleState.Disabled;
+					handle.ErrorCode = PluginManagementErrorCodes.UserDisabled;
+					handle.ErrorMessage = "插件已由用户禁用";
+				}
+				else
+				{
+					handle.State = PluginLifecycleState.PendingRestart;
+					handle.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
+					handle.ErrorMessage = "插件程序集仍被占用，重启后完成禁用";
+				}
+			}
+		}
+		finally { _lifecycleGate.Release(); }
+	}
+
+	/// <summary>禁用并安全删除插件安装目录；用户数据默认保留。</summary>
+	public async Task<PluginUninstallResult> UninstallAsync(string pluginId, bool deleteData = false, CancellationToken cancellationToken = default)
+	{
+		EnsureNotDisposed();
+		ValidatePluginId(pluginId);
+		await _lifecycleGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+		try
+		{
+			Discover();
+			PluginHandle handle = GetRequiredHandle(pluginId);
+			EnsureNoActiveDependents(pluginId);
+			_stateStore.SetEnabled(pluginId, false);
+
+			try { await DeactivateCoreAsync(pluginId, cancellationToken, disabled: true).ConfigureAwait(false); }
+			catch (PluginException) { /* cleanup still decides whether uninstall can continue */ }
+
+			if (!UnloadContext(handle))
+			{
+				_stateStore.SetPendingUninstall(pluginId, deleteData);
+				handle.State = PluginLifecycleState.PendingRestart;
+				handle.ErrorCode = PluginManagementErrorCodes.UninstallPendingRestart;
+				handle.ErrorMessage = "插件正在使用中，将在重启后完成卸载";
+				return new PluginUninstallResult(true, true, CreateInfo(handle));
+			}
+
+			try
+			{
+				_installer.Uninstall(pluginId);
+				if (deleteData) DeletePluginData(pluginId);
+				_plugins.Remove(pluginId);
+				_startupRecovery.Clear(pluginId);
+				_stateStore.Remove(pluginId);
+				return new PluginUninstallResult(true, false, null);
+			}
+			catch (PluginException exception) when (exception.Code == PluginErrorCodes.UnloadPendingRestart)
+			{
+				_stateStore.SetPendingUninstall(pluginId, deleteData);
+				handle.State = PluginLifecycleState.PendingRestart;
+				handle.ErrorCode = PluginManagementErrorCodes.UninstallPendingRestart;
+				handle.ErrorMessage = "插件文件当前被占用，将在重启后完成卸载";
+				return new PluginUninstallResult(true, true, CreateInfo(handle));
 			}
 		}
 		finally { _lifecycleGate.Release(); }
@@ -275,6 +429,7 @@ public sealed class PluginManager : IAsyncDisposable
 		{
 			handle.State = PluginLifecycleState.Disabled;
 			handle.ErrorCode = PluginErrorCodes.SafeModeDisabled;
+			handle.ErrorMessage = "安全模式临时禁用了第三方插件";
 		}
 	}
 
@@ -304,7 +459,12 @@ public sealed class PluginManager : IAsyncDisposable
 
 	public void MarkPendingRestart(string pluginId)
 	{
-		if (_plugins.TryGetValue(pluginId, out PluginHandle? handle)) handle.State = PluginLifecycleState.PendingRestart;
+		if (_plugins.TryGetValue(pluginId, out PluginHandle? handle))
+		{
+			handle.State = PluginLifecycleState.PendingRestart;
+			handle.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
+			handle.ErrorMessage = "插件需要重启后完成当前操作";
+		}
 	}
 
 	public async ValueTask DisposeAsync()
@@ -344,6 +504,7 @@ public sealed class PluginManager : IAsyncDisposable
 	private async Task ActivateCoreAsync(PluginHandle handle, CancellationToken cancellationToken)
 	{
 		handle.State = PluginLifecycleState.Loading;
+		handle.ErrorMessage = null;
 		PluginLoadContext? loadContext = null;
 		try
 		{
@@ -359,6 +520,7 @@ public sealed class PluginManager : IAsyncDisposable
 			await instance.ActivateAsync(handle.Context, cancellationToken).AsTask().WaitAsync(_options.ActivationTimeout, cancellationToken).ConfigureAwait(false);
 			handle.State = PluginLifecycleState.Active;
 			handle.ErrorCode = null;
+			handle.ErrorMessage = null;
 			ClearStartupFailure(handle.Manifest.Id);
 		}
 		catch (PluginException exception)
@@ -379,32 +541,54 @@ public sealed class PluginManager : IAsyncDisposable
 		if (!_plugins.TryGetValue(pluginId, out PluginHandle? handle)) return;
 		if (handle.Instance is null)
 		{
+			handle.Context?.Revoke();
+			handle.Context?.Dispose();
+			handle.Context = null;
+			handle.Contributions.RevokeAll();
 			if (disabled) handle.State = PluginLifecycleState.Disabled;
 			return;
 		}
+
 		handle.State = PluginLifecycleState.Stopping;
 		try { handle.StopSource?.Cancel(throwOnFirstException: false); } catch { }
+		try { handle.Contributions.RevokeAll(); } catch { }
+		try { handle.Context?.Revoke(); } catch { }
+
 		PluginException? failure = null;
+		if (_options.ClosePluginWindowsAsync is not null)
+		{
+			try
+			{
+				await _options.ClosePluginWindowsAsync(pluginId, cancellationToken).WaitAsync(_options.DeactivationTimeout, cancellationToken).ConfigureAwait(false);
+			}
+			catch (Exception exception)
+			{
+				failure = new PluginException(PluginErrorCodes.DeactivationFailed, "插件窗口关闭失败", exception);
+				Report(failure);
+			}
+		}
+
 		try
 		{
 			await handle.Instance.DeactivateAsync(cancellationToken).AsTask().WaitAsync(_options.DeactivationTimeout, cancellationToken).ConfigureAwait(false);
 		}
 		catch (Exception exception)
 		{
-			failure = exception is PluginException pluginException && pluginException.Code == PluginErrorCodes.DeactivationFailed
+			PluginException deactivateFailure = exception is PluginException pluginException && pluginException.Code == PluginErrorCodes.DeactivationFailed
 				? pluginException
 				: new PluginException(PluginErrorCodes.DeactivationFailed, $"插件停用失败: {handle.Manifest.Name}", exception);
-			Report(failure);
+			failure ??= deactivateFailure;
+			Report(deactivateFailure);
 		}
 		finally
 		{
-			handle.Context?.Revoke();
 			handle.Instance = null;
 			handle.Context?.Dispose();
 			handle.Context = null;
 			handle.StopSource = null;
 			handle.State = failure is null ? (disabled ? PluginLifecycleState.Disabled : PluginLifecycleState.Installed) : PluginLifecycleState.Failed;
 			handle.ErrorCode = failure?.Code;
+			handle.ErrorMessage = failure is null ? null : SanitizeMessage(failure.Message);
 		}
 		if (failure is not null) throw failure;
 	}
@@ -455,6 +639,7 @@ public sealed class PluginManager : IAsyncDisposable
 	private void FailActivation(PluginHandle handle, PluginException exception, PluginLoadContext? loadContext)
 	{
 		handle.ErrorCode = exception.Code;
+		handle.ErrorMessage = SanitizeMessage(exception.Message);
 		handle.State = PluginLifecycleState.Failed;
 		RecordStartupFailure(handle);
 		handle.Context?.Revoke();
@@ -468,19 +653,20 @@ public sealed class PluginManager : IAsyncDisposable
 		Report(exception);
 	}
 
-	private void UnloadContext(PluginHandle handle)
+	private bool UnloadContext(PluginHandle handle)
 	{
 		PluginLoadContext? context = handle.LoadContext;
 		handle.LoadContext = null;
-		if (context is null) return;
+		if (context is null) return true;
 		WeakReference weak;
 		try { weak = UnloadAndTrack(context); }
 		catch (Exception exception)
 		{
 			handle.State = PluginLifecycleState.PendingRestart;
 			handle.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
+			handle.ErrorMessage = "插件程序集无法卸载，需要重启";
 			Report(new PluginException(PluginErrorCodes.UnloadPendingRestart, "插件程序集无法卸载", exception));
-			return;
+			return false;
 		}
 		context = null;
 		for (int index = 0; index < 10 && weak.IsAlive; index++)
@@ -490,11 +676,11 @@ public sealed class PluginManager : IAsyncDisposable
 			GC.Collect();
 			if (weak.IsAlive) Thread.Sleep(10);
 		}
-		if (weak.IsAlive)
-		{
-			handle.State = PluginLifecycleState.PendingRestart;
-			handle.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
-		}
+		if (!weak.IsAlive) return true;
+		handle.State = PluginLifecycleState.PendingRestart;
+		handle.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
+		handle.ErrorMessage = "插件程序集仍被引用，需要重启";
+		return false;
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
@@ -505,15 +691,26 @@ public sealed class PluginManager : IAsyncDisposable
 		return weak;
 	}
 
-	private void Register(string directory, PluginManifest manifest, PluginLifecycleState state, string? errorCode)
+	private void Register(string directory, PluginManifest manifest, PluginLifecycleState state, string? errorCode, string? errorMessage)
 	{
-		if (_plugins.TryGetValue(manifest.Id, out PluginHandle? existing) && existing.State == PluginLifecycleState.Active)
+		if (_plugins.TryGetValue(manifest.Id, out PluginHandle? existing))
 		{
-			existing.State = PluginLifecycleState.PendingRestart;
-			existing.ErrorCode = null;
-			return;
+			bool sameDirectory = PathsEqual(existing.Directory, directory);
+			if (existing.State == PluginLifecycleState.Active)
+			{
+				if (!sameDirectory)
+				{
+					existing.State = PluginLifecycleState.PendingRestart;
+					existing.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
+					existing.ErrorMessage = "已安装新版本，重启后切换";
+				}
+				return;
+			}
+			if (sameDirectory && existing.State is PluginLifecycleState.Failed or PluginLifecycleState.PendingRestart
+				&& state is PluginLifecycleState.Discovered or PluginLifecycleState.Installed)
+				return;
 		}
-		_plugins[manifest.Id] = new PluginHandle(directory, manifest, state, errorCode);
+		_plugins[manifest.Id] = new PluginHandle(directory, manifest, state, errorCode, errorMessage);
 	}
 
 	private void InstallInboxPackages()
@@ -523,7 +720,12 @@ public sealed class PluginManager : IAsyncDisposable
 			try
 			{
 				PluginManifest manifest = _installer.InspectPackage(packagePath);
-				if (!_installer.IsVersionInstalled(manifest.Id, manifest.Version)) _installer.Install(packagePath);
+				if (!_installer.IsVersionInstalled(manifest.Id, manifest.Version))
+				{
+					bool existed = _installer.ResolveCurrentDirectory(manifest.Id) is not null;
+					_installer.Install(packagePath);
+					if (!existed) _stateStore.SetEnabled(manifest.Id, false);
+				}
 			}
 			catch (PluginException exception)
 			{
@@ -536,7 +738,7 @@ public sealed class PluginManager : IAsyncDisposable
 	{
 		foreach (PluginHandle handle in _plugins.Values)
 		{
-			if (handle.State is PluginLifecycleState.Disabled or PluginLifecycleState.Failed) continue;
+			if (handle.State is PluginLifecycleState.Disabled or PluginLifecycleState.Failed or PluginLifecycleState.PendingRestart) continue;
 			foreach (PluginDependency dependency in handle.Manifest.Dependencies)
 			{
 				if (!_plugins.TryGetValue(dependency.Id, out PluginHandle? target))
@@ -566,6 +768,15 @@ public sealed class PluginManager : IAsyncDisposable
 		}
 	}
 
+	private void EnsureNoActiveDependents(string pluginId)
+	{
+		PluginHandle? dependent = _plugins.Values.FirstOrDefault(handle =>
+			handle.State == PluginLifecycleState.Active &&
+			handle.Manifest.Dependencies.Any(dependency => !dependency.Optional && string.Equals(dependency.Id, pluginId, StringComparison.Ordinal)));
+		if (dependent is not null)
+			throw new PluginException(PluginManagementErrorCodes.DependencyInUse, $"插件仍被活动依赖使用: {dependent.Manifest.Id}");
+	}
+
 	private void Visit(PluginHandle handle, HashSet<string> visiting, HashSet<string> visited, List<PluginInfo> ordered)
 	{
 		if (visited.Contains(handle.Manifest.Id)) return;
@@ -577,7 +788,7 @@ public sealed class PluginManager : IAsyncDisposable
 		}
 		visiting.Remove(handle.Manifest.Id);
 		visited.Add(handle.Manifest.Id);
-		ordered.Add(handle.Info);
+		ordered.Add(CreateInfo(handle));
 	}
 
 	private void SetIncompatible(PluginHandle handle, string code)
@@ -585,6 +796,16 @@ public sealed class PluginManager : IAsyncDisposable
 		if (handle.State is PluginLifecycleState.Active or PluginLifecycleState.Loading) return;
 		handle.State = PluginLifecycleState.Incompatible;
 		handle.ErrorCode = code;
+		handle.ErrorMessage = FriendlyMessage(code);
+	}
+
+	private (bool Compatible, string? ErrorCode) Compatibility(PluginManifest manifest)
+	{
+		if (!PluginManifestReader.IsPlatformSupported(manifest.Platforms)) return (false, PluginErrorCodes.UnsupportedPlatform);
+		if (!PluginManifestReader.IsCompatible(_options.HostApiVersion, manifest.Api)) return (false, PluginErrorCodes.IncompatibleApi);
+		if (!_options.DevelopmentHost && !PluginManifestReader.IsHostVersionSupported(_options.HostVersion, manifest.MinHostVersion)) return (false, PluginErrorCodes.IncompatibleHost);
+		if (manifest.Capabilities.Any(capability => !_options.KnownCapabilityIds.Contains(capability, StringComparer.Ordinal))) return (false, PluginErrorCodes.UnknownCapability);
+		return (true, null);
 	}
 
 	private void RecordStartupFailure(PluginHandle handle)
@@ -594,12 +815,99 @@ public sealed class PluginManager : IAsyncDisposable
 		{
 			handle.State = PluginLifecycleState.Disabled;
 			handle.ErrorCode = PluginErrorCodes.StartupRecoveryDisabled;
+			handle.ErrorMessage = "插件因连续启动失败被保护性禁用";
 		}
 	}
 
-	private void ClearStartupFailure(string pluginId)
+	private void ClearStartupFailure(string pluginId) => _startupRecovery.Clear(pluginId);
+
+	private void CompletePendingUninstalls()
 	{
-		_startupRecovery.Clear(pluginId);
+		foreach ((string pluginId, bool deleteData) in _stateStore.PendingUninstalls())
+		{
+			try
+			{
+				_installer.Uninstall(pluginId);
+				if (deleteData) DeletePluginData(pluginId);
+				_startupRecovery.Clear(pluginId);
+				_stateStore.Remove(pluginId);
+				_plugins.Remove(pluginId);
+			}
+			catch (PluginException exception)
+			{
+				Report(exception);
+			}
+		}
+	}
+
+	private void DeletePluginData(string pluginId)
+	{
+		ValidatePluginId(pluginId);
+		string dataRoot = Path.GetFullPath(_options.DataDirectory);
+		string pluginData = Path.GetFullPath(Path.Combine(dataRoot, pluginId));
+		PluginPathSafety.EnsureTreeNoReparsePoints(dataRoot, pluginData, PluginErrorCodes.StorageFailed, "插件数据目录越过宿主管理边界或包含符号链接");
+		if (!Directory.Exists(pluginData)) return;
+		try { Directory.Delete(pluginData, recursive: true); }
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+		{
+			throw new PluginException(PluginErrorCodes.StorageFailed, "插件数据删除失败", exception);
+		}
+	}
+
+	private PluginInfo CreateInfo(PluginHandle handle)
+	{
+		IReadOnlyList<PluginCapabilityStatus> statuses = handle.Context?.CapabilityRegistry.Statuses ??
+			handle.Manifest.Capabilities.Concat(handle.Manifest.OptionalCapabilities)
+				.Distinct(StringComparer.Ordinal)
+				.OrderBy(id => id, StringComparer.Ordinal)
+				.Select(id => new PluginCapabilityStatus(id, true, _options.KnownCapabilityIds.Contains(id, StringComparer.Ordinal), false))
+				.ToArray();
+		return new PluginInfo(handle.Manifest.Id, handle.Manifest, handle.State, handle.ErrorCode)
+		{
+			UserEnabled = _stateStore.IsEnabled(handle.Manifest.Id),
+			ErrorMessage = handle.ErrorMessage,
+			RequiresRestart = handle.State == PluginLifecycleState.PendingRestart,
+			CapabilityStatuses = statuses,
+		};
+	}
+
+	private PluginHandle GetRequiredHandle(string pluginId)
+	{
+		if (_plugins.TryGetValue(pluginId, out PluginHandle? handle)) return handle;
+		throw new PluginException(PluginManagementErrorCodes.PluginNotFound, "插件不存在或尚未安装");
+	}
+
+	private static void ValidatePluginId(string pluginId)
+	{
+		if (!PluginManifestReader.IsValidPluginId(pluginId))
+			throw new PluginException(PluginManagementErrorCodes.InvalidPluginId, "插件 ID 无效");
+	}
+
+	private string SanitizeMessage(string? message)
+	{
+		if (string.IsNullOrWhiteSpace(message)) return "插件操作失败";
+		string sanitized = message.Replace('\r', ' ').Replace('\n', ' ')
+			.Replace(_options.PluginsDirectory, "<plugins>", StringComparison.OrdinalIgnoreCase)
+			.Replace(_options.DataDirectory, "<plugin-data>", StringComparison.OrdinalIgnoreCase);
+		while (sanitized.Contains("  ", StringComparison.Ordinal)) sanitized = sanitized.Replace("  ", " ", StringComparison.Ordinal);
+		sanitized = sanitized.Trim();
+		return sanitized.Length <= 512 ? sanitized : sanitized[..512];
+	}
+
+	private static string? FriendlyMessage(string? code) => code switch
+	{
+		PluginErrorCodes.UnsupportedPlatform => "插件不支持当前平台",
+		PluginErrorCodes.IncompatibleApi => "插件 API 与当前宿主不兼容",
+		PluginErrorCodes.IncompatibleHost => "当前 Nori 版本不满足插件要求",
+		PluginErrorCodes.UnknownCapability => "插件声明了宿主未知的必需权限",
+		PluginErrorCodes.MissingDependency => "插件缺少必需依赖",
+		_ => null,
+	};
+
+	private static bool PathsEqual(string left, string right)
+	{
+		StringComparison comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+		return Path.TrimEndingDirectorySeparator(Path.GetFullPath(left)).Equals(Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)), comparison);
 	}
 
 	private void Report(PluginException exception)
@@ -614,23 +922,24 @@ public sealed class PluginManager : IAsyncDisposable
 
 	private sealed class PluginHandle
 	{
-		public PluginHandle(string directory, PluginManifest manifest, PluginLifecycleState state, string? errorCode)
+		public PluginHandle(string directory, PluginManifest manifest, PluginLifecycleState state, string? errorCode, string? errorMessage)
 		{
 			Directory = directory;
 			Manifest = manifest;
 			State = state;
 			ErrorCode = errorCode;
+			ErrorMessage = errorMessage;
 		}
 
 		public string Directory { get; }
 		public PluginManifest Manifest { get; }
 		public PluginLifecycleState State { get; set; }
 		public string? ErrorCode { get; set; }
+		public string? ErrorMessage { get; set; }
 		public INoriPlugin? Instance { get; set; }
 		public PluginLoadContext? LoadContext { get; set; }
 		public PluginContext? Context { get; set; }
 		public CancellationTokenSource? StopSource { get; set; }
 		public PluginContributionRegistry Contributions { get; } = new();
-		public PluginInfo Info => new(Manifest.Id, Manifest, State, ErrorCode);
 	}
 }

--- a/app/desktop/Nori.Plugin.Runtime/PluginPackageInstaller.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginPackageInstaller.cs
@@ -114,6 +114,28 @@ public sealed class PluginPackageInstaller
 		}
 	}
 
+	/// <summary>
+	/// 删除宿主管理根下指定 manifest ID 的全部已安装版本和 current.json。
+	/// 只接受经过 manifest ID 规则校验的 ID，不接受任意路径。
+	/// </summary>
+	public void Uninstall(string id)
+	{
+		if (!PluginManifestReader.IsValidPluginId(id))
+			throw new PluginException(PluginErrorCodes.InvalidManifest, "插件 ID 无效");
+
+		string pluginDirectory = Path.GetFullPath(CurrentDirectory(id));
+		PluginPathSafety.EnsureTreeNoReparsePoints(_root, pluginDirectory, PluginErrorCodes.PackagePathDenied, "插件卸载目录越过宿主管理边界或包含符号链接");
+		if (!Directory.Exists(pluginDirectory)) return;
+		try
+		{
+			Directory.Delete(pluginDirectory, recursive: true);
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+		{
+			throw new PluginException(PluginErrorCodes.UnloadPendingRestart, "插件文件当前无法删除，需要重启后完成卸载", exception);
+		}
+	}
+
 	/// <summary>读取插件的 current.json 并返回对应的版本目录。</summary>
 	public string? ResolveCurrentDirectory(string id)
 	{

--- a/app/desktop/Nori.Plugin.Runtime/PluginPathSafety.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginPathSafety.cs
@@ -79,6 +79,34 @@ internal static class PluginPathSafety
 		}
 	}
 
+	/// <summary>扫描宿主管理目录树，拒绝任何链接或 reparse point。</summary>
+	public static void EnsureTreeNoReparsePoints(string trustedRoot, string path, string errorCode, string message)
+	{
+		string root = FullPath(trustedRoot);
+		string target = FullPath(path);
+		if (!IsSameOrWithin(root, target)) throw new PluginException(errorCode, message);
+		EnsureNoReparsePoints(root, target, errorCode, message);
+		if (!Directory.Exists(target)) return;
+
+		Stack<string> directories = new();
+		directories.Push(target);
+		while (directories.Count > 0)
+		{
+			string directory = directories.Pop();
+			foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
+			{
+				EnsureNoReparsePoint(entry, errorCode, message);
+				FileAttributes attributes;
+				try { attributes = File.GetAttributes(entry); }
+				catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+				{
+					throw new PluginException(errorCode, message, exception);
+				}
+				if ((attributes & FileAttributes.Directory) != 0) directories.Push(entry);
+			}
+		}
+	}
+
 	public static IReadOnlyList<string> EnumerateDllFilesWithoutReparsePoints(string root, string errorCode, string message)
 	{
 		string canonicalRoot = FullPath(root);

--- a/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Nori.Plugin.Abstractions;
 
 namespace Nori.Plugin.Runtime;
 

--- a/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
@@ -1,0 +1,149 @@
+using System.Text.Json;
+
+namespace Nori.Plugin.Runtime;
+
+/// <summary>持久化用户对插件的启用意图与需要重启后完成的卸载请求。</summary>
+internal sealed class PluginStateStore
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		WriteIndented = true,
+	};
+
+	private readonly object _gate = new();
+	private readonly string _path;
+	private Dictionary<string, PluginRuntimeState> _states;
+
+	public PluginStateStore(string path)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(path);
+		_path = Path.GetFullPath(path);
+		Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+		_states = Load(_path);
+	}
+
+	/// <summary>既有插件没有记录时保持 1.0 兼容语义，默认视为启用。</summary>
+	public bool IsEnabled(string pluginId)
+	{
+		ValidateId(pluginId);
+		lock (_gate)
+			return !_states.TryGetValue(pluginId, out PluginRuntimeState? state) || state.Enabled;
+	}
+
+	public void SetEnabled(string pluginId, bool enabled)
+	{
+		ValidateId(pluginId);
+		lock (_gate)
+		{
+			_states.TryGetValue(pluginId, out PluginRuntimeState? previous);
+			_states[pluginId] = (previous ?? new PluginRuntimeState()) with { Enabled = enabled };
+			Persist();
+		}
+	}
+
+	public void SetPendingUninstall(string pluginId, bool deleteData)
+	{
+		ValidateId(pluginId);
+		lock (_gate)
+		{
+			_states.TryGetValue(pluginId, out PluginRuntimeState? previous);
+			_states[pluginId] = (previous ?? new PluginRuntimeState()) with
+			{
+				Enabled = false,
+				PendingUninstall = true,
+				DeleteData = deleteData,
+			};
+			Persist();
+		}
+	}
+
+	public bool TryGetPendingUninstall(string pluginId, out bool deleteData)
+	{
+		ValidateId(pluginId);
+		lock (_gate)
+		{
+			if (_states.TryGetValue(pluginId, out PluginRuntimeState? state) && state.PendingUninstall)
+			{
+				deleteData = state.DeleteData;
+				return true;
+			}
+		}
+		deleteData = false;
+		return false;
+	}
+
+	public IReadOnlyList<(string PluginId, bool DeleteData)> PendingUninstalls()
+	{
+		lock (_gate)
+		{
+			return _states
+				.Where(pair => pair.Value.PendingUninstall && PluginManifestReader.IsValidPluginId(pair.Key))
+				.OrderBy(pair => pair.Key, StringComparer.Ordinal)
+				.Select(pair => (pair.Key, pair.Value.DeleteData))
+				.ToArray();
+		}
+	}
+
+	public void ClearPendingUninstall(string pluginId)
+	{
+		ValidateId(pluginId);
+		lock (_gate)
+		{
+			if (!_states.TryGetValue(pluginId, out PluginRuntimeState? state) || !state.PendingUninstall) return;
+			_states[pluginId] = state with { PendingUninstall = false, DeleteData = false };
+			Persist();
+		}
+	}
+
+	public void Remove(string pluginId)
+	{
+		ValidateId(pluginId);
+		lock (_gate)
+		{
+			if (!_states.Remove(pluginId)) return;
+			Persist();
+		}
+	}
+
+	private void Persist()
+	{
+		string temporary = _path + ".tmp-" + Guid.NewGuid().ToString("N");
+		try
+		{
+			File.WriteAllText(temporary, JsonSerializer.Serialize(_states, JsonOptions));
+			File.Move(temporary, _path, true);
+		}
+		finally
+		{
+			try { if (File.Exists(temporary)) File.Delete(temporary); } catch { }
+		}
+	}
+
+	private static Dictionary<string, PluginRuntimeState> Load(string path)
+	{
+		if (!File.Exists(path)) return new(StringComparer.Ordinal);
+		try
+		{
+			Dictionary<string, PluginRuntimeState>? states = JsonSerializer.Deserialize<Dictionary<string, PluginRuntimeState>>(File.ReadAllText(path), JsonOptions);
+			return states is null ? new(StringComparer.Ordinal) : new(states, StringComparer.Ordinal);
+		}
+		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+		{
+			return new(StringComparer.Ordinal);
+		}
+	}
+
+	private static void ValidateId(string pluginId)
+	{
+		if (!PluginManifestReader.IsValidPluginId(pluginId))
+			throw new PluginException(PluginErrorCodes.InvalidManifest, "插件 ID 无效");
+	}
+
+	private sealed record PluginRuntimeState
+	{
+		public bool Enabled { get; init; } = true;
+		public bool PendingUninstall { get; init; }
+		public bool DeleteData { get; init; }
+	}
+}

--- a/app/desktop/src/components/settings/PluginsSettings.vue
+++ b/app/desktop/src/components/settings/PluginsSettings.vue
@@ -1,0 +1,320 @@
+<script setup lang="ts">
+import {computed, onMounted, ref} from "vue"
+import Icon from "../Icon.vue"
+import AppButton from "../ui/AppButton.vue"
+import AppChip from "../ui/AppChip.vue"
+import AppModal from "../ui/AppModal.vue"
+import AppSectionHeader from "../ui/AppSectionHeader.vue"
+import {feedback} from "../../services/feedback"
+import usePluginLanguages from "../../services/i18n/usePluginLanguages"
+import {RUNTIME} from "../../services/runtime"
+import {
+	disablePlugin,
+	enablePlugin,
+	installLocalPlugin,
+	listPlugins,
+	uninstallPlugin,
+	type PluginInfo,
+	type PluginState,
+} from "../../services/plugins"
+
+const I18N = computed(() => usePluginLanguages().plugins)
+const plugins = ref<PluginInfo[]>([])
+const loading = ref(false)
+const busyId = ref<string | null>(null)
+const riskModal = ref(false)
+const detailPlugin = ref<PluginInfo | null>(null)
+const uninstallTarget = ref<PluginInfo | null>(null)
+const deleteData = ref(false)
+
+const TRUST_KEY = "nori.plugins.trusted-in-process-warning.v1"
+const safeMode = computed(() => RUNTIME.snapshot.value?.app.safeMode === true)
+
+const statusLabel = (state: PluginState): string => I18N.value.status[state]
+const isBusy = (plugin: PluginInfo): boolean =>
+	busyId.value === plugin.id || plugin.state === "loading" || plugin.state === "stopping"
+
+const replacePlugin = (next: PluginInfo): void => {
+	const index = plugins.value.findIndex(item => item.id === next.id)
+	if (index < 0) plugins.value.push(next)
+	else plugins.value[index] = next
+	plugins.value = [...plugins.value].sort((left, right) => left.name.localeCompare(right.name))
+}
+
+const refresh = async (): Promise<void> => {
+	loading.value = true
+	try {
+		plugins.value = await listPlugins()
+	} catch (error) {
+		feedback.error(I18N.value.error.load, error)
+	} finally {
+		loading.value = false
+	}
+}
+
+const executeInstall = async (): Promise<void> => {
+	loading.value = true
+	try {
+		const result = await installLocalPlugin()
+		if (!result.cancelled && result.plugin) replacePlugin(result.plugin)
+	} catch (error) {
+		feedback.error(I18N.value.error.install, error)
+	} finally {
+		loading.value = false
+	}
+}
+
+const beginInstall = (): void => {
+	if (safeMode.value) return
+	if (localStorage.getItem(TRUST_KEY) === "1") {
+		void executeInstall()
+		return
+	}
+	riskModal.value = true
+}
+
+const confirmRisk = (): void => {
+	localStorage.setItem(TRUST_KEY, "1")
+	riskModal.value = false
+	void executeInstall()
+}
+
+const enable = async (plugin: PluginInfo): Promise<void> => {
+	if (safeMode.value || isBusy(plugin)) return
+	busyId.value = plugin.id
+	try {
+		replacePlugin(await enablePlugin(plugin.id))
+	} catch (error) {
+		feedback.error(I18N.value.error.enable, error)
+	} finally {
+		busyId.value = null
+	}
+}
+
+const disable = async (plugin: PluginInfo): Promise<void> => {
+	if (isBusy(plugin)) return
+	busyId.value = plugin.id
+	try {
+		replacePlugin(await disablePlugin(plugin.id))
+	} catch (error) {
+		feedback.error(I18N.value.error.disable, error)
+	} finally {
+		busyId.value = null
+	}
+}
+
+const beginUninstall = (plugin: PluginInfo): void => {
+	deleteData.value = false
+	uninstallTarget.value = plugin
+}
+
+const confirmUninstall = async (): Promise<void> => {
+	const target = uninstallTarget.value
+	if (!target) return
+	busyId.value = target.id
+	try {
+		const result = await uninstallPlugin(target.id, deleteData.value)
+		if (result.plugin) replacePlugin(result.plugin)
+		else plugins.value = plugins.value.filter(item => item.id !== target.id)
+		uninstallTarget.value = null
+		deleteData.value = false
+	} catch (error) {
+		feedback.error(I18N.value.error.uninstall, error)
+	} finally {
+		busyId.value = null
+	}
+}
+
+const capabilityLabel = (plugin: PluginInfo, id: string): string => {
+	const status = plugin.capabilityStatuses.find(item => item.id === id)
+	if (!status?.declared) return I18N.value.permissions.undeclared
+	if (!status.granted) return I18N.value.permissions.unavailable
+	return status.available ? I18N.value.permissions.granted : I18N.value.permissions.unavailable
+}
+
+onMounted(async () => {
+	try { await RUNTIME.init() } catch { }
+	await refresh()
+})
+</script>
+
+<template>
+	<div class="w-full h-full flex flex-col gap-4 px-6 py-4 scroll-area">
+		<AppSectionHeader :title="I18N.title" :subtitle="I18N.subtitle">
+			<template #actions>
+				<AppButton
+					v-if="!safeMode"
+					variant="primary"
+					size="sm"
+					icon="upload"
+					:loading="loading"
+					@click="beginInstall"
+				>{{ I18N.action.install }}</AppButton>
+			</template>
+		</AppSectionHeader>
+
+		<div v-if="safeMode" class="surface-card border border-line-subtle px-3.5 py-3 flex gap-2.5 items-start">
+			<Icon name="info" :size="17" class="text-nori-teal-bright shrink-0 mt-0.5"/>
+			<div class="min-w-0">
+				<h4 class="m-0 text-sm font-600 text-text-primary">{{ I18N.safeMode.title }}</h4>
+				<p class="m-0 mt-1 text-xs text-text-muted leading-relaxed">{{ I18N.safeMode.desc }}</p>
+			</div>
+		</div>
+
+		<div v-if="loading && plugins.length === 0" class="flex-1 flex items-center justify-center text-text-muted gap-2">
+			<Icon name="loading" :size="18" class="spin"/>
+		</div>
+
+		<div v-else-if="plugins.length === 0" class="surface-card flex-1 min-h-[14rem] flex flex-col items-center justify-center text-center gap-2 px-6">
+			<Icon name="package" :size="30" class="text-text-faint"/>
+			<h3 class="m-0 text-base font-600 text-text-primary">{{ I18N.empty.title }}</h3>
+			<p class="m-0 max-w-[34rem] text-sm text-text-muted leading-relaxed">{{ I18N.empty.desc }}</p>
+			<AppButton v-if="!safeMode" variant="ghost" size="sm" icon="upload" @click="beginInstall">{{ I18N.action.install }}</AppButton>
+		</div>
+
+		<div v-else class="grid gap-3 grid-cols-[repeat(auto-fill,minmax(26rem,1fr))] pb-2">
+			<article
+				v-for="plugin in plugins"
+				:key="plugin.id"
+				class="surface-card flex flex-col gap-3 px-3.5 py-3 border border-line-subtle"
+			>
+				<div class="flex items-start justify-between gap-3">
+					<div class="flex gap-2.5 min-w-0">
+						<div class="w-10 h-10 shrink-0 rounded-sm bg-nori-teal-bright/10 text-nori-teal-bright flex items-center justify-center overflow-hidden">
+							<img v-if="plugin.iconUrl" :src="plugin.iconUrl" :alt="plugin.name" class="w-full h-full object-cover"/>
+							<Icon v-else name="plug" :size="20"/>
+						</div>
+						<div class="min-w-0">
+							<div class="flex items-center gap-1.5 flex-wrap">
+								<h4 class="m-0 text-base font-600 text-text-primary truncate">{{ plugin.name }}</h4>
+								<AppChip>{{ statusLabel(plugin.state) }}</AppChip>
+								<span class="text-xs text-text-faint mono">v{{ plugin.version }}</span>
+							</div>
+							<p class="m-0 mt-0.5 text-xs text-text-faint mono truncate">{{ plugin.id }}</p>
+							<p v-if="plugin.author" class="m-0 mt-0.5 text-xs text-text-faint">{{ plugin.author }}</p>
+						</div>
+					</div>
+					<Icon v-if="isBusy(plugin)" name="loading" :size="16" class="spin text-nori-teal-bright shrink-0"/>
+				</div>
+
+				<p class="m-0 text-xs text-text-muted leading-relaxed">{{ plugin.description }}</p>
+
+				<div class="flex flex-wrap gap-1.5">
+					<AppChip v-for="capability in plugin.capabilities" :key="`required:${capability}`">
+						{{ capability }} · {{ I18N.permissions.required }} · {{ capabilityLabel(plugin, capability) }}
+					</AppChip>
+					<AppChip v-for="capability in plugin.optionalCapabilities" :key="`optional:${capability}`">
+						{{ capability }} · {{ I18N.permissions.optional }} · {{ capabilityLabel(plugin, capability) }}
+					</AppChip>
+					<span v-if="plugin.capabilities.length === 0 && plugin.optionalCapabilities.length === 0" class="text-xs text-text-faint">{{ I18N.permissions.none }}</span>
+				</div>
+
+				<div v-if="plugin.errorCode || plugin.errorMessage" class="rounded-sm border border-line-subtle bg-bg-deep/45 px-2.5 py-2 text-xs">
+					<p v-if="plugin.errorCode" class="m-0 text-text-muted mono">{{ plugin.errorCode }}</p>
+					<p v-if="plugin.errorMessage" class="m-0 mt-1 text-text-faint leading-relaxed">{{ plugin.errorMessage }}</p>
+				</div>
+				<p v-if="plugin.requiresRestart || plugin.state === 'pending_restart'" class="m-0 text-xs text-nori-teal-bright">{{ I18N.restart }}</p>
+
+				<div class="mt-auto pt-1 flex items-center gap-1.5 flex-wrap">
+					<AppButton variant="ghost" size="sm" icon="info" @click="detailPlugin = plugin">{{ I18N.action.details }}</AppButton>
+					<AppButton
+						v-if="plugin.state === 'active'"
+						variant="ghost"
+						size="sm"
+						icon="power"
+						:loading="busyId === plugin.id"
+						:disabled="isBusy(plugin)"
+						@click="disable(plugin)"
+					>{{ I18N.action.disable }}</AppButton>
+					<AppButton
+						v-else-if="plugin.state === 'failed'"
+						v-show="!safeMode"
+						variant="ghost"
+						size="sm"
+						icon="refresh"
+						:loading="busyId === plugin.id"
+						:disabled="isBusy(plugin)"
+						@click="enable(plugin)"
+					>{{ I18N.action.retry }}</AppButton>
+					<AppButton
+						v-else-if="plugin.state === 'installed' || plugin.state === 'disabled'"
+						v-show="!safeMode"
+						variant="primary"
+						size="sm"
+						icon="power"
+						:loading="busyId === plugin.id"
+						:disabled="isBusy(plugin)"
+						@click="enable(plugin)"
+					>{{ I18N.action.enable }}</AppButton>
+					<AppButton
+						v-if="plugin.state === 'failed'"
+						variant="ghost"
+						size="sm"
+						icon="power"
+						:disabled="isBusy(plugin)"
+						@click="disable(plugin)"
+					>{{ I18N.action.disable }}</AppButton>
+					<AppButton
+						variant="danger"
+						size="sm"
+						icon="trash"
+						:disabled="isBusy(plugin)"
+						@click="beginUninstall(plugin)"
+					>{{ I18N.action.uninstall }}</AppButton>
+				</div>
+			</article>
+		</div>
+
+		<AppModal v-model:show="riskModal" :title="I18N.risk.title" :close-label="I18N.action.cancel" :mask-closable="false">
+			<p class="m-0 text-sm text-text-muted leading-relaxed">{{ I18N.risk.desc }}</p>
+			<template #footer>
+				<AppButton variant="ghost" @click="riskModal = false">{{ I18N.action.cancel }}</AppButton>
+				<AppButton variant="primary" icon="upload" @click="confirmRisk">{{ I18N.risk.confirm }}</AppButton>
+			</template>
+		</AppModal>
+
+		<AppModal
+			:show="uninstallTarget !== null"
+			:title="I18N.uninstall.title"
+			:close-label="I18N.action.cancel"
+			:mask-closable="false"
+			@update:show="value => { if (!value) uninstallTarget = null }"
+		>
+			<p class="m-0 text-sm text-text-muted leading-relaxed">{{ I18N.uninstall.desc }}</p>
+			<label class="surface-card flex items-start gap-2.5 px-3 py-2.5 cursor-pointer">
+				<input v-model="deleteData" type="checkbox" class="mt-0.5 accent-nori-teal-bright"/>
+				<span class="min-w-0">
+					<span class="block text-sm text-text-primary">{{ I18N.uninstall.deleteData }}</span>
+					<span class="block mt-0.5 text-xs text-text-faint leading-relaxed">{{ I18N.uninstall.deleteDataHint }}</span>
+				</span>
+			</label>
+			<template #footer>
+				<AppButton variant="ghost" @click="uninstallTarget = null">{{ I18N.action.cancel }}</AppButton>
+				<AppButton variant="danger" icon="trash" :loading="busyId === uninstallTarget?.id" @click="confirmUninstall">{{ I18N.action.uninstall }}</AppButton>
+			</template>
+		</AppModal>
+
+		<AppModal
+			:show="detailPlugin !== null"
+			:title="detailPlugin?.name"
+			:close-label="I18N.action.cancel"
+			@update:show="value => { if (!value) detailPlugin = null }"
+		>
+			<div v-if="detailPlugin" class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+				<span class="text-text-faint">{{ I18N.detail.id }}</span><span class="mono text-text-primary break-all">{{ detailPlugin.id }}</span>
+				<span class="text-text-faint">{{ I18N.detail.version }}</span><span class="text-text-primary">{{ detailPlugin.version }}</span>
+				<span class="text-text-faint">{{ I18N.detail.author }}</span><span class="text-text-primary">{{ detailPlugin.author || '—' }}</span>
+				<span class="text-text-faint">{{ I18N.detail.license }}</span><span class="text-text-primary">{{ detailPlugin.license || '—' }}</span>
+				<span class="text-text-faint">{{ I18N.detail.homepage }}</span><span class="text-text-primary break-all">{{ detailPlugin.homepage || '—' }}</span>
+				<span class="text-text-faint">{{ I18N.detail.repository }}</span><span class="text-text-primary break-all">{{ detailPlugin.repository || '—' }}</span>
+				<span class="text-text-faint">{{ I18N.permissions.title }}</span><span class="text-text-primary">{{ [...detailPlugin.capabilities, ...detailPlugin.optionalCapabilities].join(', ') || I18N.permissions.none }}</span>
+				<template v-if="detailPlugin.errorCode || detailPlugin.errorMessage">
+					<span class="text-text-faint">{{ I18N.detail.error }}</span><span class="text-text-primary break-all">{{ [detailPlugin.errorCode, detailPlugin.errorMessage].filter(Boolean).join(' · ') }}</span>
+				</template>
+			</div>
+			<template #footer>
+				<AppButton variant="primary" @click="detailPlugin = null">{{ I18N.action.confirm }}</AppButton>
+			</template>
+		</AppModal>
+	</div>
+</template>

--- a/app/desktop/src/components/settings/SettingsPanel.vue
+++ b/app/desktop/src/components/settings/SettingsPanel.vue
@@ -9,6 +9,7 @@
  */
 import {computed, ref, watch} from "vue"
 import useLanguages from "../../services/i18n/useLanguages.ts"
+import usePluginLanguages from "../../services/i18n/usePluginLanguages"
 import Icon from "../Icon.vue"
 import AppSearchField from "../ui/AppSearchField.vue"
 import type {IconName} from "../../services/icon"
@@ -19,12 +20,13 @@ import ProactiveSettings from "./ProactiveSettings.vue"
 import SkillsSettings from "./SkillsSettings.vue"
 import McpSettings from "./McpSettings.vue"
 import AutomationSettings from "./AutomationSettings.vue"
+import PluginsSettings from "./PluginsSettings.vue"
 import GeneralSettings from "./GeneralSettings.vue"
 import DebugSettings from "./DebugSettings.vue"
 import AboutSettings from "./AboutSettings.vue"
 
 /** 二级页 key, 同时是它在语言包 `views.main` 下的子树名 (搜索索引靠这个对应) */
-type SettingsTabKey = "ai" | "voice" | "proactive" | "skills" | "mcp" | "automation" | "general" | "debug" | "about"
+type SettingsTabKey = "ai" | "voice" | "proactive" | "skills" | "mcp" | "automation" | "plugins" | "general" | "debug" | "about"
 
 const props = withDefaults(defineProps<{
 	/** 打开时直达的子页 (主页磁贴跳转用) */
@@ -37,6 +39,7 @@ const props = withDefaults(defineProps<{
 })
 
 const I18N = computed(() => useLanguages().views.main.settingsTabs)
+const PLUGIN_I18N = computed(() => usePluginLanguages())
 const GROUP_I18N = computed(() => useLanguages().views.main.settingsGroups)
 const SEARCH_I18N = computed(() => useLanguages().views.main.settingsSearch)
 
@@ -81,6 +84,7 @@ const TAB_GROUPS = computed<TabGroup[]>(() => [
 			{key: "skills", label: I18N.value.skills, icon: "sparkles"},
 			{key: "mcp", label: I18N.value.mcp, icon: "plug"},
 			{key: "automation", label: I18N.value.automation, icon: "bot"},
+			{key: "plugins", label: PLUGIN_I18N.value.settingsTab, icon: "plug"},
 		],
 	},
 	{
@@ -235,6 +239,7 @@ const onListKeydown = (event: KeyboardEvent) => {
 					<SkillsSettings v-else-if="currentTab === 'skills'"/>
 					<McpSettings v-else-if="currentTab === 'mcp'"/>
 					<AutomationSettings v-else-if="currentTab === 'automation'"/>
+					<PluginsSettings v-else-if="currentTab === 'plugins'"/>
 					<GeneralSettings v-else-if="currentTab === 'general'"/>
 					<DebugSettings v-else-if="currentTab === 'debug'"/>
 					<AboutSettings v-else/>

--- a/app/desktop/src/services/host/commands.ts
+++ b/app/desktop/src/services/host/commands.ts
@@ -23,6 +23,7 @@ import type {
 	UiSnapshot,
 	VisionProbeResult,
 } from "../runtime/types"
+import type {PluginInfo, PluginInstallResult, PluginUninstallResult} from "../plugins"
 
 export type CommandArgs = Record<string, unknown>
 export type EmptyCommandArgs = undefined
@@ -135,6 +136,12 @@ export interface BridgeCommandMap {
 	mcp_call_tool: {args: {serverId: string; toolName: string; arguments: CommandArgs}; result: unknown}
 	mcp_import_url: {args: {url: string}; result: unknown}
 
+	plugin_list: {args: EmptyCommandArgs; result: {plugins: PluginInfo[]}}
+	plugin_install_local: {args: EmptyCommandArgs; result: PluginInstallResult}
+	plugin_enable: {args: {id: string}; result: PluginInfo}
+	plugin_disable: {args: {id: string}; result: PluginInfo}
+	plugin_uninstall: {args: {id: string; deleteData: boolean}; result: PluginUninstallResult}
+
 	reminder_add: {args: {content: string; delayMinutes: number}; result: unknown}
 	reminder_cancel: {args: {id: string}; result: boolean}
 	tts_test: {args: {text?: string}; result: void}
@@ -146,8 +153,8 @@ export interface BridgeCommandMap {
 	audio_playback_finished: {args: {token: string; error?: string}; result: void}
 	audio_level: {args: {level: number}; result: void}
 	audio_record_ready: {args: {token: string}; result: void}
-	audio_record_failed: {args: {token: string; error?: string}; result: void}
-	audio_upload_failed: {args: {token: string; error?: string}; result: void}
+	audio_record_failed: {args: {token: string; error: string}; result: void}
+	audio_upload_failed: {args: {token: string; error: string}; result: void}
 
 	window_show: {args: {label: string}; result: void}
 	window_hide: {args: {label: string}; result: void}

--- a/app/desktop/src/services/host/commands.ts
+++ b/app/desktop/src/services/host/commands.ts
@@ -153,8 +153,8 @@ export interface BridgeCommandMap {
 	audio_playback_finished: {args: {token: string; error?: string}; result: void}
 	audio_level: {args: {level: number}; result: void}
 	audio_record_ready: {args: {token: string}; result: void}
-	audio_record_failed: {args: {token: string; error: string}; result: void}
-	audio_upload_failed: {args: {token: string; error: string}; result: void}
+	audio_record_failed: {args: {token: string; error?: string}; result: void}
+	audio_upload_failed: {args: {token: string; error?: string}; result: void}
 
 	window_show: {args: {label: string}; result: void}
 	window_hide: {args: {label: string}; result: void}

--- a/app/desktop/src/services/i18n/index.ts
+++ b/app/desktop/src/services/i18n/index.ts
@@ -1,5 +1,6 @@
 import {createI18n} from "vue-i18n"
 import useLanguages from "./useLanguages.ts"
+import {mergePluginMessages} from "./pluginMessages"
 
 /**
  * 语言类型
@@ -48,7 +49,7 @@ const useLanguage = {
 			const LOADER = this.getLoader(lang)
 			if (LOADER) {
 				const MODULE = await LOADER()
-				i18n.global.setLocaleMessage(lang, MODULE.default)
+				i18n.global.setLocaleMessage(lang, mergePluginMessages(lang, MODULE.default))
 			}
 		}
 		i18n.global.locale.value = lang

--- a/app/desktop/src/services/i18n/pluginMessages.ts
+++ b/app/desktop/src/services/i18n/pluginMessages.ts
@@ -1,0 +1,93 @@
+export interface PluginSettingsMessages {
+	settingsTabs: {plugins: string}
+	plugins: {
+		title: string
+		subtitle: string
+		action: {
+			install: string
+			enable: string
+			disable: string
+			retry: string
+			uninstall: string
+			details: string
+			cancel: string
+			confirm: string
+		}
+		empty: {title: string; desc: string}
+		status: Record<string, string>
+		permissions: {
+			title: string
+			required: string
+			optional: string
+			granted: string
+			unavailable: string
+			undeclared: string
+			none: string
+		}
+		risk: {title: string; desc: string; confirm: string}
+		uninstall: {title: string; desc: string; deleteData: string; deleteDataHint: string}
+		safeMode: {title: string; desc: string}
+		restart: string
+		error: {load: string; install: string; enable: string; disable: string; uninstall: string}
+		detail: {id: string; version: string; author: string; license: string; homepage: string; repository: string; error: string}
+		search: {plugin: string; extension: string; install: string; package: string}
+	}
+}
+
+export const PLUGIN_MESSAGES: Record<"zh-CN" | "en-US", PluginSettingsMessages> = {
+	"zh-CN": {
+		settingsTabs: {plugins: "插件"},
+		plugins: {
+			title: "插件管理",
+			subtitle: "管理本地插件、扩展、权限状态与 .noripack 安装包。第三方插件在 Nori 进程内运行，仅启用可信来源。",
+			action: {install: "安装本地插件", enable: "启用", disable: "禁用", retry: "重试启用", uninstall: "卸载", details: "详情", cancel: "取消", confirm: "确认"},
+			empty: {title: "还没有安装插件", desc: "可以从本地 .noripack 安装扩展。新安装的插件默认保持禁用，确认后再手动启用。"},
+			status: {installed: "已安装", loading: "正在加载", active: "已启用", stopping: "正在停用", disabled: "已禁用", failed: "启动失败", incompatible: "不兼容", pending_restart: "等待重启"},
+			permissions: {title: "权限", required: "必需", optional: "可选", granted: "已授权", unavailable: "当前不可用", undeclared: "未声明", none: "未声明插件权限"},
+			risk: {title: "信任本地插件", desc: "Nori 插件是受信任的进程内代码。启用后，它会在 Nori 进程中执行。仅安装你信任来源提供的 .noripack。", confirm: "我了解风险，继续选择文件"},
+			uninstall: {title: "卸载插件", desc: "插件程序文件会被删除。默认保留插件数据，方便之后重新安装。", deleteData: "同时删除插件数据", deleteDataHint: "开启后会删除该插件自己的数据目录，此操作无法撤销。"},
+			safeMode: {title: "安全模式", desc: "安全模式允许查看、禁用和卸载插件，安装与启用功能暂时关闭。"},
+			restart: "需要重启 Nori 后完成当前操作。",
+			error: {load: "插件列表加载失败", install: "插件安装失败", enable: "插件启用失败", disable: "插件禁用失败", uninstall: "插件卸载失败"},
+			detail: {id: "插件 ID", version: "版本", author: "作者", license: "许可证", homepage: "主页", repository: "代码仓库", error: "错误"},
+			search: {plugin: "插件", extension: "扩展", install: "安装", package: "noripack"},
+		},
+	},
+	"en-US": {
+		settingsTabs: {plugins: "Plugins"},
+		plugins: {
+			title: "Plugin management",
+			subtitle: "Manage local plugins, extensions, capability status, and .noripack packages. Third-party plugins run in the Nori process, so only enable trusted sources.",
+			action: {install: "Install local plugin", enable: "Enable", disable: "Disable", retry: "Retry enable", uninstall: "Uninstall", details: "Details", cancel: "Cancel", confirm: "Confirm"},
+			empty: {title: "No plugins installed", desc: "Install extensions from a local .noripack. Newly installed plugins stay disabled until you explicitly enable them."},
+			status: {installed: "Installed", loading: "Loading", active: "Enabled", stopping: "Stopping", disabled: "Disabled", failed: "Startup failed", incompatible: "Incompatible", pending_restart: "Restart pending"},
+			permissions: {title: "Capabilities", required: "Required", optional: "Optional", granted: "Granted", unavailable: "Unavailable", undeclared: "Not declared", none: "No plugin capabilities declared"},
+			risk: {title: "Trust local plugins", desc: "Nori plugins are trusted in-process code. Once enabled, they execute inside the Nori process. Only install .noripack files from sources you trust.", confirm: "I understand the risk and want to choose a file"},
+			uninstall: {title: "Uninstall plugin", desc: "Plugin program files will be removed. Plugin data is kept by default so it can be reused after reinstalling.", deleteData: "Also delete plugin data", deleteDataHint: "When enabled, this deletes only this plugin's data directory and cannot be undone."},
+			safeMode: {title: "Safe Mode", desc: "Safe Mode allows viewing, disabling, and uninstalling plugins. Install and enable actions are unavailable."},
+			restart: "Restart Nori to finish this operation.",
+			error: {load: "Failed to load plugins", install: "Plugin installation failed", enable: "Failed to enable plugin", disable: "Failed to disable plugin", uninstall: "Failed to uninstall plugin"},
+			detail: {id: "Plugin ID", version: "Version", author: "Author", license: "License", homepage: "Homepage", repository: "Repository", error: "Error"},
+			search: {plugin: "plugin", extension: "extension", install: "install", package: "noripack"},
+		},
+	},
+}
+
+export const mergePluginMessages = (locale: string, source: any): any => {
+	const additions = PLUGIN_MESSAGES[locale as "zh-CN" | "en-US"]
+	if (!additions) return source
+	return {
+		...source,
+		views: {
+			...(source?.views ?? {}),
+			main: {
+				...(source?.views?.main ?? {}),
+				settingsTabs: {
+					...(source?.views?.main?.settingsTabs ?? {}),
+					plugins: additions.settingsTabs.plugins,
+				},
+				plugins: additions.plugins,
+			},
+		},
+	}
+}

--- a/app/desktop/src/services/i18n/usePluginLanguages.ts
+++ b/app/desktop/src/services/i18n/usePluginLanguages.ts
@@ -1,0 +1,77 @@
+import {i18n} from "./index"
+
+export default () => {
+	const t = i18n.global.t
+	return {
+		settingsTab: t("views.main.settingsTabs.plugins"),
+		plugins: {
+			title: t("views.main.plugins.title"),
+			subtitle: t("views.main.plugins.subtitle"),
+			action: {
+				install: t("views.main.plugins.action.install"),
+				enable: t("views.main.plugins.action.enable"),
+				disable: t("views.main.plugins.action.disable"),
+				retry: t("views.main.plugins.action.retry"),
+				uninstall: t("views.main.plugins.action.uninstall"),
+				details: t("views.main.plugins.action.details"),
+				cancel: t("views.main.plugins.action.cancel"),
+				confirm: t("views.main.plugins.action.confirm"),
+			},
+			empty: {
+				title: t("views.main.plugins.empty.title"),
+				desc: t("views.main.plugins.empty.desc"),
+			},
+			status: {
+				installed: t("views.main.plugins.status.installed"),
+				loading: t("views.main.plugins.status.loading"),
+				active: t("views.main.plugins.status.active"),
+				stopping: t("views.main.plugins.status.stopping"),
+				disabled: t("views.main.plugins.status.disabled"),
+				failed: t("views.main.plugins.status.failed"),
+				incompatible: t("views.main.plugins.status.incompatible"),
+				pending_restart: t("views.main.plugins.status.pending_restart"),
+			},
+			permissions: {
+				title: t("views.main.plugins.permissions.title"),
+				required: t("views.main.plugins.permissions.required"),
+				optional: t("views.main.plugins.permissions.optional"),
+				granted: t("views.main.plugins.permissions.granted"),
+				unavailable: t("views.main.plugins.permissions.unavailable"),
+				undeclared: t("views.main.plugins.permissions.undeclared"),
+				none: t("views.main.plugins.permissions.none"),
+			},
+			risk: {
+				title: t("views.main.plugins.risk.title"),
+				desc: t("views.main.plugins.risk.desc"),
+				confirm: t("views.main.plugins.risk.confirm"),
+			},
+			uninstall: {
+				title: t("views.main.plugins.uninstall.title"),
+				desc: t("views.main.plugins.uninstall.desc"),
+				deleteData: t("views.main.plugins.uninstall.deleteData"),
+				deleteDataHint: t("views.main.plugins.uninstall.deleteDataHint"),
+			},
+			safeMode: {
+				title: t("views.main.plugins.safeMode.title"),
+				desc: t("views.main.plugins.safeMode.desc"),
+			},
+			restart: t("views.main.plugins.restart"),
+			error: {
+				load: t("views.main.plugins.error.load"),
+				install: t("views.main.plugins.error.install"),
+				enable: t("views.main.plugins.error.enable"),
+				disable: t("views.main.plugins.error.disable"),
+				uninstall: t("views.main.plugins.error.uninstall"),
+			},
+			detail: {
+				id: t("views.main.plugins.detail.id"),
+				version: t("views.main.plugins.detail.version"),
+				author: t("views.main.plugins.detail.author"),
+				license: t("views.main.plugins.detail.license"),
+				homepage: t("views.main.plugins.detail.homepage"),
+				repository: t("views.main.plugins.detail.repository"),
+				error: t("views.main.plugins.detail.error"),
+			},
+		},
+	}
+}

--- a/app/desktop/src/services/plugins/index.ts
+++ b/app/desktop/src/services/plugins/index.ts
@@ -1,0 +1,64 @@
+import {invoke} from "../host/invoke"
+
+export type PluginState =
+	| "installed"
+	| "loading"
+	| "active"
+	| "stopping"
+	| "disabled"
+	| "failed"
+	| "incompatible"
+	| "pending_restart"
+
+export interface PluginCapabilityStatus {
+	id: string
+	declared: boolean
+	granted: boolean
+	available: boolean
+}
+
+export interface PluginInfo {
+	id: string
+	name: string
+	description: string
+	version: string
+	author: string
+	homepage: string | null
+	repository: string | null
+	license: string | null
+	state: PluginState
+	enabled: boolean
+	capabilities: string[]
+	optionalCapabilities: string[]
+	capabilityStatuses: PluginCapabilityStatus[]
+	errorCode: string | null
+	errorMessage: string | null
+	requiresRestart: boolean
+	iconUrl: string | null
+}
+
+export interface PluginInstallResult {
+	cancelled: boolean
+	plugin: PluginInfo | null
+}
+
+export interface PluginUninstallResult {
+	success: boolean
+	requiresRestart: boolean
+	plugin: PluginInfo | null
+}
+
+export const listPlugins = async (): Promise<PluginInfo[]> =>
+	(await invoke("plugin_list")).plugins
+
+export const installLocalPlugin = async (): Promise<PluginInstallResult> =>
+	invoke("plugin_install_local")
+
+export const enablePlugin = async (id: string): Promise<PluginInfo> =>
+	invoke("plugin_enable", {id})
+
+export const disablePlugin = async (id: string): Promise<PluginInfo> =>
+	invoke("plugin_disable", {id})
+
+export const uninstallPlugin = async (id: string, deleteData = false): Promise<PluginUninstallResult> =>
+	invoke("plugin_uninstall", {id, deleteData})

--- a/app/desktop/tests/settings/plugins.test.ts
+++ b/app/desktop/tests/settings/plugins.test.ts
@@ -1,0 +1,165 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+import {createApp, h, nextTick} from "vue"
+import ZH from "../../src/services/i18n/locales/zh-CN"
+import {i18n} from "../../src/services/i18n"
+import {mergePluginMessages} from "../../src/services/i18n/pluginMessages"
+import {RUNTIME} from "../../src/services/runtime"
+import PluginsSettings from "../../src/components/settings/PluginsSettings.vue"
+import type {PluginInfo} from "../../src/services/plugins"
+
+const plugin = (state: PluginInfo["state"], overrides: Partial<PluginInfo> = {}): PluginInfo => ({
+	id: "io.nori.test",
+	name: "Test Plugin",
+	description: "A test plugin extension",
+	version: "1.2.3",
+	author: "Nori",
+	homepage: null,
+	repository: null,
+	license: "MIT",
+	state,
+	enabled: state === "active",
+	capabilities: ["ui.webview"],
+	optionalCapabilities: [],
+	capabilityStatuses: [{id: "ui.webview", declared: true, granted: true, available: state === "active"}],
+	errorCode: state === "failed" ? "plugin.activation_failed" : null,
+	errorMessage: state === "failed" ? "Activation failed" : null,
+	requiresRestart: state === "pending_restart",
+	iconUrl: null,
+	...overrides,
+})
+
+const settle = async (): Promise<void> => {
+	for (let index = 0; index < 4; index += 1) await nextTick()
+	await new Promise<void>(resolve => setTimeout(resolve, 0))
+	await nextTick()
+}
+
+const mount = () => {
+	const container = document.createElement("div")
+	document.body.appendChild(container)
+	const app = createApp({render: () => h(PluginsSettings)})
+	app.use(i18n)
+	app.mount(container)
+	return {app, container}
+}
+
+const button = (root: ParentNode, text: string): HTMLButtonElement => {
+	const found = Array.from(root.querySelectorAll("button")).find(item => item.textContent?.includes(text))
+	if (!(found instanceof HTMLButtonElement)) throw new Error(`button not found: ${text}`)
+	return found
+}
+
+describe("PluginsSettings.vue", () => {
+	beforeEach(() => {
+		vi.restoreAllMocks()
+		localStorage.clear()
+		document.body.innerHTML = ""
+		i18n.global.setLocaleMessage("zh-CN", mergePluginMessages("zh-CN", ZH))
+		i18n.global.locale.value = "zh-CN"
+		RUNTIME.snapshot.value = {app: {safeMode: false}} as any
+		vi.spyOn(RUNTIME, "init").mockResolvedValue()
+	})
+
+	it("renders empty state and opens picker only after first trust confirmation", async () => {
+		const invoked: string[] = []
+		;(window as any).__nori = {
+			assetBase: "/nori-assets/",
+			label: "main",
+			invoke: async (cmd: string) => {
+				invoked.push(cmd)
+				if (cmd === "plugin_list") return {plugins: []}
+				if (cmd === "plugin_install_local") return {cancelled: true, plugin: null}
+				return null
+			},
+			emit: () => {}, listen: () => () => {}, dispatch: () => {},
+		}
+
+		const view = mount()
+		try {
+			await settle()
+			expect(view.container.textContent).toContain("还没有安装插件")
+			button(view.container, "安装本地插件").click()
+			await settle()
+			expect(invoked.filter(cmd => cmd === "plugin_install_local")).toHaveLength(0)
+			expect(document.body.textContent).toContain("信任本地插件")
+			button(document.body, "我了解风险").click()
+			await settle()
+			expect(invoked.filter(cmd => cmd === "plugin_install_local")).toHaveLength(1)
+		} finally {
+			view.app.unmount()
+			view.container.remove()
+		}
+	})
+
+	it("renders lifecycle states and uses returned DTO for enable and disable", async () => {
+		let items = [
+			plugin("active"),
+			plugin("disabled", {id: "io.nori.disabled", name: "Disabled Plugin", enabled: false}),
+			plugin("failed", {id: "io.nori.failed", name: "Failed Plugin", enabled: true}),
+			plugin("pending_restart", {id: "io.nori.restart", name: "Restart Plugin", enabled: false}),
+		]
+		const calls: {cmd: string; args: any}[] = []
+		;(window as any).__nori = {
+			assetBase: "/nori-assets/", label: "main",
+			invoke: async (cmd: string, args: any) => {
+				calls.push({cmd, args})
+				if (cmd === "plugin_list") return {plugins: items}
+				if (cmd === "plugin_disable") return plugin("disabled", {enabled: false})
+				if (cmd === "plugin_enable") return plugin("active", {id: args.id, enabled: true})
+				return null
+			},
+			emit: () => {}, listen: () => () => {}, dispatch: () => {},
+		}
+
+		const view = mount()
+		try {
+			await settle()
+			expect(view.container.textContent).toContain("已启用")
+			expect(view.container.textContent).toContain("已禁用")
+			expect(view.container.textContent).toContain("启动失败")
+			expect(view.container.textContent).toContain("等待重启")
+			expect(view.container.textContent).toContain("需要重启 Nori")
+			button(view.container, "禁用").click()
+			await settle()
+			expect(calls.some(call => call.cmd === "plugin_disable" && call.args.id === "io.nori.test")).toBe(true)
+		} finally {
+			view.app.unmount()
+			view.container.remove()
+		}
+	})
+
+	it("passes deleteData only after uninstall confirmation and hides install in Safe Mode", async () => {
+		RUNTIME.snapshot.value = {app: {safeMode: true}} as any
+		const target = plugin("disabled", {enabled: false})
+		const calls: {cmd: string; args: any}[] = []
+		;(window as any).__nori = {
+			assetBase: "/nori-assets/", label: "main",
+			invoke: async (cmd: string, args: any) => {
+				calls.push({cmd, args})
+				if (cmd === "plugin_list") return {plugins: [target]}
+				if (cmd === "plugin_uninstall") return {success: true, requiresRestart: false, plugin: null}
+				return null
+			},
+			emit: () => {}, listen: () => () => {}, dispatch: () => {},
+		}
+
+		const view = mount()
+		try {
+			await settle()
+			expect(view.container.textContent).toContain("安全模式")
+			expect(Array.from(view.container.querySelectorAll("button")).some(item => item.textContent?.includes("安装本地插件"))).toBe(false)
+			button(view.container, "卸载").click()
+			await settle()
+			const checkbox = document.body.querySelector("input[type='checkbox']") as HTMLInputElement
+			expect(checkbox).toBeTruthy()
+			checkbox.click()
+			await nextTick()
+			button(document.body, "卸载").click()
+			await settle()
+			expect(calls.some(call => call.cmd === "plugin_uninstall" && call.args.id === target.id && call.args.deleteData === true)).toBe(true)
+		} finally {
+			view.app.unmount()
+			view.container.remove()
+		}
+	})
+})

--- a/app/desktop/tests/settings/plugins.test.ts
+++ b/app/desktop/tests/settings/plugins.test.ts
@@ -152,9 +152,12 @@ describe("PluginsSettings.vue", () => {
 			await settle()
 			const checkbox = document.body.querySelector("input[type='checkbox']") as HTMLInputElement
 			expect(checkbox).toBeTruthy()
+			const dialog = checkbox.closest("[role='dialog']") as HTMLElement
+			expect(dialog).toBeTruthy()
 			checkbox.click()
 			await nextTick()
-			button(document.body, "卸载").click()
+			expect(calls.some(call => call.cmd === "plugin_uninstall")).toBe(false)
+			button(dialog, "卸载").click()
 			await settle()
 			expect(calls.some(call => call.cmd === "plugin_uninstall" && call.args.id === target.id && call.args.deleteData === true)).toBe(true)
 		} finally {

--- a/app/desktop/tests/settings/searchIndex.test.ts
+++ b/app/desktop/tests/settings/searchIndex.test.ts
@@ -1,12 +1,14 @@
 import {describe, expect, it} from "vitest"
 import ZH from "../../src/services/i18n/locales/zh-CN"
+import {mergePluginMessages} from "../../src/services/i18n/pluginMessages"
 import {buildSettingsSearchIndex, matchSettingsEntry} from "../../src/services/settings/searchIndex"
 import type {MessageTree} from "../../src/services/settings/searchIndex"
 
-const MAIN = (ZH as unknown as {views: {main: MessageTree}}).views.main
+const MERGED_ZH = mergePluginMessages("zh-CN", ZH)
+const MAIN = (MERGED_ZH as unknown as {views: {main: MessageTree}}).views.main
 
 /** 与 SettingsPanel 一致的二级页列表 (key 即语言包子树名) */
-const TAB_KEYS = ["ai", "voice", "proactive", "skills", "mcp", "automation", "general", "debug", "about"] as const
+const TAB_KEYS = ["ai", "voice", "proactive", "skills", "mcp", "automation", "plugins", "general", "debug", "about"] as const
 
 const REAL_INDEX = buildSettingsSearchIndex(TAB_KEYS.map(key => ({key, label: key, page: MAIN[key]})))
 
@@ -60,7 +62,6 @@ describe("设置搜索索引", () => {
 		expect(matchSettingsEntry(undefined, "telemetry")).toBeNull()
 	})
 
-	// 回归: 手写 keywords 换成语言包生成后, 原来那批关键词必须照样能搜到
 	it("旧手写关键词仍然命中对应二级页", () => {
 		expect(hits("apikey")).toContain("ai")
 		expect(hits("人设")).toContain("ai")
@@ -77,6 +78,14 @@ describe("设置搜索索引", () => {
 		expect(hits("log")).toContain("debug")
 		expect(hits("license")).toContain("about")
 		expect(hits("协议")).toContain("about")
+	})
+
+	it("插件页通过真实语言包文案命中插件、扩展、安装和 noripack", () => {
+		expect(hits("插件")).toContain("plugins")
+		expect(hits("plugin")).toContain("plugins")
+		expect(hits("扩展")).toContain("plugins")
+		expect(hits("安装")).toContain("plugins")
+		expect(hits("noripack")).toContain("plugins")
 	})
 
 	it("每个二级页都有可检索文本", () => {

--- a/app/desktop/tests/views/mount-views.test.ts
+++ b/app/desktop/tests/views/mount-views.test.ts
@@ -225,8 +225,8 @@ describe("Views and Panels Mounting", () => {
 
 	it("switches all SettingsPanel tabs without leaving a blank panel", async () => {
 		const MOUNT = mountComponent(SettingsPanel)
-		// 设置面板包含 9 个子页
-		const SETTINGS_TABS = ["ai", "voice", "proactive", "skills", "mcp", "automation", "general", "debug", "about"]
+		// 设置面板包含 10 个子页
+		const SETTINGS_TABS = ["ai", "voice", "proactive", "skills", "mcp", "automation", "plugins", "general", "debug", "about"]
 		try {
 			await settleView()
 			const NAV_BUTTONS = Array.from(MOUNT.container.querySelectorAll("nav button"))
@@ -240,7 +240,7 @@ describe("Views and Panels Mounting", () => {
 				expect(PANELS[0].textContent?.trim()).not.toBe("")
 			}
 
-			click(NAV_BUTTONS[7])
+			click(NAV_BUTTONS[8])
 			click(NAV_BUTTONS[3])
 			click(NAV_BUTTONS[0])
 			await settleView()
@@ -282,4 +282,3 @@ describe("Views and Panels Mounting", () => {
 		}
 	})
 })
-

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -1,6 +1,6 @@
-# Nori Plugin Specification 1.0 第一阶段
+# Nori Plugin Specification 1.0
 
-本文记录 Nori Desktop 当前实现的 NPS 1.0 基础设施边界。插件是受信任的 .NET 进程内扩展；`AssemblyLoadContext` 只用于依赖隔离和卸载尝试，**不是安全沙箱**。
+本文记录 Nori Desktop 当前实现的 NPS 1.0 基础设施与本地插件管理边界。插件是受信任的 .NET 进程内扩展；`AssemblyLoadContext` 只用于依赖隔离和卸载尝试，**不是安全沙箱**。
 
 ## 核心合同
 
@@ -8,6 +8,7 @@
 - **Contribution** 表示插件向 Nori 提供的内容，例如 `IGameProvider`、`IArcadeCartridge` 和 `IHarnessTool`。
 - **Capability** 表示插件希望使用的宿主能力。当前只定义 `ui.webview` 与 `arcade`，并独立记录 `Declared`、`Granted`、`Available`。
 - 插件只引用 `Nori.Plugin.Abstractions` 及对应领域 Abstractions，不引用 `Nori.Core`、`Nori.Desktop`、`AppServices`、`IServiceProvider`、Bridge、窗口管理或业务运行时。
+- 插件管理只走 Host Vue → `NoriBridge` → Plugins command domain → `PluginManager`。插件自己的 `PluginBridge` 白名单不包含安装、启用、禁用或卸载命令。
 
 ## 程序集与依赖
 
@@ -91,12 +92,20 @@ runtimes/       (插件私有运行时依赖)
     ├── 1.0.0/
     └── 1.1.0/
 
-<data>/plugin-data/<pluginId>/storage.json
+<data>/plugin-data/
+├── runtime/
+│   ├── plugin-state.json
+│   └── plugin-startup.json
+└── <pluginId>/storage.json
 ```
 
 安装顺序是包预检、同卷 staging、安全解压、manifest/入口/引用复校验、版本目录原子移动、`current.json` 原子替换。旧 current 不会被失败安装覆盖，插件数据不放入版本目录。ZIP Slip、绝对路径、`..`、控制字符、重复规范化路径、符号链接、单文件/总展开大小及压缩比均拒绝。包中携带四个 contract DLL 也拒绝。
 
-当前没有联网 Marketplace、签名系统或自动更新；活动版本更新应在后续启动切换，避免覆盖正在使用的目录。
+设置页的“本地安装”只允许宿主 Avalonia `StorageProvider` 文件选择器产生 `.noripack` 路径。前端没有任意路径安装参数。首次继续安装前会提示插件属于 trusted in-process 扩展；确认只记录在主 WebView 的 localStorage。
+
+**新安装插件默认 `enabled=false`，安装完成后不会自动加载或执行第三方 DLL。** 用户需要在插件设置页显式点击启用。既有安装若没有 `plugin-state.json` 记录，则按兼容语义视为 enabled。
+
+当前没有联网 Marketplace、签名系统或自动更新；活动版本更新只切换 `current.json`，无法安全回收当前 ALC 时由重启完成切换或卸载。
 
 ## Runtime 生命周期
 
@@ -109,18 +118,61 @@ manifest/schema/API/platform/dependency/capability validation
   -> ActivateAsync
   -> Active / 可枚举 Contribution
 
-停用/退出
+显式停用/禁用
   -> Stopping
-  -> 取消 IPluginContext.StoppingToken
-  -> DeactivateAsync
-  -> 撤销全部 IPluginRegistration
-  -> 释放 capability lease、关闭插件窗口/session
-  -> 清除实例、类型和委托引用
+  -> revoke stopping token / contribution / capability lease
+  -> await PluginWindowHost 关闭该插件全部 WebView
+  -> DeactivateAsync / cleanup
+  -> 清除实例、context 与委托引用
   -> ALC.Unload + 有界 GC 检查
-      -> Installed/Disabled，或无法回收时 PendingRestart
+      -> Installed/Disabled
+      -> 无法回收时 PendingRestart
 ```
 
-激活、停用、贡献调用和桥接回调均在宿主边界包装。插件异常记录 `pluginId`、版本、阶段和稳定错误码，不把参数、结果、请求正文或异常敏感路径送入遥测。连续启动失败会记录在 `plugin-data/runtime/plugin-startup.json`，同一插件连续两次失败后自动标记禁用，避免每次启动反复执行坏插件。
+`PluginStateStore` 固定写入 `plugin-data/runtime/plugin-state.json`，保存用户启用意图以及需要重启后完成的卸载请求。用户禁用不会被 Safe Mode 或启动失败保护覆盖。`plugin-startup.json` 继续只承担启动失败恢复；连续启动失败会触发保护性禁用，显式重新启用时清除该保护后重试。
+
+`EnableAsync` 会校验插件 ID、安装状态、宿主兼容性和依赖，先持久化用户启用意图，再尝试热激活。失败状态保留稳定错误码与脱敏、截断后的用户可读错误，可再次重试。
+
+`DisableAsync` 会持久化 `enabled=false`，撤销 contribution、关闭插件窗口、调用停用清理并尝试回收 ALC。回收失败时保留用户禁用意图并返回 `PendingRestart`。
+
+`UninstallAsync` 只接收经过 manifest ID 规则校验的插件 ID，不接受任意路径。存在活动依赖时拒绝。正常卸载删除 `<plugins>/<pluginId>` 下所有版本和 `current.json`，默认保留 `<plugin-data>/<pluginId>`；用户显式勾选删除数据时才删除该精确目录。若 ALC 或文件仍被占用，运行时持久化 pending-uninstall 与 `deleteData`，下次启动创建任何插件 ALC 前再次尝试完成删除。
+
+重复 `Discover()` 对同一 current 版本的活动插件保持 Active，不会误标 `PendingRestart`。用户 disabled 插件在 discover/startup 阶段绝不创建 ALC。
+
+激活、停用、贡献调用和桥接回调均在宿主边界包装。插件异常记录 `pluginId`、版本、阶段和稳定错误码，不把参数、结果、请求正文、完整路径或 stack trace 暴露给前端 DTO。
+
+## 主设置页插件管理
+
+主设置页的 Extend 分组在 Automation 后提供 Plugins 页面。列表 DTO 已包含详情所需字段，因此没有额外 `plugin_get_details` 命令，也没有本阶段的轮询或 `nori:plugins-changed` 事件。
+
+宿主管理命令固定为：
+
+```text
+plugin_list
+plugin_install_local
+plugin_enable({ id })
+plugin_disable({ id })
+plugin_uninstall({ id, deleteData })
+```
+
+这些命令只允许**当前可见的 main WebView** 调用。`plugin_list` 只做无 ALC 的 refresh/discover；安装取消返回 `{ cancelled: true }`；启用、禁用和卸载优先返回最新稳定 DTO，让前端本地更新列表。
+
+列表 DTO 只暴露 manifest 的公开元数据、固定 state 字符串、用户 enabled 意图、capability status、稳定错误码、脱敏错误文本、requiresRestart 与由 AssetServer 提供的 `iconUrl`。不会序列化安装路径、插件数据路径、ALC、context 或异常对象。
+
+固定 state 字符串为：
+
+```text
+installed
+loading
+active
+stopping
+disabled
+failed
+incompatible
+pending_restart
+```
+
+插件页支持本地安装、显式启用/禁用、失败重试、卸载、可选删除数据、权限状态、错误状态和重启提示。安装、启用、禁用、卸载均不绕过 `PluginManager`。
 
 ## Plugin Abstractions
 
@@ -144,7 +196,7 @@ Storage 是异步 JSON KV，按插件目录隔离；Assets 只公开 `web/`、`a
 
 ### Harness
 
-Harness 层统一使用 `IHarnessTool`、`IHarnessResourceProvider` 与 `IHarnessEventSource`，不区分 Codex/Claude/OpenCode。工具风险等级为 `Safe`、`Sensitive`、`Destructive`；调用上下文包含 HarnessId、SessionId、TrustLevel 和 GrantedScopes。未来 adapter 负责把本地工具 ID导出成 `<pluginId>/<toolId>`，资源 URI 使用 `nori-plugin://<pluginId>/...`。
+Harness 层统一使用 `IHarnessTool`、`IHarnessResourceProvider` 与 `IHarnessEventSource`，不区分 Codex/Claude/OpenCode。工具风险等级为 `Safe`、`Sensitive`、`Destructive`；调用上下文包含 HarnessId、SessionId、TrustLevel 和 GrantedScopes。未来 adapter 负责把本地工具 ID 导出成 `<pluginId>/<toolId>`，资源 URI 使用 `nori-plugin://<pluginId>/...`。
 
 ## AssetServer 与 Plugin WebView
 
@@ -156,21 +208,35 @@ Harness 层统一使用 `IHarnessTool`、`IHarnessResourceProvider` 与 `IHarnes
 
 它复用相同的 Host/prefix 校验和精确路径安全检查，不启动第二个 static server。`IPluginAssets.GetUri()` 在生产返回带随机 prefix 的绝对同源 URL，开发模式返回 `/plugins/...`，由 Vite 代理到 14201。`vite.config.ts` 保留 `base: "./"`，新增 `/plugins` 代理。
 
-插件 WebView 位于 `Nori.Desktop/Plugins/`，由独立 `PluginWindowHost` 管理，不加入固定的 `WindowDefinition.All`。窗口标签固定为 `plugin:<pluginId>:<windowId>`；窗口创建时由宿主绑定 descriptor 和 revoke token，页面提交的 `pluginId` 永远不是权限依据。窗口停用时关闭并释放自己的 `PluginBridge`。
+插件 WebView 位于 `Nori.Desktop/Plugins/`，由独立 `PluginWindowHost` 管理，不加入固定的 `WindowDefinition.All`。窗口标签固定为 `plugin:<pluginId>:<windowId>`；窗口创建时由宿主绑定 descriptor 和 revoke token，页面提交的 `pluginId` 永远不是权限依据。Runtime 只依赖 `PluginRuntimeOptions.ClosePluginWindowsAsync` 回调，Desktop 装配层注入 `PluginWindowHost.CloseAllWindowsForPluginAsync`，因此 Runtime 不引用 Desktop 类型。
 
-`PluginBridge` 不转发到 `NoriBridge`，只保留插件摘要、能力状态、当前窗口信息、关闭自身和 ping 等最小命令，并使用独立的 `window.__noriPlugin.dispatch` 信封。当前没有通用 JS SDK、宿主 Vue 组件注入、Pinia/Router/DOM 访问或任意网络 capability。
+`PluginBridge` 不转发到 `NoriBridge`，只保留插件摘要、能力状态、当前窗口信息、关闭自身和 ping 等最小命令，并使用独立的 `window.__noriPlugin.dispatch` 信封。插件管理命令不会转发给插件 WebView。当前没有通用 JS SDK、宿主 Vue 组件注入、Pinia/Router/DOM 访问或任意网络 capability。
 
 ## Safe Mode
 
-`--safe-mode` 是人工命令行排障模式。PluginManager 仍可发现已安装 manifest，但会把第三方插件标记为 `Disabled`，跳过 inbox 安装、ALC 创建和任何 Activate 调用。Storage、日志、诊断和本地手动修复仍由宿主保留。ALC 无法回收时仅标记 `PendingRestart`，不会为了强制卸载而杀死线程或让应用崩溃。
+`--safe-mode` 采用 fail-closed。PluginManager 仍可发现已安装 manifest，列表仍展示 manifest、用户 enabled 意图和 Safe Mode 临时禁用原因，但不会创建 ALC 或执行任何第三方入口。
+
+Safe Mode 允许：
+
+- `plugin_list`
+- `plugin_disable`
+- `plugin_uninstall`
+
+Safe Mode 拒绝：
+
+- `plugin_install_local`
+- `plugin_enable`
+
+安全模式不会覆盖用户在 `plugin-state.json` 中保存的 enabled 意图。退出 Safe Mode 后，用户原本的启用选择仍然存在。
 
 ## 当前未实现
 
-- Marketplace、联网安装、签名/供应链验证、WASM 和 out-of-process 沙箱。
+- Marketplace、联网下载/安装、签名与供应链验证、自动更新。
+- WASM 与 out-of-process 插件沙箱。
 - Codex/MCP/HTTP/stdio adapter、完整 Harness 执行审批与工具运行时。
 - Arcade WebSocket/world/patch runtime，以及 cakeduel/chess/codenames/pictionary cartridge 移植。
 - ARG artifact runtime。
-- 插件管理 Vue 页面、完整前端 SDK、动态 Vue 注入、插件直接 Avalonia Control。
+- 完整插件前端 SDK、动态 Vue 注入、插件直接 Avalonia Control。
 - 任意 network/filesystem/shell/process/LLM/memory/MCP/automation/pet/chat capability。
 
-下一步 `io.nori.games` 应先只引用四个公开程序集中的 Abstractions：实现四个 `IGameProvider` 或 Arcade cartridge，使用 `IPluginStorage` 保存版本无关的存档，通过 `IPluginAssets.GetUri()` 读取自己的页面资源；宿主再单独实现游戏 session 生命周期、权限和 Harness adapter，不把游戏逻辑塞进 `BridgeCommands`。
+`io.nori.games`、Marketplace、签名、Nori.Web runtime 和完整 Arcade/Harness runtime 都不属于当前 Plugin Management Vertical Slice。在这一垂直切片通过构建、测试和审查前，不开始 `io.nori.games` 实现。


### PR DESCRIPTION
## NPS 1.0 — Phase 2: Plugin Management Vertical Slice

Implements the local plugin-management loop through Host Vue → NoriBridge → Bridge command domain → PluginManager while keeping the plugin-side `PluginBridge` whitelist unchanged.

### Runtime
- persistent user enabled intent in `plugin-data/runtime/plugin-state.json`
- explicit enable / disable / uninstall lifecycle
- new installs default disabled
- safe uninstall boundaries and optional plugin-data deletion
- pending-uninstall restart recovery
- safe-mode fail-closed behavior
- stable management errors, sanitized UI-facing messages and capability status snapshots
- duplicate discover no longer marks an unchanged active current version as pending restart

### Host bridge
- stable plugin-management DTOs
- `plugin_list`
- `plugin_install_local`
- `plugin_enable`
- `plugin_disable`
- `plugin_uninstall`
- visible-main source enforcement
- native Avalonia file picker; frontend file paths are ignored
- injectable picker for deterministic bridge tests
- dedicated Plugins command domain without exposing management commands to plugin WebViews

### Settings UI
- Plugins tab under Extend after Automation
- local `.noripack` install with first-use trusted in-process warning
- enable / disable / retry / uninstall flows
- optional delete-data confirmation
- capability, error and restart-state display
- safe-mode restrictions
- stable service layer under `src/services/plugins`
- zh-CN / en-US messages and settings-search coverage

### Tests
Adds runtime, bridge and Vue coverage for the management lifecycle, security boundaries, safe mode, picker cancellation, DTO redaction and settings interactions.

### Still being finalized in this draft
- production PluginWindowHost close callback wiring
- plugin-system documentation update
- final i18n organization cleanup
- full CI/build verification
