### PR TITLE
fix(plugin): harden management state and lifecycle invariants

### DIFF
--- a/app/desktop/Nori.Plugin.Runtime.Tests/PluginManagementTests.cs
+++ b/app/desktop/Nori.Plugin.Runtime.Tests/PluginManagementTests.cs
@@ -60,6 +60,48 @@ public sealed class PluginManagementTests
 	}
 
 	[Fact]
+	public async Task 损坏的插件状态文件会FailClosed且显式重新启用可跨重启恢复()
+	{
+		string root = CreateTemp();
+		try
+		{
+			string plugins = Path.Combine(root, "plugins");
+			PluginPackageInstaller installer = new(plugins);
+			installer.Install(CreateTestPackage(root, "first.plugin", "1.0.0"));
+			installer.Install(CreateTestPackage(root, "second.plugin", "1.0.0"));
+
+			string runtime = Path.Combine(root, "plugin-data", "runtime");
+			Directory.CreateDirectory(runtime);
+			File.WriteAllText(Path.Combine(runtime, "plugin-state.json"), "{ broken json");
+
+			PluginManager first = CreateManager(root);
+			PluginInfo[] failedClosed = first.Discover().OrderBy(item => item.Id, StringComparer.Ordinal).ToArray();
+			Assert.Equal(2, failedClosed.Length);
+			Assert.All(failedClosed, item =>
+			{
+				Assert.False(item.UserEnabled);
+				Assert.Equal(PluginLifecycleState.Disabled, item.State);
+			});
+			Assert.Empty(first.GetContributions<IPluginContribution>());
+
+			await first.EnableAsync("first.plugin");
+			PluginInfo enabled = Assert.Single(first.Plugins, item => item.Id == "first.plugin");
+			Assert.True(enabled.UserEnabled);
+			Assert.Equal(PluginLifecycleState.Active, enabled.State);
+			await first.DisposeAsync();
+
+			PluginManager rebuilt = CreateManager(root);
+			PluginInfo[] restored = rebuilt.Discover().OrderBy(item => item.Id, StringComparer.Ordinal).ToArray();
+			Assert.True(Assert.Single(restored, item => item.Id == "first.plugin").UserEnabled);
+			PluginInfo stillClosed = Assert.Single(restored, item => item.Id == "second.plugin");
+			Assert.False(stillClosed.UserEnabled);
+			Assert.Equal(PluginLifecycleState.Disabled, stillClosed.State);
+			await rebuilt.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
 	public async Task 激活失败后仍可重试并保持用户启用意图()
 	{
 		string root = CreateTemp();
@@ -130,6 +172,54 @@ public sealed class PluginManagementTests
 			await manager.ActivateAsync("dependent.plugin");
 			PluginException inUse = await Assert.ThrowsAsync<PluginException>(() => manager.UninstallAsync("base.plugin"));
 			Assert.Equal(PluginManagementErrorCodes.DependencyInUse, inUse.Code);
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task 活动必需依赖会拒绝Disable且保持双方Active()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginManager manager = CreateManager(root);
+			manager.Installer.Install(CreateTestPackage(root, "base.plugin", "1.0.0"));
+			manager.Installer.Install(CreateTestPackage(root, "dependent.plugin", "1.0.0", dependencies: "[{\"id\":\"base.plugin\",\"version\":\">=1.0.0 <2.0.0\",\"optional\":false}]"));
+			manager.Discover();
+			await manager.ActivateAsync("base.plugin");
+			await manager.ActivateAsync("dependent.plugin");
+
+			PluginException inUse = await Assert.ThrowsAsync<PluginException>(() => manager.DisableAsync("base.plugin"));
+			Assert.Equal(PluginManagementErrorCodes.DependencyInUse, inUse.Code);
+			PluginInfo baseInfo = Assert.Single(manager.Plugins, item => item.Id == "base.plugin");
+			PluginInfo dependentInfo = Assert.Single(manager.Plugins, item => item.Id == "dependent.plugin");
+			Assert.True(baseInfo.UserEnabled);
+			Assert.Equal(PluginLifecycleState.Active, baseInfo.State);
+			Assert.Equal(PluginLifecycleState.Active, dependentInfo.State);
+			await manager.DisposeAsync();
+		}
+		finally { DeleteDirectory(root); }
+	}
+
+	[Fact]
+	public async Task 活动插件安装新版本后保持Active贡献并单独标记需要重启()
+	{
+		string root = CreateTemp();
+		try
+		{
+			PluginManager manager = CreateManager(root);
+			await manager.InstallAsync(CreateTestPackage(root, "update.plugin", "1.0.0"));
+			await manager.EnableAsync("update.plugin");
+			Assert.NotEmpty(manager.GetContributions<IPluginContribution>());
+
+			await manager.InstallAsync(CreateTestPackage(root, "update.plugin", "1.1.0"));
+
+			PluginInfo running = Assert.Single(manager.Plugins);
+			Assert.Equal(PluginLifecycleState.Active, running.State);
+			Assert.True(running.RequiresRestart);
+			Assert.Equal("1.0.0", running.Manifest.Version);
+			Assert.NotEmpty(manager.GetContributions<IPluginContribution>());
 			await manager.DisposeAsync();
 		}
 		finally { DeleteDirectory(root); }

--- a/app/desktop/Nori.Plugin.Runtime/PluginManager.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginManager.cs
@@ -351,6 +351,7 @@ public sealed class PluginManager : IAsyncDisposable
 		{
 			Discover();
 			PluginHandle handle = GetRequiredHandle(pluginId);
+			EnsureNoActiveDependents(pluginId);
 			_stateStore.SetEnabled(pluginId, false);
 			try
 			{
@@ -361,6 +362,7 @@ public sealed class PluginManager : IAsyncDisposable
 				bool unloaded = UnloadContext(handle);
 				if (unloaded)
 				{
+					handle.UpdatePendingRestart = false;
 					handle.State = PluginLifecycleState.Disabled;
 					handle.ErrorCode = PluginManagementErrorCodes.UserDisabled;
 					handle.ErrorMessage = "插件已由用户禁用";
@@ -519,6 +521,7 @@ public sealed class PluginManager : IAsyncDisposable
 			handle.Instance = instance;
 			await instance.ActivateAsync(handle.Context, cancellationToken).AsTask().WaitAsync(_options.ActivationTimeout, cancellationToken).ConfigureAwait(false);
 			handle.State = PluginLifecycleState.Active;
+			handle.UpdatePendingRestart = false;
 			handle.ErrorCode = null;
 			handle.ErrorMessage = null;
 			ClearStartupFailure(handle.Manifest.Id);
@@ -700,9 +703,19 @@ public sealed class PluginManager : IAsyncDisposable
 			{
 				if (!sameDirectory)
 				{
-					existing.State = PluginLifecycleState.PendingRestart;
-					existing.ErrorCode = PluginErrorCodes.UnloadPendingRestart;
+					// current.json 已切到新版本，但旧版本实例仍在本进程运行。此时不能把
+					// LifecycleState 改成 PendingRestart，否则宿主会立刻停止枚举其贡献，
+					// 形成“代码仍运行但贡献消失”的半活动状态。保持 Active，并单独标记
+					// 重启需求；下次启动自然从 current.json 加载新版本。
+					existing.UpdatePendingRestart = true;
+					existing.ErrorCode = null;
 					existing.ErrorMessage = "已安装新版本，重启后切换";
+				}
+				else if (existing.UpdatePendingRestart)
+				{
+					existing.UpdatePendingRestart = false;
+					existing.ErrorCode = null;
+					existing.ErrorMessage = null;
 				}
 				return;
 			}
@@ -866,7 +879,7 @@ public sealed class PluginManager : IAsyncDisposable
 		{
 			UserEnabled = _stateStore.IsEnabled(handle.Manifest.Id),
 			ErrorMessage = handle.ErrorMessage,
-			RequiresRestart = handle.State == PluginLifecycleState.PendingRestart,
+			RequiresRestart = handle.State == PluginLifecycleState.PendingRestart || handle.UpdatePendingRestart,
 			CapabilityStatuses = statuses,
 		};
 	}
@@ -936,6 +949,7 @@ public sealed class PluginManager : IAsyncDisposable
 		public PluginLifecycleState State { get; set; }
 		public string? ErrorCode { get; set; }
 		public string? ErrorMessage { get; set; }
+		public bool UpdatePendingRestart { get; set; }
 		public INoriPlugin? Instance { get; set; }
 		public PluginLoadContext? LoadContext { get; set; }
 		public PluginContext? Context { get; set; }

--- a/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
@@ -138,7 +138,8 @@ internal sealed class PluginStateStore
 		try
 		{
 			Dictionary<string, PluginRuntimeState>? states = JsonSerializer.Deserialize<Dictionary<string, PluginRuntimeState>>(File.ReadAllText(path), JsonOptions);
-			return states is null ? FailClosedState() : new(states, StringComparer.Ordinal);
+			if (states is null || states.Values.Any(state => state is null)) return FailClosedState();
+			return new(states, StringComparer.Ordinal);
 		}
 		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
 		{

--- a/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
@@ -138,18 +138,20 @@ internal sealed class PluginStateStore
 		try
 		{
 			Dictionary<string, PluginRuntimeState>? states = JsonSerializer.Deserialize<Dictionary<string, PluginRuntimeState>>(File.ReadAllText(path), JsonOptions);
-			return states is null ? new(StringComparer.Ordinal) : new(states, StringComparer.Ordinal);
+			return states is null ? FailClosedState() : new(states, StringComparer.Ordinal);
 		}
 		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
 		{
 			// 状态损坏时绝不能退化为“所有未知插件默认启用”。保留一个不可伪造的
 			// 哨兵；后续任意成功写入都会把它持久化，从而跨重启维持 fail-closed。
-			return new(StringComparer.Ordinal)
-			{
-				[FailClosedSentinel] = new PluginRuntimeState { Enabled = false },
-			};
+			return FailClosedState();
 		}
 	}
+
+	private static Dictionary<string, PluginRuntimeState> FailClosedState() => new(StringComparer.Ordinal)
+	{
+		[FailClosedSentinel] = new PluginRuntimeState { Enabled = false },
+	};
 
 	private static void ValidateId(string pluginId)
 	{

--- a/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
+++ b/app/desktop/Nori.Plugin.Runtime/PluginStateStore.cs
@@ -6,6 +6,11 @@ namespace Nori.Plugin.Runtime;
 /// <summary>持久化用户对插件的启用意图与需要重启后完成的卸载请求。</summary>
 internal sealed class PluginStateStore
 {
+	// 该键不可能通过插件 ID 正则，因此不会与真实插件冲突。
+	// 一旦状态文件损坏，保留该哨兵使“无记录插件”在后续重启中继续 fail-closed，
+	// 直到用户显式重新启用对应插件并写入独立状态。
+	private const string FailClosedSentinel = "__fail_closed__";
+
 	private static readonly JsonSerializerOptions JsonOptions = new()
 	{
 		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -24,12 +29,18 @@ internal sealed class PluginStateStore
 		_states = Load(_path);
 	}
 
-	/// <summary>既有插件没有记录时保持 1.0 兼容语义，默认视为启用。</summary>
+	/// <summary>
+	/// 正常状态文件中，既有插件没有记录时保持 1.0 兼容语义，默认视为启用。
+	/// 如果状态文件曾损坏，则未知插件默认禁用，避免用户明确禁用过的代码被静默重新执行。
+	/// </summary>
 	public bool IsEnabled(string pluginId)
 	{
 		ValidateId(pluginId);
 		lock (_gate)
-			return !_states.TryGetValue(pluginId, out PluginRuntimeState? state) || state.Enabled;
+		{
+			if (_states.TryGetValue(pluginId, out PluginRuntimeState? state)) return state.Enabled;
+			return !_states.ContainsKey(FailClosedSentinel);
+		}
 	}
 
 	public void SetEnabled(string pluginId, bool enabled)
@@ -131,7 +142,12 @@ internal sealed class PluginStateStore
 		}
 		catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
 		{
-			return new(StringComparer.Ordinal);
+			// 状态损坏时绝不能退化为“所有未知插件默认启用”。保留一个不可伪造的
+			// 哨兵；后续任意成功写入都会把它持久化，从而跨重启维持 fail-closed。
+			return new(StringComparer.Ordinal)
+			{
+				[FailClosedSentinel] = new PluginRuntimeState { Enabled = false },
+			};
 		}
 	}
 


### PR DESCRIPTION
## Summary

Focused follow-up review of the NPS 1.0 plugin-management vertical slice landed in #22.

This PR fixes three concrete runtime issues without changing the public NPS contracts:

- fail closed when `plugin-state.json` is corrupt instead of silently treating previously disabled/unknown plugins as enabled
- reject disabling a plugin while an active plugin has a required dependency on it, matching uninstall's dependency protection
- keep an already-running plugin `Active` when a newer version is installed, while exposing `RequiresRestart` separately so its live contributions do not disappear before restart

## Details

### Persisted state corruption
Previously `PluginStateStore.Load()` returned an empty dictionary on JSON/I/O failure. Because missing entries intentionally preserve legacy behavior as enabled, corruption could silently re-enable third-party plugins that the user had disabled.

A fail-closed sentinel now survives subsequent writes. Unknown plugins remain disabled after a corrupt state file until the user explicitly enables them. Valid state files retain the existing backward-compatible default.

### Required dependencies
`UninstallAsync()` already rejected removing a plugin with active required dependents, but `DisableAsync()` did not. Disabling a required dependency could therefore leave its dependent plugin marked `Active` with a broken runtime invariant.

`DisableAsync()` now applies the same active-dependent guard before changing persistent enabled state.

### Active plugin updates
Installing a new version changed the live old handle from `Active` to `PendingRestart` even though its code remained loaded. Contribution and Harness enumeration only exposes `Active` handles, so the running plugin immediately disappeared from host registries while still executing.

The live handle now remains `Active`; a separate internal update-restart flag drives `PluginInfo.RequiresRestart`. The current process keeps using the old version and its contributions until shutdown, while `current.json` selects the new version on the next launch.

## Regression coverage

Added tests for:

- corrupt persisted state stays fail-closed across manager reconstruction and selective explicit re-enable
- disabling an active required dependency returns `plugin.dependency_in_use` and leaves both plugins active
- installing an update over an active plugin preserves `Active`, contributions, and exposes `RequiresRestart`

## Scope

No Marketplace, game integration, Bridge surface expansion, or public Plugin API changes are included.