### PR TITLE
修复 Windows 上鼠标穿透仍然无法正常使用的问题

### DIFF
--- a/app/desktop/Nori.Core.Tests/PlatformCapabilitiesTests.cs
+++ b/app/desktop/Nori.Core.Tests/PlatformCapabilitiesTests.cs
@@ -14,6 +14,7 @@ public class PlatformCapabilitiesTests
 	private const int GwlExStyle = -20;
 	private const long WsExTopmost = 0x00000008;
 	private const long WsExTransparent = 0x00000020;
+	private const long WsExLayered = 0x00080000;
 	private const uint WsPopup = 0x80000000;
 
 	[DllImport("user32.dll", EntryPoint = "CreateWindowExW", CharSet = CharSet.Unicode, SetLastError = true)]
@@ -101,7 +102,7 @@ public class PlatformCapabilitiesTests
 	}
 
 	[Fact]
-	public void Windows穿透会切换透明样式与Topmost层级()
+	public void Windows穿透叠加分层透明样式且保持置顶()
 	{
 		if (!OperatingSystem.IsWindows()) return;
 
@@ -113,11 +114,13 @@ public class PlatformCapabilitiesTests
 			services.SetClickThrough(window, true);
 			long throughStyle = GetWindowLongPtr(window, GwlExStyle).ToInt64();
 			Assert.NotEqual(0, throughStyle & WsExTransparent);
-			Assert.Equal(0, throughStyle & WsExTopmost);
+			Assert.NotEqual(0, throughStyle & WsExLayered);
+			Assert.NotEqual(0, throughStyle & WsExTopmost);
 
 			services.SetClickThrough(window, false);
 			long clickableStyle = GetWindowLongPtr(window, GwlExStyle).ToInt64();
 			Assert.Equal(0, clickableStyle & WsExTransparent);
+			Assert.Equal(0, clickableStyle & WsExLayered);
 			Assert.NotEqual(0, clickableStyle & WsExTopmost);
 		}
 		finally

--- a/app/desktop/Nori.Core/Platform/IPlatformServices.cs
+++ b/app/desktop/Nori.Core/Platform/IPlatformServices.cs
@@ -80,7 +80,7 @@ public interface IPlatformServices
 	/// <summary>
 	/// 设置窗口是否整体穿透点击
 	///
-	/// Windows 用它同步 WS_EX_TRANSPARENT 与 Topmost Z 序, WM_NCHITTEST 仍负责逐点判定;
+	/// Windows 上通过 WS_EX_LAYERED + WS_EX_TRANSPARENT 让系统 hit-test 无视 Z 序跳过窗口, 保持置顶;
 	/// macOS / Linux 则按 alpha 采样结果在「整窗可点」与「整窗穿透」之间切换。
 	/// </summary>
 	void SetClickThrough(nint windowHandle, bool through);

--- a/app/desktop/Nori.Core/Platform/WindowsPlatformServices.cs
+++ b/app/desktop/Nori.Core/Platform/WindowsPlatformServices.cs
@@ -3,12 +3,15 @@ using System.Runtime.Versioning;
 
 namespace Nori.Core.Platform;
 
-/// <summary>
+///
 /// Windows 实现
 ///
-/// 模型交互矩形由 PetWindow 的 WM_NCHITTEST 钩子逐点判定；SetClickThrough 同步
-/// WS_EX_TRANSPARENT 与 Topmost Z 序，避免透明命中被困在 Topmost 窗口组内。
-/// </summary>
+/// 跨进程点击穿透配方: WS_EX_TRANSPARENT 必须叠加 WS_EX_LAYERED 并用
+/// SetLayeredWindowAttributes 激活分层, 系统 hit-test 才会无视 Z 序跳过本窗口;
+/// 裸 WS_EX_TRANSPARENT / HTTRANSPARENT 只在同一线程内生效, 点不到其他程序的窗口。
+/// 桌宠是 WS_EX_NOREDIRECTIONBITMAP 的 DirectComposition 窗口, alpha=255 的分层
+/// 属性不参与合成, 画面不变; 窗口全程保持 Topmost。
+///
 [SupportedOSPlatform("windows")]
 public sealed class WindowsPlatformServices : IPlatformServices
 {
@@ -16,8 +19,9 @@ public sealed class WindowsPlatformServices : IPlatformServices
 	private const nint HtCaption = 2;
 	private const int GwlExStyle = -20;
 	private const int WsExTransparent = 0x00000020;
+	private const int WsExLayered = 0x00080000;
+	private const uint LwaAlpha = 0x00000002;
 	private static readonly nint HwndTopmost = new(-1);
-	private static readonly nint HwndNoTopmost = new(-2);
 	private const uint SwpNoSize = 0x0001;
 	private const uint SwpNoMove = 0x0002;
 	private const uint SwpNoActivate = 0x0010;
@@ -27,6 +31,10 @@ public sealed class WindowsPlatformServices : IPlatformServices
 	[return: MarshalAs(UnmanagedType.Bool)]
 	private static extern bool SetWindowPos(
 		nint hWnd, nint hWndInsertAfter, int x, int y, int width, int height, uint flags);
+
+	[DllImport("user32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool SetLayeredWindowAttributes(nint hWnd, uint crKey, byte bAlpha, uint dwFlags);
 
 	[StructLayout(LayoutKind.Sequential)]
 	private struct Point
@@ -90,7 +98,11 @@ public sealed class WindowsPlatformServices : IPlatformServices
 		int error = Marshal.GetLastPInvokeError();
 		if (style == 0 && error != 0) throw new InvalidOperationException($"读取 Windows 桌宠窗口样式失败: {error}");
 
-		nint next = through ? style | WsExTransparent : style & ~WsExTransparent;
+		// WS_EX_TRANSPARENT 只有在 WS_EX_LAYERED + SetLayeredWindowAttributes 激活分层后,
+		// 才能让系统 hit-test 无视 Z 序跨进程跳过本窗口; 裸 WS_EX_TRANSPARENT 与
+		// HTTRANSPARENT 都只在同一线程内生效。桌宠是 WS_EX_NOREDIRECTIONBITMAP 的
+		// DirectComposition 窗口, alpha=255 的分层属性不参与合成, 画面不受影响。
+		nint next = through ? style | WsExTransparent | WsExLayered : style & ~(WsExTransparent | WsExLayered);
 		if (next != style)
 		{
 			Marshal.SetLastPInvokeError(0);
@@ -99,10 +111,14 @@ public sealed class WindowsPlatformServices : IPlatformServices
 			if (previous == 0 && error != 0) throw new InvalidOperationException($"设置 Windows 桌宠窗口样式失败: {error}");
 		}
 
-		// Windows 不会让 HTTRANSPARENT/WS_EX_TRANSPARENT 跨 Topmost 组寻找普通窗口。
-		// 穿透时降到普通 Z 序, 恢复可点时再抬回 Topmost, 不抢当前焦点。
-		nint insertAfter = through ? HwndNoTopmost : HwndTopmost;
-		if (!SetWindowPos(windowHandle, insertAfter, 0, 0, 0, 0,
+		if (through && !SetLayeredWindowAttributes(windowHandle, 0, 255, LwaAlpha))
+		{
+			throw new InvalidOperationException($"激活 Windows 桌宠分层窗口失败: {Marshal.GetLastWin32Error()}");
+		}
+
+		// 穿透由分层 hit-test 跳过实现, 与 Z 序无关: 桌宠保持置顶。
+		// SetWindowPos 同时让 SetWindowLongPtr 的样式改动立即生效。
+		if (!SetWindowPos(windowHandle, HwndTopmost, 0, 0, 0, 0,
 			SwpNoSize | SwpNoMove | SwpNoActivate | SwpFrameChanged))
 		{
 			throw new InvalidOperationException($"设置 Windows 桌宠窗口层级失败: {Marshal.GetLastWin32Error()}");

--- a/app/desktop/Nori.Desktop/Windows/PetWindow.cs
+++ b/app/desktop/Nori.Desktop/Windows/PetWindow.cs
@@ -19,8 +19,8 @@ namespace Nori.Desktop.Windows;
 ///
 /// 承载 PetGlControl 并接管桌宠的全部交互：
 /// - 模型外接矩形穿透: 约 10Hz 从 alpha 画面更新连续交互范围; Windows 走 WM_NCHITTEST
-///   并按命中状态切换 Topmost Z 序, macOS/Linux(X11) 设置穿透开关/输入形状;
-///   Wayland 无此能力, 降级为整窗可点
+///   逐点判定, 并用 WS_EX_LAYERED|WS_EX_TRANSPARENT 分层样式实现跨进程穿透, 窗口始终置顶;
+///   macOS/Linux(X11) 设置穿透开关/输入形状; Wayland 无此能力, 降级为整窗可点
 /// - 左键拖拽移动窗口 + 坐标持久化（阈值 4px）
 /// - 左键点击触发动作与表情判定
 /// - 深海微光配色原生右键菜单（打开主界面 / 随机动作 / 重置位置 / 隐藏桌宠 / 退出）
@@ -392,7 +392,7 @@ public sealed class PetWindow : Window
 		RefreshInputState();
 	}
 
-	/// <summary>刷新 Windows 桌宠的点击穿透与 Z 序状态。</summary>
+	/// <summary>刷新 Windows 桌宠的点击穿透状态 (窗口保持置顶)。</summary>
 	public void RefreshInputState()
 	{
 		if (!OperatingSystem.IsWindows() || PlatformServices.Current is not WindowsPlatformServices windows) return;
@@ -425,7 +425,6 @@ public sealed class PetWindow : Window
 		try
 		{
 			windows.SetClickThrough(handle, through);
-			Topmost = !through;
 			_lastClickThrough = through;
 		}
 		catch (Exception exception) when (exception is InvalidOperationException or EntryPointNotFoundException or DllNotFoundException)

--- a/app/desktop/Nori.Desktop/Windows/WindowManager.cs
+++ b/app/desktop/Nori.Desktop/Windows/WindowManager.cs
@@ -114,7 +114,7 @@ public sealed class WindowManager(AssetServer assetServer, IClassicDesktopStyleA
 		window.Show();
 		if (window is PetWindow pet)
 		{
-			// 桌宠不抢当前应用焦点；穿透状态会自行决定 Topmost / 普通 Z 序。
+			// 桌宠不抢当前应用焦点；点击穿透由分层样式实现，窗口保持置顶。
 			pet.ApplyWindowSize();
 			pet.ReapplyInputState();
 			return;


### PR DESCRIPTION
<!--
感谢您参与 Nori Desktop Pet 的贡献！

提交 PR 前请确认:
1. 已阅读开发与代码规范: https://github.com/MF-Dust/Nori-Desktop-Pet/blob/main/docs/%E8%A7%84%E8%8C%83.md
2. 确保在本地执行并通过质量门禁:
   - 前端: pnpm build && pnpm test
   - 宿主: dotnet test

⚠ 在提交 PR 前，请确保您已在本地完成测试，且确保要实现的功能或修复的问题能正常工作。 ⚠
请确保填写以下信息:
-->

## 类型
<!-- 请至少选择一项 -->

- [x] Bug 修复
- [ ] 新功能
- [ ] 性能优化
- [ ] 架构重构
- [ ] 文档与文档注释
- [ ] CI / 构建配置
- [ ] 其他（请描述）:  

## 这个 Pull Request 做了什么？
修复了仍然有问题的 Windows 上的鼠标穿透功能
已经在 Windows 11 上测试 而且不会有窗口不能置顶的问题

## 截图 / 录屏
<img width="859" height="722" alt="image" src="https://github.com/user-attachments/assets/60a9bc63-c741-4c50-b4df-fd78f1fb094d" />

## 相关 Issue
Fixes #24

## 检查清单

<!-- 
⚠ 在勾选复选框前，请确保您已经真正完成了本地验证并保证这个 PR 要实现的功能或修复的问题能正常工作。 ⚠
如果您是正在自动填写此模板的 Agent，请确保您已经完成了必要的测试。如果没有测试条件，请提醒调用者完成测试。
-->

- [x] 我已经在本地完成测试，确保欲实现的功能或修复的问题能正常工作。
- [x] 本地已通过门禁验证（`pnpm build`、`pnpm test` 与 `dotnet test`）。
- [x] 我已阅读并遵循本项目的代码与开发规范（`docs/规范.md`，如 Tab 缩进、中文注释与局部变量 UPPER_SNAKE 等）。
- [x] 涉及 UI 或桌宠视觉交互变更时，我已补充截图或录屏（如适用）。
