### PR TITLE
fix: 修复 IndexTTS-2 合并后审查问题

### DIFF
--- a/app/desktop/Nori.Core.Tests/IndexTtsReviewRegressionTests.cs
+++ b/app/desktop/Nori.Core.Tests/IndexTtsReviewRegressionTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Voice;
+
+namespace Nori.Core.Tests;
+
+/// <summary>PR #33 审查问题的回归测试。</summary>
+public sealed class IndexTtsReviewRegressionTests : IDisposable
+{
+	private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"nori-indextts-review-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+
+	public IndexTtsReviewRegressionTests()
+	{
+		_database = NoriDatabase.Open(_dbPath);
+		_config = new ConfigStore(_database);
+		_config.InitDefaults("0.1.0");
+		_config.Set("tts_provider", new ConfigValue.Text("indextts"));
+		_config.Set("tts_api_key", new ConfigValue.Text("test-secret"));
+	}
+
+	[Fact]
+	public async Task 完整Speech端点克隆时会归一化到VoiceUpload且使用配置模型()
+	{
+		string tempDir = CreateTempDir();
+		string template = Path.Combine(tempDir, "voice.wav");
+		File.WriteAllBytes(template, MinimalWav());
+		_config.Set("tts_base_url", new ConfigValue.Text("https://api.modelverse.cn/v1/audio/speech"));
+		_config.Set("tts_model", new ConfigValue.Text("custom/index-tts-model"));
+
+		RecordingHandler handler = new(request =>
+			Task.FromResult(JsonResponse(HttpStatusCode.OK, """{"id":"uspeech:clone"}""")));
+		using HttpClient client = new(handler);
+		IndexTtsProvider provider = new(client, _config, new AppStoragePaths(tempDir));
+
+		await provider.CloneVoiceAsync(template, CancellationToken.None);
+
+		Assert.Equal(new Uri("https://api.modelverse.cn/v1/audio/voice/upload"), handler.LastUri);
+		Assert.Contains("custom/index-tts-model", handler.LastBody, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 原模板删除后过期音色仍从本地存档续期()
+	{
+		string tempDir = CreateTempDir();
+		string template = Path.Combine(tempDir, "voice.wav");
+		File.WriteAllBytes(template, MinimalWav());
+		AppStoragePaths paths = new(tempDir);
+		_config.Set("indextts_template_audio", new ConfigValue.Text(template));
+
+		int uploadCount = 0;
+		RecordingHandler handler = new(request =>
+		{
+			if (request.RequestUri?.AbsolutePath.EndsWith("/audio/voice/upload", StringComparison.Ordinal) == true)
+			{
+				uploadCount++;
+				return Task.FromResult(JsonResponse(HttpStatusCode.OK, $$"""{"id":"uspeech:renew-{{uploadCount}}"}"""));
+			}
+			return Task.FromResult(WavResponse());
+		});
+		using HttpClient client = new(handler);
+		IndexTtsProvider provider = new(client, _config, paths);
+
+		Assert.Equal("uspeech:renew-1", await provider.CloneVoiceAsync(template, CancellationToken.None));
+
+		IndexTtsProvider.IndexTtsVoiceCache cache = JsonSerializer.Deserialize<IndexTtsProvider.IndexTtsVoiceCache>(
+			File.ReadAllText(paths.IndexTtsCachePath))!;
+		IndexTtsProvider.IndexTtsVoiceEntry entry = Assert.Single(cache.Voices.Values);
+		string archivedFile = entry.ArchiveFile;
+		entry.UploadUnixSeconds = DateTimeOffset.UtcNow.AddDays(-8).ToUnixTimeSeconds();
+		File.WriteAllText(paths.IndexTtsCachePath, JsonSerializer.Serialize(cache));
+		File.Delete(template);
+
+		string renewed = await provider.ResolveTemplateVoiceAsync(CancellationToken.None);
+
+		Assert.Equal("uspeech:renew-2", renewed);
+		Assert.Equal(2, uploadCount);
+		Assert.True(File.Exists(archivedFile));
+	}
+
+	[Fact]
+	public async Task 情绪强度零值按零发送()
+	{
+		_config.Set("indextts_emo_alpha", new ConfigValue.Text("0"));
+		RecordingHandler handler = new(_ => Task.FromResult(WavResponse()));
+		using HttpClient client = new(handler);
+		IndexTtsProvider provider = new(client, _config);
+
+		await provider.SynthesizeAsync(
+			"测试",
+			new TtsSynthesizeOptions {Voice = "uspeech:test", EmotionText = "happy"},
+			CancellationToken.None);
+
+		JsonNode body = JsonNode.Parse(handler.LastBody)!;
+		Assert.Equal(0d, body["emo_weight"]?.GetValue<double>());
+	}
+
+	[Fact]
+	public async Task 情绪强度变化会生成新的合成缓存身份()
+	{
+		int synthCount = 0;
+		RecordingHandler handler = new(request =>
+		{
+			if (request.RequestUri?.AbsolutePath.EndsWith("/audio/speech", StringComparison.Ordinal) == true) synthCount++;
+			return Task.FromResult(WavResponse());
+		});
+		using HttpClient client = new(handler);
+		using VoiceService service = new(client, _config, null, () => null);
+		TtsSynthesizeOptions options = new() {Voice = "uspeech:test", EmotionText = "happy"};
+
+		_config.Set("indextts_emo_alpha", new ConfigValue.Text("0.2"));
+		await service.SynthesizeAsync("同一句话", options, CancellationToken.None);
+		_config.Set("indextts_emo_alpha", new ConfigValue.Text("0.8"));
+		await service.SynthesizeAsync("同一句话", options, CancellationToken.None);
+
+		Assert.Equal(2, synthCount);
+	}
+
+	[Theory]
+	[InlineData("𠮷野家", "𠮷野家")]
+	[InlineData("数学字符𝕏仍保留", "数学字符𝕏仍保留")]
+	[InlineData("𠮷野家😊", "𠮷野家")]
+	public void 非Emoji补充平面字符会保留(string input, string expected)
+	{
+		Assert.Equal(expected, VoiceTextSanitizer.StripKaomoji(input));
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_dbPath); } catch (IOException) { }
+	}
+
+	private static string CreateTempDir()
+	{
+		string path = Path.Combine(Path.GetTempPath(), $"nori-indextts-review-files-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(path);
+		return path;
+	}
+
+	private static HttpResponseMessage JsonResponse(HttpStatusCode status, string json) => new(status)
+	{
+		Content = new StringContent(json, Encoding.UTF8, "application/json"),
+	};
+
+	private static HttpResponseMessage WavResponse() => new(HttpStatusCode.OK)
+	{
+		Content = new ByteArrayContent(MinimalWav())
+		{
+			Headers = {ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/wav")},
+		},
+	};
+
+	private static byte[] MinimalWav()
+	{
+		using MemoryStream stream = new(44);
+		using (BinaryWriter writer = new(stream, Encoding.ASCII, leaveOpen: true))
+		{
+			writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+			writer.Write(36);
+			writer.Write(Encoding.ASCII.GetBytes("WAVE"));
+			writer.Write(Encoding.ASCII.GetBytes("fmt "));
+			writer.Write(16);
+			writer.Write((short)1);
+			writer.Write((short)1);
+			writer.Write(24000);
+			writer.Write(48000);
+			writer.Write((short)2);
+			writer.Write((short)16);
+			writer.Write(Encoding.ASCII.GetBytes("data"));
+			writer.Write(0);
+		}
+		return stream.ToArray();
+	}
+
+	private sealed class RecordingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> responder) : HttpMessageHandler
+	{
+		public Uri? LastUri { get; private set; }
+		public string LastBody { get; private set; } = "";
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			LastUri = request.RequestUri;
+			LastBody = request.Content is null ? "" : await request.Content.ReadAsStringAsync(cancellationToken);
+			return await responder(request);
+		}
+	}
+}

--- a/app/desktop/Nori.Core/Voice/IndexTtsProvider.cs
+++ b/app/desktop/Nori.Core/Voice/IndexTtsProvider.cs
@@ -25,6 +25,7 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 	private const string DefaultModel = "IndexTeam/IndexTTS-2";
 	private const double DefaultEmotionAlpha = 0.3;
 	private const string DefaultTemplateAudioConfigKey = "indextts_template_audio";
+	private const string SpeechEndpointSuffix = "/audio/speech";
 
 	/// <summary>音色有效期 (秒), 与平台 7 天一致。</summary>
 	internal static readonly TimeSpan VoiceTtl = TimeSpan.FromDays(7);
@@ -92,13 +93,22 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 		return model.Length == 0 ? DefaultModel : model;
 	}
 
-	private string ResolveEndpoint()
+	private string ResolveApiBaseUrl()
 	{
 		string baseUrl = (config.GetStringOr("tts_base_url", "") is {Length: > 0} saved ? saved : DefaultBaseUrl)
 			.Trim().TrimEnd('/');
-		return baseUrl.EndsWith("/audio/speech", StringComparison.OrdinalIgnoreCase)
-			? baseUrl
-			: $"{baseUrl}/audio/speech";
+		return baseUrl.EndsWith(SpeechEndpointSuffix, StringComparison.OrdinalIgnoreCase)
+			? baseUrl[..^SpeechEndpointSuffix.Length]
+			: baseUrl;
+	}
+
+	private string ResolveEndpoint() => $"{ResolveApiBaseUrl()}{SpeechEndpointSuffix}";
+
+	/// <summary>返回会影响 IndexTTS 合成结果、需要参与合成缓存身份的配置。</summary>
+	internal string GetSynthesisCacheVariant()
+	{
+		double emotionAlpha = ReadDouble(config, "indextts_emo_alpha", DefaultEmotionAlpha);
+		return $"emo_alpha={emotionAlpha.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}";
 	}
 
 	// ---- 模板音频 → 音色 (上传/存档/缓存/续期) ----
@@ -113,16 +123,33 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 	{
 		string templatePath = config.GetStringOr(DefaultTemplateAudioConfigKey, "").Trim();
 		if (templatePath.Length == 0) return "";
-		if (!File.Exists(templatePath)) throw new InvalidOperationException($"IndexTTS-2 音频模板文件不存在: {templatePath}");
 
 		IndexTtsVoiceCache cache = LoadCache();
-		string? cached = cache.FindBySource(templatePath);
-		if (cached is not null && !cache.IsExpired(templatePath))
+		IndexTtsVoiceEntry? entry = cache.FindEntryBySource(templatePath);
+		if (entry is not null)
 		{
-			return cached;
+			if (!string.IsNullOrWhiteSpace(entry.VoiceId) && !cache.IsExpired(templatePath))
+			{
+				return entry.VoiceId;
+			}
+
+			// 已缓存音色续期时优先读取应用自己的存档；原始模板即使被移动、删除或位于离线盘也不影响续期。
+			if (!string.IsNullOrWhiteSpace(entry.ArchiveFile) && File.Exists(entry.ArchiveFile))
+			{
+				return await UploadAndCacheVoiceAsync(
+					templatePath,
+					entry.ArchiveFile,
+					string.IsNullOrWhiteSpace(entry.Name) ? Path.GetFileNameWithoutExtension(templatePath) : entry.Name,
+					cache,
+					cancellationToken);
+			}
 		}
 
-		// 过期或未缓存：克隆（过期时用存档音频续期，key 不变）。
+		if (!File.Exists(templatePath))
+		{
+			throw new InvalidOperationException($"IndexTTS-2 音频模板文件不存在，且没有可用的本地存档: {templatePath}");
+		}
+
 		return await CloneVoiceAsync(templatePath, cache, cancellationToken);
 	}
 
@@ -137,15 +164,23 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 
 	private async Task<string> CloneVoiceAsync(string templatePath, IndexTtsVoiceCache cache, CancellationToken cancellationToken)
 	{
+		string archiveFile = ArchiveTemplateAudio(templatePath);
+		string name = Path.GetFileNameWithoutExtension(templatePath);
+		return await UploadAndCacheVoiceAsync(templatePath, archiveFile, name, cache, cancellationToken);
+	}
+
+	private async Task<string> UploadAndCacheVoiceAsync(
+		string sourcePath,
+		string archiveFile,
+		string name,
+		IndexTtsVoiceCache cache,
+		CancellationToken cancellationToken)
+	{
 		string apiKey = config.GetStringOr("tts_api_key", "").Trim();
 		if (string.IsNullOrWhiteSpace(apiKey)) throw new InvalidOperationException("未配置 IndexTTS-2 API Key");
 
-		// 存档参考音频（内容 hash 去重），续期走这份存档而不是用户原始路径。
-		string archiveFile = ArchiveTemplateAudio(templatePath);
-		string name = Path.GetFileNameWithoutExtension(templatePath);
 		string voiceId = await UploadVoiceAsync(archiveFile, name, apiKey, cancellationToken);
-
-		cache.Set(templatePath, voiceId, archiveFile, name, DateTimeOffset.UtcNow);
+		cache.Set(sourcePath, voiceId, archiveFile, name, DateTimeOffset.UtcNow);
 		SaveCache(cache);
 		return voiceId;
 	}
@@ -168,9 +203,7 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 
 	private async Task<string> UploadVoiceAsync(string audioFile, string name, string apiKey, CancellationToken cancellationToken)
 	{
-		string baseUrl = (config.GetStringOr("tts_base_url", "") is {Length: > 0} saved ? saved : DefaultBaseUrl)
-			.Trim().TrimEnd('/');
-		string url = $"{baseUrl}/audio/voice/upload";
+		string url = $"{ResolveApiBaseUrl()}/audio/voice/upload";
 
 		using MultipartFormDataContent form = new();
 		byte[] audioBytes = await File.ReadAllBytesAsync(audioFile, cancellationToken);
@@ -178,7 +211,7 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 		file.Headers.TryAddWithoutValidation("Content-Type", InferAudioMime(audioFile));
 		form.Add(file, "speaker_file", Path.GetFileName(audioFile));
 		form.Add(new StringContent(name), "name");
-		form.Add(new StringContent(DefaultModel), "model");
+		form.Add(new StringContent(ResolveModel()), "model");
 
 		using HttpRequestMessage request = new(HttpMethod.Post, url) {Content = form};
 		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
@@ -266,19 +299,25 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 		/// <remarks>Windows 路径大小写不敏感，统一用忽略大小写比较，避免同一文件不同大小写重复克隆。</remarks>
 		public Dictionary<string, IndexTtsVoiceEntry> Voices { get; set; } = new(PathKeyComparer);
 
+		/// <summary>按源路径查找缓存条目。</summary>
+		public IndexTtsVoiceEntry? FindEntryBySource(string sourcePath)
+		{
+			string key = NormalizeKey(sourcePath);
+			return Voices.TryGetValue(key, out IndexTtsVoiceEntry? entry) ? entry : null;
+		}
+
 		/// <summary>按源路径查找未过期的 voice_id。</summary>
 		public string? FindBySource(string sourcePath)
 		{
-			string key = NormalizeKey(sourcePath);
-			if (!Voices.TryGetValue(key, out IndexTtsVoiceEntry? entry)) return null;
-			return string.IsNullOrWhiteSpace(entry.VoiceId) ? null : entry.VoiceId;
+			IndexTtsVoiceEntry? entry = FindEntryBySource(sourcePath);
+			return entry is null || string.IsNullOrWhiteSpace(entry.VoiceId) ? null : entry.VoiceId;
 		}
 
 		/// <summary>判断源路径对应音色是否已过期。</summary>
 		public bool IsExpired(string sourcePath)
 		{
-			string key = NormalizeKey(sourcePath);
-			if (!Voices.TryGetValue(key, out IndexTtsVoiceEntry? entry)) return true;
+			IndexTtsVoiceEntry? entry = FindEntryBySource(sourcePath);
+			if (entry is null) return true;
 			long uploaded = entry.UploadUnixSeconds;
 			if (uploaded <= 0) return true;
 			return DateTimeOffset.UtcNow - DateTimeOffset.FromUnixTimeSeconds(uploaded) > VoiceTtl;
@@ -343,7 +382,7 @@ public sealed class IndexTtsProvider(HttpClient httpClient, ConfigStore config, 
 	/// <summary>读取数值配置, 非法或缺失时回退默认值。</summary>
 	private static double ReadDouble(ConfigStore config, string key, double fallback) =>
 		double.TryParse(config.GetStringOr(key, ""), System.Globalization.NumberStyles.Float,
-			System.Globalization.CultureInfo.InvariantCulture, out double value) && value is > 0 and <= 1 ? value : fallback;
+			System.Globalization.CultureInfo.InvariantCulture, out double value) && value is >= 0 and <= 1 ? value : fallback;
 
 	/// <summary>从配置读取可选扩展字段；配置值存在且非空时才加入 payload。</summary>
 	private static void AppendOptional(JsonObject payload, ConfigStore config, string configKey, string apiField)

--- a/app/desktop/Nori.Core/Voice/VoiceService.cs
+++ b/app/desktop/Nori.Core/Voice/VoiceService.cs
@@ -247,6 +247,11 @@ public sealed class VoiceService : IDisposable
 			merged = merged with {Voice = resolvedVoice};
 		}
 		string endpoint = ResolveProviderEndpoint(providerName);
+		// IndexTTS 的情绪强度会改变音频结果，也要参与缓存身份；这样配置从任何入口变化都不会命中旧音频。
+		if (provider is IndexTtsProvider cacheAwareIndexTts)
+		{
+			endpoint = $"{endpoint}:{cacheAwareIndexTts.GetSynthesisCacheVariant()}";
+		}
 		string key = AudioSynthesisCache.CreateKey(endpoint, merged.Voice, merged.Speed, text, merged.EmotionText);
 		if (SynthesisCache.TryGet(key, out EncodedAudio cached)) return cached;
 

--- a/app/desktop/Nori.Core/Voice/VoiceTextSanitizer.cs
+++ b/app/desktop/Nori.Core/Voice/VoiceTextSanitizer.cs
@@ -90,7 +90,7 @@ public static class VoiceTextSanitizer
 
 		while (i < length)
 		{
-			// 跳过 emoji（代理对 / 变体选择符 / ZWJ），IndexTTS 会读成怪叫
+			// 跳过真正的 emoji Unicode scalar 及其变体/ZWJ 组合。
 			if (IsEmojiAt(text, i))
 			{
 				i += EmojiLength(text, i);
@@ -101,7 +101,6 @@ public static class VoiceTextSanitizer
 			int leadStart = i;
 			int cursor = i;
 			while (cursor < length && LeadDecor.Contains(text[cursor])) cursor++;
-			int contentStart = cursor;
 
 			// 是否是开括号
 			bool isOpen = cursor < length && (text[cursor] == '(' || text[cursor] == '（');
@@ -172,82 +171,78 @@ public static class VoiceTextSanitizer
 		return false;
 	}
 
-	/// <summary>判断位置 i 是否处于一个 emoji 序列的起点（代理对 / 变体选择符 / ZWJ / 常见 emoji 符号）。</summary>
+	/// <summary>判断位置 i 是否处于一个 emoji 序列的起点。</summary>
 	private static bool IsEmojiAt(string text, int i)
 	{
 		char c = text[i];
-		// 补充平面（U+10000 以上）：代理对，基本全是 emoji / 罕见表意字，TTS 语境按 emoji 处理
-		if (char.IsHighSurrogate(c)) return true;
-		// 低代理不应出现在这里（前面已被 HighSurrogate 消费），保险起见也跳过
-		if (char.IsLowSurrogate(c)) return true;
-		// 变体选择符 VS16（U+FE0F，emoji 形式）与 VS15（U+FE0E）
-		if (c == '\uFE0F' || c == '\uFE0E') return true;
-		// ZWJ 零宽连接符（多 emoji 组合，如 👨👩👧）
-		if (c == '\u200D') return true;
-		// 杂项符号区中常见 emoji（U+2600–U+27BF 子集）
-		return EmojiSymbol.Contains(c);
+		if (c == '\uFE0F' || c == '\uFE0E' || c == '\u200D') return true;
+		if (!Rune.TryGetRuneAt(text, i, out Rune rune)) return false;
+		return IsEmojiRune(rune);
 	}
 
-	/// <summary>从位置 i 起跳过整个 emoji 序列（含后续变体选择符/ZWJ 组合），返回序列长度。</summary>
+	/// <summary>判断 Unicode scalar 是否属于需要从 TTS 文本中去除的 emoji。</summary>
+	private static bool IsEmojiRune(Rune rune)
+	{
+		int value = rune.Value;
+		if (value <= char.MaxValue) return EmojiSymbol.Contains((char)value);
+
+		return value is 0x1F004 or 0x1F0CF
+			|| value is >= 0x1F1E6 and <= 0x1F1FF
+			|| value is >= 0x1F300 and <= 0x1F5FF
+			|| value is >= 0x1F600 and <= 0x1F64F
+			|| value is >= 0x1F680 and <= 0x1F6FF
+			|| value is >= 0x1F7E0 and <= 0x1F7EB
+			|| value is >= 0x1F900 and <= 0x1F9FF
+			|| value is >= 0x1FA70 and <= 0x1FAFF;
+	}
+
+	/// <summary>从位置 i 起跳过整个 emoji 序列（含后续变体选择符/ZWJ 组合），返回 UTF-16 长度。</summary>
 	private static int EmojiLength(string text, int i)
 	{
-		int count = 0;
-		while (i + count < text.Length)
+		int cursor = i;
+		while (cursor < text.Length)
 		{
-			char c = text[i + count];
-			if (char.IsHighSurrogate(c))
+			char c = text[cursor];
+			if (c == '\uFE0F' || c == '\uFE0E' || c == '\u200D')
 			{
-				if (i + count + 1 < text.Length && char.IsLowSurrogate(text[i + count + 1]))
-				{
-					count += 2;
-					continue;
-				}
-				count++;
+				cursor++;
 				continue;
 			}
-			if (char.IsLowSurrogate(c) || c == '\uFE0F' || c == '\uFE0E' || c == '\u200D')
-			{
-				count++;
-				continue;
-			}
-			if (EmojiSymbol.Contains(c))
-			{
-				count++;
-				continue;
-			}
-			break;
+
+			if (!Rune.TryGetRuneAt(text, cursor, out Rune rune) || !IsEmojiRune(rune)) break;
+			cursor += rune.Utf16SequenceLength;
 		}
-		return Math.Max(1, count);
+		return Math.Max(1, cursor - i);
 	}
 
 	/// <summary>杂项符号/装饰符号区中常见的 emoji 字符（单 char 表示的 emoji）。</summary>
 	private static readonly HashSet<char> EmojiSymbol =
 	[
-		'\u00A9', // ©
-		'\u00AE', // ®
-		'\u203C', // ‼
-		'\u2049', // ⁉
-		'\u2122', // ™
-		'\u2139', // ℹ
-		'\u2194', '\u2195', '\u2196', '\u2197', '\u2198', '\u2199', // ↔ ↕ ↖ ↗ ↘ ↙
-		'\u21A9', '\u21AA', // ↩ ↪
-		'\u231A', '\u231B', // ⌚ ⌛
-		'\u2328', // ⌨
-		'\u23CF', '\u23E9', '\u23EA', '\u23EB', '\u23EC', '\u23ED', '\u23EE', '\u23EF', '\u23F0', '\u23F1', '\u23F2', '\u23F3', // ⏏ ⏩ ⏪ ⏫ ⏬ ⏭ ⏮ ⏯ ⏰ ⏱ ⏲ ⏳
-		'\u23F8', '\u23F9', '\u23FA', // ⏸ ⏹ ⏺
-		'\u24C2', // Ⓜ
-		'\u25AA', '\u25AB', '\u25B6', '\u25C0', '\u25FB', '\u25FC', '\u25FD', '\u25FE', // ▪ ▫ ▶ ◀ ◻ ◼ ◽ ◾
-		'\u2600', '\u2601', '\u2602', '\u2603', '\u2604', '\u260E', '\u2611', '\u2614', '\u2615', // ☀ ☁ ☂ ☃ ☄ ☎ ☑ ☔ ☕
-		'\u2618', '\u261D', '\u2620', '\u2622', '\u2623', '\u2626', '\u262A', '\u262E', '\u262F', '\u2638', '\u2639', '\u263A', // ☘ ☝ ☠ ☢ ☣ ☦ ☪ ☮ ☯ ☸ ☹ ☺
-		'\u2640', '\u2642', '\u2648', '\u2649', '\u264A', '\u264B', '\u264C', '\u264D', '\u264E', '\u264F', '\u2650', '\u2651', '\u2652', '\u2653', // ♀ ♂ 十二星座
-		'\u2660', '\u2663', '\u2665', '\u2666', '\u2668', // ♠ ♣ ♥ ♦ ♨
-		'\u267B', '\u267E', '\u267F', // ♻ ♾ ♿
-		'\u2692', '\u2693', '\u2694', '\u2696', '\u2697', '\u2699', '\u269B', '\u269C', '\u26A0', '\u26A1', '\u26A7', '\u26AA', '\u26AB', // ⚒ ⚓ ⚔ ⚖ ⚗ ⚙ ⚛ ⚜ ⚠ ⚡ ⚧ ⚪ ⚫
-		'\u26B0', '\u26B1', '\u26BD', '\u26BE', // ⚰ ⚱ ⚽ ⚾
-		'\u26C4', '\u26C5', '\u26C8', '\u26CE', '\u26CF', '\u26D1', '\u26D3', '\u26D4', '\u26E9', '\u26EA', '\u26F0', '\u26F1', '\u26F2', '\u26F3', '\u26F4', '\u26F5', '\u26F7', '\u26F8', '\u26F9', '\u26FA', '\u26FD', // ⛄ ⛅ ⛈ ⛎ ⛏ ⛑ ⛓ ⛔ ⛩ ⛪ ⛰ ⛱ ⛲ ⛳ ⛴ ⛵ ⛷ ⛸ ⛹ ⛺ ⛽
-		'\u2702', '\u2705', '\u2708', '\u2709', '\u270A', '\u270B', '\u270C', '\u270D', '\u270F', '\u2712', '\u2714', '\u2716', '\u271D', '\u2721', // ✂ ✅ ✈ ✉ ✊ ✋ ✌ ☝ ✍ ✏ ✒ ✔ ✖ ✝ ✡
-		'\u2728', '\u2733', '\u2734', '\u2744', '\u2747', '\u274C', '\u274E', '\u2753', '\u2754', '\u2755', '\u2757', // ✨ ✳ ✴ ❄ ❇ ❌ ❎ ❓ ❔ ❕ ❗
-		'\u2763', '\u2764', '\u2795', '\u2796', '\u2797', '\u27A1', '\u27B0', '\u27BF', // ❣ ❤ ➕ ➖ ➗ ➡ ➰ ➿
+		'\u00A9',
+		'\u00AE',
+		'\u203C',
+		'\u2049',
+		'\u2122',
+		'\u2139',
+		'\u2194', '\u2195', '\u2196', '\u2197', '\u2198', '\u2199',
+		'\u21A9', '\u21AA',
+		'\u231A', '\u231B',
+		'\u2328',
+		'\u23CF', '\u23E9', '\u23EA', '\u23EB', '\u23EC', '\u23ED', '\u23EE', '\u23EF', '\u23F0', '\u23F1', '\u23F2', '\u23F3',
+		'\u23F8', '\u23F9', '\u23FA',
+		'\u24C2',
+		'\u25AA', '\u25AB', '\u25B6', '\u25C0', '\u25FB', '\u25FC', '\u25FD', '\u25FE',
+		'\u2600', '\u2601', '\u2602', '\u2603', '\u2604', '\u260E', '\u2611', '\u2614', '\u2615',
+		'\u2618', '\u261D', '\u2620', '\u2622', '\u2623', '\u2626', '\u262A', '\u262E', '\u262F', '\u2638', '\u2639', '\u263A',
+		'\u2640', '\u2642', '\u2648', '\u2649', '\u264A', '\u264B', '\u264C', '\u264D', '\u264E', '\u264F', '\u2650', '\u2651', '\u2652', '\u2653',
+		'\u2660', '\u2663', '\u2665', '\u2666', '\u2668',
+		'\u267B', '\u267E', '\u267F',
+		'\u2692', '\u2693', '\u2694', '\u2696', '\u2697', '\u2699', '\u269B', '\u269C', '\u26A0', '\u26A1', '\u26A7', '\u26AA', '\u26AB',
+		'\u26B0', '\u26B1', '\u26BD', '\u26BE',
+		'\u26C4', '\u26C5', '\u26C8', '\u26CE', '\u26CF', '\u26D1', '\u26D3', '\u26D4', '\u26E9', '\u26EA', '\u26F0', '\u26F1', '\u26F2', '\u26F3', '\u26F4', '\u26F5', '\u26F7', '\u26F8', '\u26F9', '\u26FA', '\u26FD',
+		'\u2702', '\u2705', '\u2708', '\u2709', '\u270A', '\u270B', '\u270C', '\u270D', '\u270F', '\u2712', '\u2714', '\u2716', '\u271D', '\u2721',
+		'\u2728', '\u2733', '\u2734', '\u2744', '\u2747', '\u274C', '\u274E', '\u2753', '\u2754', '\u2755', '\u2757',
+		'\u2763', '\u2764', '\u2795', '\u2796', '\u2797', '\u27A1', '\u27B0', '\u27BF',
 	];
 
 	private static bool AllIn(string content, HashSet<char> set)


### PR DESCRIPTION
## 类型

- [x] Bug 修复

## 背景

跟进已合并的 #33 中 Codex Review 提出的 6 个问题。

## 修复内容

- 音色解析改为先读取缓存；原始模板被移动、删除或离线时，未过期 voice_id 仍可直接使用，过期后优先使用 `ArchiveFile` 自动续期。
- 统一归一化 IndexTTS API Base URL；当 `tts_base_url` 已配置为完整 `/audio/speech` 端点时，克隆仍正确请求 `/audio/voice/upload`。
- 克隆上传使用配置后的 `tts_model`，与后续合成保持一致。
- `indextts_emo_alpha=0` 作为合法值保留，不再回退到 0.3。
- IndexTTS 情绪强度加入合成缓存身份，强度变化后不会命中旧音频缓存，即使配置不是从设置页入口修改也能正确失效。
- emoji 清洗改为基于 Unicode scalar 判断真实 emoji 范围，不再把所有 UTF-16 代理对都当作 emoji；`𠮷`、`𝕏` 等补充平面字符会被保留。

## 回归测试

新增 `IndexTtsReviewRegressionTests`，覆盖：

- 完整 speech endpoint 下的克隆 URL
- 克隆使用自定义 model
- 删除原模板后的存档续期
- 情绪强度 0
- 情绪强度变化后的缓存失效
- 非 emoji 补充平面字符保留

## 关联

Follow-up for #33.