### PR TITLE
chore: add reproducible Codex Cloud environment setup

### DIFF
--- a/app/desktop/scripts/codex-cloud-maintenance.sh
+++ b/app/desktop/scripts/codex-cloud-maintenance.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DESKTOP_DIR="$REPO_ROOT/app/desktop"
+
+log() {
+	printf '[nori-codex] %s\n' "$*"
+}
+
+if ! command -v pnpm >/dev/null 2>&1; then
+	echo "pnpm 不可用，Codex Cloud 缓存环境需要重建。" >&2
+	exit 1
+fi
+
+if ! command -v dotnet >/dev/null 2>&1 || ! dotnet --list-sdks 2>/dev/null | grep -Eq '^10\.0\.'; then
+	echo ".NET 10 SDK 不可用，Codex Cloud 缓存环境需要重建。" >&2
+	exit 1
+fi
+
+cd "$DESKTOP_DIR"
+
+log "同步前端依赖。"
+pnpm install --frozen-lockfile
+
+log "同步 .NET solution 依赖。"
+dotnet restore Nori.slnx
+
+log "同步 Linux 发布 RID 依赖。"
+dotnet restore Nori.Desktop/Nori.Desktop.csproj --runtime linux-x64
+
+log "Codex Cloud 缓存维护完成。"

--- a/app/desktop/scripts/codex-cloud-maintenance.sh
+++ b/app/desktop/scripts/codex-cloud-maintenance.sh
@@ -8,6 +8,15 @@ log() {
 	printf '[nori-codex] %s\n' "$*"
 }
 
+if [[ -x "$HOME/.dotnet/dotnet" ]]; then
+	export DOTNET_ROOT="$HOME/.dotnet"
+	export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+fi
+
+if [[ -d "$HOME/.local/bin" ]]; then
+	export PATH="$HOME/.local/bin:$PATH"
+fi
+
 if ! command -v pnpm >/dev/null 2>&1; then
 	echo "pnpm 不可用，Codex Cloud 缓存环境需要重建。" >&2
 	exit 1

--- a/app/desktop/scripts/codex-cloud-maintenance.sh
+++ b/app/desktop/scripts/codex-cloud-maintenance.sh
@@ -8,6 +8,15 @@ log() {
 	printf '[nori-codex] %s\n' "$*"
 }
 
+if command -v mise >/dev/null 2>&1; then
+	NODE24_DIR="$(mise where node@24 2>/dev/null || true)"
+	if [[ -n "$NODE24_DIR" ]]; then
+		export PATH="$NODE24_DIR/bin:$PATH"
+		hash -r
+	fi
+	unset NODE24_DIR
+fi
+
 if [[ -x "$HOME/.dotnet/dotnet" ]]; then
 	export DOTNET_ROOT="$HOME/.dotnet"
 	export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
@@ -15,6 +24,11 @@ fi
 
 if [[ -d "$HOME/.local/bin" ]]; then
 	export PATH="$HOME/.local/bin:$PATH"
+fi
+
+if ! command -v node >/dev/null 2>&1 || (( $(node -p 'process.versions.node.split(".")[0]') < 24 )); then
+	echo "Node.js 24 不可用，Codex Cloud 缓存环境需要重建。" >&2
+	exit 1
 fi
 
 if ! command -v pnpm >/dev/null 2>&1; then

--- a/app/desktop/scripts/codex-cloud-setup.sh
+++ b/app/desktop/scripts/codex-cloud-setup.sh
@@ -31,16 +31,48 @@ install_linux_dependencies() {
 		libwebkit2gtk-4.1-0
 }
 
-ensure_node() {
-	if ! command -v node >/dev/null 2>&1; then
-		echo "未找到 Node.js。请在 Codex Cloud 的包版本中选择 Node.js 24。" >&2
+activate_node24() {
+	if ! command -v mise >/dev/null 2>&1; then
+		echo "Codex universal 环境中未找到 mise，无法安装 Nori.Desktop 所需的 Node.js 24。" >&2
 		exit 1
 	fi
 
-	local node_major
-	node_major="$(node -p 'process.versions.node.split(".")[0]')"
+	log "通过 mise 准备 Node.js 24。"
+	mise install node@24
+
+	local node_dir
+	node_dir="$(mise where node@24)"
+	export PATH="$node_dir/bin:$PATH"
+	hash -r
+
+	if ! grep -Fq '# Nori Codex Cloud Node.js 24' "$HOME/.bashrc" 2>/dev/null; then
+		cat >> "$HOME/.bashrc" <<'EOF'
+
+# Nori Codex Cloud Node.js 24
+if command -v mise >/dev/null 2>&1; then
+	NORI_NODE24_DIR="$(mise where node@24 2>/dev/null || true)"
+	if [[ -n "$NORI_NODE24_DIR" ]]; then
+		export PATH="$NORI_NODE24_DIR/bin:$PATH"
+	fi
+	unset NORI_NODE24_DIR
+fi
+EOF
+	fi
+}
+
+ensure_node() {
+	local node_major=0
+	if command -v node >/dev/null 2>&1; then
+		node_major="$(node -p 'process.versions.node.split(".")[0]')"
+	fi
+
 	if (( node_major < 24 )); then
-		echo "Nori.Desktop 需要 Node.js 24+，当前为 $(node --version)。请在 Codex Cloud 中切换到 Node.js 24。" >&2
+		activate_node24
+		node_major="$(node -p 'process.versions.node.split(".")[0]')"
+	fi
+
+	if (( node_major < 24 )); then
+		echo "Nori.Desktop 需要 Node.js 24+，当前为 $(node --version)。" >&2
 		exit 1
 	fi
 

--- a/app/desktop/scripts/codex-cloud-setup.sh
+++ b/app/desktop/scripts/codex-cloud-setup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DESKTOP_DIR="$REPO_ROOT/app/desktop"
+
+log() {
+	printf '[nori-codex] %s\n' "$*"
+}
+
+install_linux_dependencies() {
+	if ! command -v apt-get >/dev/null 2>&1; then
+		log "当前环境不是 apt 系 Linux，跳过 Linux 原生依赖安装。"
+		return
+	fi
+
+	local sudo_cmd=()
+	if [[ "$(id -u)" -ne 0 ]]; then
+		if ! command -v sudo >/dev/null 2>&1; then
+			echo "需要 root 或 sudo 才能安装 WebKitGTK/GTK 依赖。" >&2
+			exit 1
+		fi
+		sudo_cmd=(sudo)
+	fi
+
+	log "安装 Linux WebView/GTK 依赖。"
+	"${sudo_cmd[@]}" apt-get update
+	"${sudo_cmd[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		ca-certificates \
+		libgtk-3-0 \
+		libwebkit2gtk-4.1-0
+}
+
+ensure_node() {
+	if ! command -v node >/dev/null 2>&1; then
+		echo "未找到 Node.js。请在 Codex Cloud 的包版本中选择 Node.js 24。" >&2
+		exit 1
+	fi
+
+	local node_major
+	node_major="$(node -p 'process.versions.node.split(".")[0]')"
+	if (( node_major < 24 )); then
+		echo "Nori.Desktop 需要 Node.js 24+，当前为 $(node --version)。请在 Codex Cloud 中切换到 Node.js 24。" >&2
+		exit 1
+	fi
+
+	log "Node.js $(node --version) 可用。"
+}
+
+ensure_pnpm() {
+	if command -v pnpm >/dev/null 2>&1 && [[ "$(pnpm --version | cut -d. -f1)" == "11" ]]; then
+		log "pnpm $(pnpm --version) 可用。"
+		return
+	fi
+
+	log "激活 pnpm 11。"
+	if command -v corepack >/dev/null 2>&1; then
+		corepack enable
+		corepack prepare pnpm@11 --activate
+	else
+		mkdir -p "$HOME/.local"
+		npm config set prefix "$HOME/.local"
+		export PATH="$HOME/.local/bin:$PATH"
+		if ! grep -Fq 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
+			printf '\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$HOME/.bashrc"
+		fi
+		npm install --global pnpm@11
+	fi
+}
+
+ensure_dotnet() {
+	if command -v dotnet >/dev/null 2>&1 && dotnet --list-sdks 2>/dev/null | grep -Eq '^10\.0\.'; then
+		log ".NET 10 SDK 已可用。"
+		return
+	fi
+
+	log "安装 .NET 10 SDK 到 ~/.dotnet。"
+	local installer="/tmp/nori-dotnet-install.sh"
+	curl -fsSL https://dot.net/v1/dotnet-install.sh -o "$installer"
+	bash "$installer" --channel 10.0 --quality GA --install-dir "$HOME/.dotnet" --no-path
+	rm -f "$installer"
+
+	export DOTNET_ROOT="$HOME/.dotnet"
+	export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+
+	if ! grep -Fq '# Nori Codex Cloud .NET' "$HOME/.bashrc" 2>/dev/null; then
+		cat >> "$HOME/.bashrc" <<'EOF'
+
+# Nori Codex Cloud .NET
+export DOTNET_ROOT="$HOME/.dotnet"
+export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+EOF
+	fi
+
+	if ! dotnet --list-sdks | grep -Eq '^10\.0\.'; then
+		echo ".NET 10 SDK 安装后仍不可用。" >&2
+		exit 1
+	fi
+}
+
+restore_dependencies() {
+	cd "$DESKTOP_DIR"
+
+	log "安装前端依赖。"
+	pnpm install --frozen-lockfile
+
+	log "还原 .NET solution 依赖。"
+	dotnet restore Nori.slnx
+
+	log "预还原 Codex Cloud Linux 发布 RID 依赖。"
+	dotnet restore Nori.Desktop/Nori.Desktop.csproj --runtime linux-x64
+}
+
+install_linux_dependencies
+ensure_node
+ensure_pnpm
+ensure_dotnet
+restore_dependencies
+
+log "Codex Cloud 环境准备完成。"
+log "Node: $(node --version) | pnpm: $(pnpm --version) | dotnet: $(dotnet --version)"

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -8,7 +8,8 @@
 
 包版本：
 
-- Node.js：`24`
+- Node.js：在 Codex Cloud 面板选择 `22`
+- Codex `universal` 当前内置 Node 版本选择最高为 `22`；setup script 会通过镜像自带的 `mise` 额外安装并激活 Nori.Desktop 要求的 Node.js `24`
 - 其他 Codex 内置语言运行时保持默认
 - .NET 10 SDK 由 setup script 检查并在缺失时安装到 `~/.dotnet`
 - pnpm 由 setup script 固定到 `11.x`
@@ -38,7 +39,7 @@ CI=1
 
 ## 网络访问
 
-Setup script 需要联网安装系统依赖、.NET SDK、pnpm、npm 依赖和 NuGet 依赖。Codex Cloud 的 setup 阶段本身允许访问互联网。
+Setup script 需要联网安装系统依赖、Node.js 24、.NET SDK、pnpm、npm 依赖和 NuGet 依赖。Codex Cloud 的 setup 阶段本身允许访问互联网。
 
 Agent 阶段推荐使用“常用依赖项”域名允许列表，并只开放 `GET`、`HEAD`、`OPTIONS`。这样在修改依赖版本或新增依赖时仍可读取 npm、NuGet 与源码托管资源，同时避免给普通代码任务开放不必要的写网络请求。
 
@@ -49,20 +50,24 @@ Agent 阶段推荐使用“常用依赖项”域名允许列表，并只开放 `
 `app/desktop/scripts/codex-cloud-setup.sh` 会：
 
 1. 在 apt 系 Linux 环境安装 `libgtk-3-0` 与 `libwebkit2gtk-4.1-0`，与 Linux CI 保持一致。
-2. 验证 Node.js 24+。
+2. 检测当前 Node.js；当 Codex 面板提供的 Node.js 22 低于项目要求时，通过 `mise` 安装并激活 Node.js 24。
 3. 固定 pnpm 11。
 4. 验证 .NET 10 SDK；缺失时安装到 `~/.dotnet`，并将路径持久化到 `~/.bashrc`。
 5. 在 `app/desktop` 执行 `pnpm install --frozen-lockfile`。
 6. 执行 `dotnet restore Nori.slnx`。
 7. 额外预还原 `linux-x64` 发布依赖，避免 Agent 阶段发布时再次联网还原。
 
-Maintenance script 用于恢复缓存容器后的依赖同步。它不会重复安装系统包或 SDK，只会重新同步 pnpm 和 NuGet 依赖。
+Maintenance script 用于恢复缓存容器后的依赖同步。它会重新定位由 `mise` 安装的 Node.js 24 和 `~/.dotnet`，再同步 pnpm 与 NuGet 依赖。
 
 ## 环境验证
 
 环境创建后，可以让 Codex 在 `app/desktop` 中执行以下门禁：
 
 ```bash
+node --version
+pnpm --version
+dotnet --version
+
 pnpm check:todo
 pnpm lint
 pnpm build
@@ -71,6 +76,8 @@ pnpm test
 dotnet build Nori.slnx --configuration Release
 dotnet test Nori.slnx --configuration Release --no-build --no-restore -m:1
 ```
+
+其中 `node --version` 应显示 `v24.x`。Codex 面板选择 Node.js 22 只决定基础环境版本，真正运行 Nori.Desktop 构建时会使用 setup script 准备的 Node.js 24。
 
 覆盖率任务按需运行：
 
@@ -83,5 +90,6 @@ Windows 发布、Windows WebView2 和 Windows 启动冒烟测试无法在 Codex 
 
 ## 官方参考
 
+- Codex Universal 镜像：https://github.com/openai/codex-universal
 - Codex Cloud 环境：https://learn.chatgpt.com/docs/environments/cloud-environment
 - Codex Cloud：https://learn.chatgpt.com/docs/cloud

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -1,0 +1,87 @@
+# Codex Cloud 环境
+
+本文件记录 `MF-Dust/Nori.Desktop` 在 Codex Cloud 中的推荐环境配置。项目的具体开发、构建和测试约束继续以仓库根目录的 `AGENTS.md` 为准。
+
+## 环境设置
+
+在 Codex 的环境设置中选择本仓库，并使用默认 `universal` 镜像。
+
+包版本：
+
+- Node.js：`24`
+- 其他 Codex 内置语言运行时保持默认
+- .NET 10 SDK 由 setup script 检查并在缺失时安装到 `~/.dotnet`
+- pnpm 由 setup script 固定到 `11.x`
+
+Setup script：
+
+```bash
+bash app/desktop/scripts/codex-cloud-setup.sh
+```
+
+Maintenance script：
+
+```bash
+bash app/desktop/scripts/codex-cloud-maintenance.sh
+```
+
+建议配置的环境变量：
+
+```text
+DOTNET_CLI_TELEMETRY_OPTOUT=1
+DOTNET_NOLOGO=1
+NUGET_XMLDOC_MODE=skip
+CI=1
+```
+
+普通构建、测试和代码修改不需要额外 secret。涉及发布、Sentry 上传或其他外部服务时，再为对应任务单独配置所需凭据，避免把长期凭据混入通用开发环境。
+
+## 网络访问
+
+Setup script 需要联网安装系统依赖、.NET SDK、pnpm、npm 依赖和 NuGet 依赖。Codex Cloud 的 setup 阶段本身允许访问互联网。
+
+Agent 阶段推荐使用“常用依赖项”域名允许列表，并只开放 `GET`、`HEAD`、`OPTIONS`。这样在修改依赖版本或新增依赖时仍可读取 npm、NuGet 与源码托管资源，同时避免给普通代码任务开放不必要的写网络请求。
+
+如果任务只修改现有代码，且 setup 已完整还原依赖，也可以关闭 Agent 阶段互联网访问。
+
+## Setup script 做了什么
+
+`app/desktop/scripts/codex-cloud-setup.sh` 会：
+
+1. 在 apt 系 Linux 环境安装 `libgtk-3-0` 与 `libwebkit2gtk-4.1-0`，与 Linux CI 保持一致。
+2. 验证 Node.js 24+。
+3. 固定 pnpm 11。
+4. 验证 .NET 10 SDK；缺失时安装到 `~/.dotnet`，并将路径持久化到 `~/.bashrc`。
+5. 在 `app/desktop` 执行 `pnpm install --frozen-lockfile`。
+6. 执行 `dotnet restore Nori.slnx`。
+7. 额外预还原 `linux-x64` 发布依赖，避免 Agent 阶段发布时再次联网还原。
+
+Maintenance script 用于恢复缓存容器后的依赖同步。它不会重复安装系统包或 SDK，只会重新同步 pnpm 和 NuGet 依赖。
+
+## 环境验证
+
+环境创建后，可以让 Codex 在 `app/desktop` 中执行以下门禁：
+
+```bash
+pnpm check:todo
+pnpm lint
+pnpm build
+pnpm test
+
+dotnet build Nori.slnx --configuration Release
+dotnet test Nori.slnx --configuration Release --no-build --no-restore -m:1
+```
+
+覆盖率任务按需运行：
+
+```bash
+pnpm coverage
+pnpm coverage:dotnet --no-build --no-restore
+```
+
+Windows 发布、Windows WebView2 和 Windows 启动冒烟测试无法在 Codex Cloud 的 Linux 容器中原生复现，继续以 GitHub Actions 的 Windows job 为最终平台门禁。
+
+## 官方参考
+
+- Codex Cloud 环境：https://learn.chatgpt.com/docs/environments/cloud-environment
+- Codex Cloud：https://learn.chatgpt.com/docs/cloud


### PR DESCRIPTION
## 变更内容

- 新增 `app/desktop/scripts/codex-cloud-setup.sh`
  - 安装 Linux WebKitGTK / GTK 依赖
  - 兼容 Codex Cloud 面板最高 Node.js 22 的限制
  - 通过 universal 镜像自带的 `mise` 安装并激活 Nori.Desktop 所需 Node.js 24
  - 固定 pnpm 11
  - 缺失时安装 .NET 10 SDK 到 `~/.dotnet`
  - 预还原 pnpm、NuGet 与 `linux-x64` RID 依赖
- 新增 `app/desktop/scripts/codex-cloud-maintenance.sh`
  - 用于 Codex Cloud 恢复缓存容器后的依赖同步
  - 主动恢复 mise Node.js 24、`~/.dotnet` / `~/.local/bin` 工具路径
- 新增 `docs/codex-cloud.md`
  - 记录推荐的 Cloud 环境、环境变量、网络策略和验证命令

## 推荐的 Codex Cloud 配置

- Base image: `universal`
- Node.js selector: `22`
- Effective Node.js used by Nori: `24.x`，由 setup script 通过 `mise` 准备
- Setup script: `bash app/desktop/scripts/codex-cloud-setup.sh`
- Maintenance script: `bash app/desktop/scripts/codex-cloud-maintenance.sh`
- Environment variables:
  - `DOTNET_CLI_TELEMETRY_OPTOUT=1`
  - `DOTNET_NOLOGO=1`
  - `NUGET_XMLDOC_MODE=skip`
  - `CI=1`
- Secrets: ordinary build/test does not require any
- Agent internet: recommend Common dependencies allowlist with `GET` / `HEAD` / `OPTIONS`

## 说明

Codex universal 当前可选 Node.js 版本最高为 22，因此不修改 Nori.Desktop 自身 Node.js 24+ 的开发/CI 要求，而是在 setup 阶段用 `mise` 补齐 Node.js 24。

Windows WebView2、Windows packaging 和启动 smoke tests 仍由 GitHub Actions 的 Windows job 负责；Codex Cloud Linux 环境负责日常前端、.NET 编译测试和 Linux 侧验证。