### PR TITLE
fix: harden Codex Cloud pnpm bootstrap

### DIFF
--- a/app/desktop/scripts/codex-cloud-maintenance.sh
+++ b/app/desktop/scripts/codex-cloud-maintenance.sh
@@ -12,9 +12,15 @@ if command -v mise >/dev/null 2>&1; then
 	NODE24_DIR="$(mise where node@24 2>/dev/null || true)"
 	if [[ -n "$NODE24_DIR" ]]; then
 		export PATH="$NODE24_DIR/bin:$PATH"
-		hash -r
 	fi
-	unset NODE24_DIR
+
+	PNPM11_BIN="$(mise which pnpm --tool=pnpm@11 2>/dev/null || true)"
+	if [[ -n "$PNPM11_BIN" ]]; then
+		export PATH="$(dirname "$PNPM11_BIN"):$PATH"
+	fi
+
+	hash -r
+	unset NODE24_DIR PNPM11_BIN
 fi
 
 if [[ -x "$HOME/.dotnet/dotnet" ]]; then
@@ -31,8 +37,8 @@ if ! command -v node >/dev/null 2>&1 || (( $(node -p 'process.versions.node.spli
 	exit 1
 fi
 
-if ! command -v pnpm >/dev/null 2>&1; then
-	echo "pnpm 不可用，Codex Cloud 缓存环境需要重建。" >&2
+if ! command -v pnpm >/dev/null 2>&1 || [[ "$(pnpm --version | cut -d. -f1)" != "11" ]]; then
+	echo "pnpm 11 不可用，Codex Cloud 缓存环境需要重建。" >&2
 	exit 1
 fi
 

--- a/app/desktop/scripts/codex-cloud-setup.sh
+++ b/app/desktop/scripts/codex-cloud-setup.sh
@@ -79,25 +79,57 @@ ensure_node() {
 	log "Node.js $(node --version) 可用。"
 }
 
-ensure_pnpm() {
-	if command -v pnpm >/dev/null 2>&1 && [[ "$(pnpm --version | cut -d. -f1)" == "11" ]]; then
-		log "pnpm $(pnpm --version) 可用。"
-		return
+activate_pnpm11() {
+	if ! command -v mise >/dev/null 2>&1; then
+		echo "Codex universal 环境中未找到 mise，无法准备 pnpm 11。" >&2
+		exit 1
 	fi
 
-	log "激活 pnpm 11。"
-	if command -v corepack >/dev/null 2>&1; then
-		corepack enable
-		corepack prepare pnpm@11 --activate
-	else
-		mkdir -p "$HOME/.local"
-		npm config set prefix "$HOME/.local"
-		export PATH="$HOME/.local/bin:$PATH"
-		if ! grep -Fq 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
-			printf '\nexport PATH="$HOME/.local/bin:$PATH"\n' >> "$HOME/.bashrc"
-		fi
-		npm install --global pnpm@11
+	log "通过 mise 的 pnpm 后端准备 pnpm 11。"
+	mise install pnpm@11
+
+	local pnpm_bin
+	pnpm_bin="$(mise which pnpm --tool=pnpm@11 2>/dev/null || true)"
+	if [[ -z "$pnpm_bin" || ! -x "$pnpm_bin" ]]; then
+		echo "mise 已安装 pnpm 11，但无法定位 pnpm 可执行文件。" >&2
+		exit 1
 	fi
+
+	export PATH="$(dirname "$pnpm_bin"):$PATH"
+	hash -r
+
+	if ! grep -Fq '# Nori Codex Cloud pnpm 11' "$HOME/.bashrc" 2>/dev/null; then
+		cat >> "$HOME/.bashrc" <<'EOF'
+
+# Nori Codex Cloud pnpm 11
+if command -v mise >/dev/null 2>&1; then
+	NORI_PNPM11_BIN="$(mise which pnpm --tool=pnpm@11 2>/dev/null || true)"
+	if [[ -n "$NORI_PNPM11_BIN" ]]; then
+		export PATH="$(dirname "$NORI_PNPM11_BIN"):$PATH"
+	fi
+	unset NORI_PNPM11_BIN
+fi
+EOF
+	fi
+}
+
+ensure_pnpm() {
+	local pnpm_major=0
+	if command -v pnpm >/dev/null 2>&1; then
+		pnpm_major="$(pnpm --version 2>/dev/null | cut -d. -f1 || true)"
+	fi
+
+	if [[ "$pnpm_major" != "11" ]]; then
+		activate_pnpm11
+		pnpm_major="$(pnpm --version | cut -d. -f1)"
+	fi
+
+	if [[ "$pnpm_major" != "11" ]]; then
+		echo "Nori.Desktop 需要 pnpm 11，当前为 $(pnpm --version 2>/dev/null || echo unavailable)。" >&2
+		exit 1
+	fi
+
+	log "pnpm $(pnpm --version) 可用。"
 }
 
 ensure_dotnet() {

--- a/docs/codex-cloud.md
+++ b/docs/codex-cloud.md
@@ -12,7 +12,7 @@
 - Codex `universal` 当前内置 Node 版本选择最高为 `22`；setup script 会通过镜像自带的 `mise` 额外安装并激活 Nori.Desktop 要求的 Node.js `24`
 - 其他 Codex 内置语言运行时保持默认
 - .NET 10 SDK 由 setup script 检查并在缺失时安装到 `~/.dotnet`
-- pnpm 由 setup script 固定到 `11.x`
+- pnpm 由 setup script 通过 `mise` 固定到 `11.x`
 
 Setup script：
 
@@ -51,13 +51,31 @@ Agent 阶段推荐使用“常用依赖项”域名允许列表，并只开放 `
 
 1. 在 apt 系 Linux 环境安装 `libgtk-3-0` 与 `libwebkit2gtk-4.1-0`，与 Linux CI 保持一致。
 2. 检测当前 Node.js；当 Codex 面板提供的 Node.js 22 低于项目要求时，通过 `mise` 安装并激活 Node.js 24。
-3. 固定 pnpm 11。
+3. 通过 `mise` 的 `pnpm` 后端安装并激活 pnpm 11。这里不使用 `corepack prepare pnpm@11`，避免 Corepack 自举阶段直接访问 npm registry 时因 Cloud 网络代理或短时网络问题失败。
 4. 验证 .NET 10 SDK；缺失时安装到 `~/.dotnet`，并将路径持久化到 `~/.bashrc`。
 5. 在 `app/desktop` 执行 `pnpm install --frozen-lockfile`。
 6. 执行 `dotnet restore Nori.slnx`。
 7. 额外预还原 `linux-x64` 发布依赖，避免 Agent 阶段发布时再次联网还原。
 
-Maintenance script 用于恢复缓存容器后的依赖同步。它会重新定位由 `mise` 安装的 Node.js 24 和 `~/.dotnet`，再同步 pnpm 与 NuGet 依赖。
+Maintenance script 用于恢复缓存容器后的依赖同步。它会重新定位由 `mise` 安装的 Node.js 24 与 pnpm 11，以及 `~/.dotnet`，再同步 pnpm 与 NuGet 依赖。
+
+## pnpm 自举说明
+
+Codex `universal` 镜像会自带 pnpm，但其版本可能低于 Nori.Desktop 当前要求的 pnpm 11。setup script 因此需要补齐 pnpm 11。
+
+不要在该环境中使用：
+
+```bash
+corepack prepare pnpm@11 --activate
+```
+
+Corepack 会在自举阶段自行请求 npm registry；在 Codex Cloud 的网络环境里，这条请求可能先于项目依赖恢复失败。当前脚本改用：
+
+```bash
+mise install pnpm@11
+```
+
+`mise` 的 `pnpm` 短名称默认使用其注册表配置的 pnpm 安装后端，并由脚本通过 `mise which` 定位实际可执行文件。
 
 ## 环境验证
 
@@ -77,7 +95,7 @@ dotnet build Nori.slnx --configuration Release
 dotnet test Nori.slnx --configuration Release --no-build --no-restore -m:1
 ```
 
-其中 `node --version` 应显示 `v24.x`。Codex 面板选择 Node.js 22 只决定基础环境版本，真正运行 Nori.Desktop 构建时会使用 setup script 准备的 Node.js 24。
+其中 `node --version` 应显示 `v24.x`，`pnpm --version` 应显示 `11.x`。Codex 面板选择 Node.js 22 只决定基础环境版本，真正运行 Nori.Desktop 构建时会使用 setup script 准备的 Node.js 24。
 
 覆盖率任务按需运行：
 


### PR DESCRIPTION
## 问题

Codex Cloud setup 在 Node.js 24 准备完成后，通过 `corepack prepare pnpm@11 --activate` 自举 pnpm 11。实际环境中 Corepack 对 `https://registry.npmjs.org/pnpm` 的请求会失败，导致 setup 在依赖恢复前中止。

## 修复

- `codex-cloud-setup.sh`
  - 移除 Corepack / npm 全局安装分支
  - 使用 universal 镜像自带的 `mise` 安装 `pnpm@11`
  - 通过 `mise which pnpm --tool=pnpm@11` 定位实际可执行文件并加入当前 PATH
  - 将 pnpm 11 的 PATH 恢复逻辑写入 `~/.bashrc`
  - 安装后显式验证 pnpm 主版本为 11
- `codex-cloud-maintenance.sh`
  - 恢复缓存容器时同时恢复 mise 管理的 pnpm 11
  - 显式验证 Node 24 / pnpm 11 / .NET 10
- `docs/codex-cloud.md`
  - 记录 Corepack 在 Cloud 自举阶段的失败模式
  - 说明当前使用 mise pnpm 后端准备 pnpm 11

## 背景

当前 `codex-universal` 镜像本身已包含 mise，并预装多个 Node 版本与 pnpm；Nori.Desktop 仍保持 Node.js 24+ / pnpm 11+ 的项目要求。这个改动只调整 Cloud 环境的 pnpm 自举方式，不修改正式 CI 的工具链口径。