### PR TITLE
feat: 工作目录文件访问（四件工具 + 原生设置页）

### DIFF
--- a/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
+++ b/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
@@ -359,6 +359,109 @@ public sealed class AgentEngineLuoLiCoreTests : IDisposable
 		Assert.False(await engine.ResetRemoteContextAsync(CancellationToken.None));
 	}
 
+
+	// ---- codex review 的两条 P1：落库顺序与取消窗口 ----
+
+	/// <summary>
+	/// 用一个真实的 ChatService 建引擎，并把「取候选名单」这一步当作挑表情的时机探针。
+	///
+	/// 那一步在 <c>AttachReactionAsync</c> 的 try 里、紧跟在落库之后，是观察「落库有没有先
+	/// 发生」最靠近的一个点。
+	/// </summary>
+	private AgentEngine BuildWithProbe(
+		ChatService chat,
+		LuoLiCoreConversation conversation,
+		ReplyReactionService reaction,
+		Func<IReadOnlyList<string>> motionNames) =>
+		new(
+			new HttpClient(),
+			_config,
+			chat,
+			tools: null!,
+			skills: null!,
+			emotion: Track(new EmotionManager(_config)),
+			memory: null!,
+			pet: null,
+			motionNames: motionNames,
+			expressionNames: () => ["smile"],
+			adapterFactory: ExplodingAdapter,
+			luoLiCore: conversation,
+			replyReaction: reaction);
+
+	/// <summary>
+	/// done 之后按停止，这一轮必须仍然落进本地历史。
+	///
+	/// 对端那一轮已经提交、界面上也已经有文本了，此刻若让取消把整轮掀掉，本地就永远没有这条
+	/// 记录 —— 远端记着、用户看见过、本地没有，下一轮的远端上下文与用户所见对不上。
+	/// </summary>
+	[Fact]
+	public async Task 完成之后取消仍然落库()
+	{
+		EnableLuoLiCore();
+		ConfigureLocalLlm();
+		using CancellationTokenSource stop = new();
+		ChatService chat = new(new HttpClient(), _database, _config);
+
+		AgentEngine engine = BuildWithProbe(
+			chat,
+			Conversation(_ => Sse("event: done\ndata: {\"text\":\"我在\"}\n\n")),
+			Reaction("{\"expression\":\"smile\"}"),
+			() =>
+			{
+				stop.Cancel();
+				stop.Token.ThrowIfCancellationRequested();
+				return [];
+			});
+
+		ProtocolMessage message = await engine.RunAsync(
+			"在吗", "session-cancel", new AgentCallbacks(), stop.Token);
+
+		Assert.Equal("我在", message.Text);
+		// 用户那条 + 她那条，两条都在。
+		Assert.Equal(2, chat.GetHistory().Count);
+	}
+
+	[Fact]
+	public async Task 挑表情之前就已经落库()
+	{
+		EnableLuoLiCore();
+		ConfigureLocalLlm();
+		ChatService chat = new(new HttpClient(), _database, _config);
+		int atReactionTime = -1;
+
+		AgentEngine engine = BuildWithProbe(
+			chat,
+			Conversation(_ => Sse("event: done\ndata: {\"text\":\"我在\"}\n\n")),
+			Reaction("{\"expression\":\"smile\",\"action\":\"Tap\"}"),
+			() =>
+			{
+				atReactionTime = chat.GetHistory().Count;
+				return ["Tap"];
+			});
+
+		ProtocolMessage message = await engine.RunAsync(
+			"在吗", "session-order", new AgentCallbacks(), CancellationToken.None);
+
+		Assert.Equal(2, atReactionTime);
+		// 顺序调整不能把表情弄丢。
+		Assert.Equal("smile", message.Expression);
+	}
+
+	[Fact]
+	public void 有会话时报告远端仍记着东西()
+	{
+		EnableLuoLiCore();
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse("event: done\ndata: {}\n\n")));
+
+		Assert.True(engine.HasRemoteContext);
+	}
+
+	[Fact]
+	public void 没接这条路时不报告远端上下文()
+	{
+		Assert.False(BuildEngine(null).HasRemoteContext);
+	}
+
 	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
 	{
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>

--- a/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
+++ b/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
@@ -1,0 +1,199 @@
+using System.Net;
+using System.Text;
+using Nori.Core.Agent;
+using Nori.Core.Chat;
+using Nori.Core.Chat.LuoLiCore;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Security;
+
+namespace Nori.Core.Tests;
+
+/// <summary>
+/// AgentEngine 把一轮交给 LuoLiCore 的分支。
+///
+/// 这条分支动的是桌宠的核心对话路径，所以两个方向都要钉住：启用时确实绕开本机的
+/// 模型与工具循环；未启用时这条路完全不存在。
+/// </summary>
+public sealed class AgentEngineLuoLiCoreTests : IDisposable
+{
+	private readonly string _path = Path.Combine(Path.GetTempPath(), $"nori-engine-luoli-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+
+	private sealed class FixedKeyStore : ISecretKeyStore
+	{
+		private readonly byte[] _key = Enumerable.Range(0, SecretKeyStore.KeySize).Select(index => (byte)index).ToArray();
+
+		public byte[] LoadOrCreate() => _key;
+
+		public bool IsFileFallback => true;
+	}
+
+	public AgentEngineLuoLiCoreTests()
+	{
+		_database = NoriDatabase.Open(_path);
+		_config = new ConfigStore(_database, new FixedKeyStore());
+		_config.InitDefaults("test");
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_path); } catch (IOException) { /* 临时库删不掉不影响断言 */ }
+	}
+
+	private void EnableLuoLiCore(bool enabled = true)
+	{
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(enabled));
+		_config.Set(LuoLiCoreSettingsStore.KeyBaseUrl, new ConfigValue.Text("http://127.0.0.1:3000"));
+		_config.Set(LuoLiCoreSettingsStore.KeyApiKey, new ConfigValue.Text("sk-test"));
+		_config.Set(LuoLiCoreSettingsStore.KeySessionId, new ConfigValue.Text("sess_fixed"));
+	}
+
+	private LuoLiCoreConversation Conversation(Func<HttpRequestMessage, HttpResponseMessage> responder)
+	{
+		HttpClient http = new(new StubHandler(responder));
+		return new LuoLiCoreConversation(new LuoLiCoreSettingsStore(_config), options => new LuoLiCoreSdkClient(http, options));
+	}
+
+	private static HttpResponseMessage Sse(string body) => new(HttpStatusCode.OK)
+	{
+		Content = new StringContent(body, Encoding.UTF8, "text/event-stream"),
+	};
+
+	/// <summary>
+	/// 本机那条路一旦被走到就会立刻炸。用它证明「确实没走本机」，而不是靠断言输出相等
+	/// —— 输出相等只说明结果一样，说不清是谁产出的。
+	/// </summary>
+	private static ILlmAdapter ExplodingAdapter(LlmProvider provider, HttpClient http) =>
+		throw new InvalidOperationException("不应该走到本机模型这条路");
+
+	/// <summary>
+	/// 工具、技能、情绪、记忆、伴侣动作五项传 null。
+	///
+	/// 这不是图省事 —— **这本身就是断言**：LuoLiCore 那条分支在读 LLM 配置之前就返回，
+	/// 一次都不该碰到它们。真的碰了就是 NullReference，测试立刻炸；换成构造出真实协作者，
+	/// 反而看不出「有没有被碰过」。
+	///
+	/// 构造函数只做字段赋值，不解引用这几项，所以这样构造是安全的。
+	/// </summary>
+	private AgentEngine BuildEngine(LuoLiCoreConversation? conversation)
+	{
+		ChatService chat = new(new HttpClient(), _database, _config);
+		return new AgentEngine(
+			new HttpClient(),
+			_config,
+			chat,
+			tools: null!,
+			skills: null!,
+			emotion: null!,
+			memory: null!,
+			pet: null,
+			motionNames: () => [],
+			expressionNames: () => [],
+			adapterFactory: ExplodingAdapter,
+			luoLiCore: conversation);
+	}
+
+	[Fact]
+	public async Task 启用时绕开本机模型与工具循环()
+	{
+		EnableLuoLiCore();
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse("event: done\ndata: {\"text\":\"我在\"}\n\n")));
+
+		List<AgentRunState> states = [];
+		List<string> chunks = [];
+		ProtocolMessage message = await engine.RunAsync(
+			"在吗",
+			"session-1",
+			new AgentCallbacks { OnState = states.Add, OnTextChunk = chunks.Add },
+			CancellationToken.None);
+
+		// 走到本机适配器会抛，能返回就说明没走。
+		Assert.Equal("我在", message.Text);
+		Assert.Contains(AgentRunState.Streaming, states);
+		Assert.Equal(AgentRunState.Idle, states[^1]);
+	}
+
+	/// <summary>只配了 LuoLiCore 的实例本来就没有 BaseUrl / ApiKey / Model 三项。</summary>
+	[Fact]
+	public async Task 没有配置本机LLM也能跑()
+	{
+		EnableLuoLiCore();
+		// 刻意不写 llm_api_base / llm_api_key / llm_model
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse("event: done\ndata: {\"text\":\"好\"}\n\n")));
+
+		ProtocolMessage message = await engine.RunAsync("嗨", "session-2", new AgentCallbacks(), CancellationToken.None);
+
+		Assert.Equal("好", message.Text);
+	}
+
+	[Fact]
+	public async Task 增量逐块回调()
+	{
+		EnableLuoLiCore();
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse(
+			"event: delta\ndata: {\"text\":\"你\"}\n\n"
+			+ "event: delta\ndata: {\"text\":\"好\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"你好\"}\n\n")));
+
+		List<string> chunks = [];
+		await engine.RunAsync("嗨", "session-3", new AgentCallbacks { OnTextChunk = chunks.Add }, CancellationToken.None);
+
+		Assert.Equal(["你", "好"], chunks);
+	}
+
+	[Fact]
+	public async Task 完成回调照常触发()
+	{
+		EnableLuoLiCore();
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse("event: done\ndata: {\"text\":\"嗯\"}\n\n")));
+
+		ProtocolMessage? completed = null;
+		await engine.RunAsync("在吗", "session-4", new AgentCallbacks { OnComplete = value => completed = value }, CancellationToken.None);
+
+		Assert.NotNull(completed);
+		Assert.Equal("嗯", completed!.Text);
+	}
+
+	[Fact]
+	public async Task 失败时状态落到Error而不是Idle()
+	{
+		EnableLuoLiCore();
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse(
+			"event: error\ndata: {\"code\":\"provider_error\",\"message\":\"上游挂了\",\"retryable\":false}\n\n")));
+
+		List<AgentRunState> states = [];
+		await Assert.ThrowsAsync<ChatException>(
+			() => engine.RunAsync("在吗", "session-5", new AgentCallbacks { OnState = states.Add }, CancellationToken.None));
+
+		Assert.Equal(AgentRunState.Error, states[^1]);
+	}
+
+	[Fact]
+	public async Task 未启用时不走这条路()
+	{
+		EnableLuoLiCore(enabled: false);
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse("event: done\ndata: {\"text\":\"不该出现\"}\n\n")));
+
+		// 没配本机 LLM，因此走本机那条会在配置检查处失败 —— 证明分支没有被走到。
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => engine.RunAsync("在吗", "session-6", new AgentCallbacks(), CancellationToken.None));
+	}
+
+	[Fact]
+	public async Task 没有注入这条路时行为不变()
+	{
+		AgentEngine engine = BuildEngine(null);
+
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => engine.RunAsync("在吗", "session-7", new AgentCallbacks(), CancellationToken.None));
+	}
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+}

--- a/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
+++ b/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
@@ -122,16 +122,14 @@ public sealed class AgentEngineLuoLiCoreTests : IDisposable
 		AgentEngine engine = BuildEngine(Conversation(_ => Sse("event: done\ndata: {\"text\":\"我在\"}\n\n")));
 
 		List<AgentRunState> states = [];
-		List<string> chunks = [];
 		ProtocolMessage message = await engine.RunAsync(
 			"在吗",
 			"session-1",
-			new AgentCallbacks { OnState = states.Add, OnTextChunk = chunks.Add },
+			new AgentCallbacks { OnState = states.Add },
 			CancellationToken.None);
 
 		// 走到本机适配器会抛，能返回就说明没走。
 		Assert.Equal("我在", message.Text);
-		Assert.Contains(AgentRunState.Streaming, states);
 		Assert.Equal(AgentRunState.Idle, states[^1]);
 	}
 
@@ -295,6 +293,70 @@ public sealed class AgentEngineLuoLiCoreTests : IDisposable
 
 		Assert.Null(message.Expression);
 		Assert.Null(message.Action);
+	}
+
+	/// <summary>
+	/// 排队期间不能显示成「正在说」。
+	///
+	/// 对端的排队闸可能让轮次等上数秒，而那条流在轮次执行期间没有任何保活帧。见到第一个
+	/// 增量才算开始说话，跟本机那条路一致。
+	/// </summary>
+	[Fact]
+	public async Task 排队时停在Thinking_见到增量才转Streaming()
+	{
+		EnableLuoLiCore();
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse(
+			"event: queued\ndata: {}\n\n"
+			+ "event: delta\ndata: {\"text\":\"在\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"在的\"}\n\n")));
+
+		List<AgentRunState> states = [];
+		await engine.RunAsync("在吗", "session-11", new AgentCallbacks { OnState = states.Add }, CancellationToken.None);
+
+		Assert.Equal(
+			[AgentRunState.Thinking, AgentRunState.Thinking, AgentRunState.Streaming, AgentRunState.Idle],
+			states);
+	}
+
+	/// <summary>一次性给完整文本的轮次没有「正在说」这一段，直接从想到说完。</summary>
+	[Fact]
+	public async Task 没有增量时不进入说话态()
+	{
+		EnableLuoLiCore();
+		AgentEngine engine = BuildEngine(Conversation(_ => Sse("event: done\ndata: {\"text\":\"在的\"}\n\n")));
+
+		List<AgentRunState> states = [];
+		await engine.RunAsync("在吗", "session-12", new AgentCallbacks { OnState = states.Add }, CancellationToken.None);
+
+		Assert.DoesNotContain(AgentRunState.Streaming, states);
+		Assert.Equal(AgentRunState.Idle, states[^1]);
+	}
+
+	[Fact]
+	public async Task 清空聊天记录时一并重置远端()
+	{
+		EnableLuoLiCore();
+		List<string> paths = [];
+		AgentEngine engine = BuildEngine(Conversation(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return new HttpResponseMessage(HttpStatusCode.OK)
+			{
+				Content = new StringContent("{\"ok\":true,\"commitId\":\"c1\"}", Encoding.UTF8, "application/json"),
+			};
+		}));
+
+		Assert.True(await engine.ResetRemoteContextAsync(CancellationToken.None));
+		Assert.Equal(["/sdk/v1/sessions/sess_fixed/reset"], paths);
+	}
+
+	/// <summary>没接这条路的实例照常能清本地，不该因此报错。</summary>
+	[Fact]
+	public async Task 没有注入这条路时重置是空操作()
+	{
+		AgentEngine engine = BuildEngine(null);
+
+		Assert.False(await engine.ResetRemoteContextAsync(CancellationToken.None));
 	}
 
 	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler

--- a/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
+++ b/app/desktop/Nori.Core.Tests/AgentEngineLuoLiCoreTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Nori.Core.Agent;
 using Nori.Core.Chat;
 using Nori.Core.Chat.LuoLiCore;
+using Nori.Core.Emotion;
 using Nori.Core.Configuration;
 using Nori.Core.Data;
 using Nori.Core.Security;
@@ -20,6 +21,7 @@ public sealed class AgentEngineLuoLiCoreTests : IDisposable
 	private readonly string _path = Path.Combine(Path.GetTempPath(), $"nori-engine-luoli-{Guid.NewGuid():N}.db");
 	private readonly NoriDatabase _database;
 	private readonly ConfigStore _config;
+	private readonly List<IDisposable> _disposables = [];
 
 	private sealed class FixedKeyStore : ISecretKeyStore
 	{
@@ -39,6 +41,7 @@ public sealed class AgentEngineLuoLiCoreTests : IDisposable
 
 	public void Dispose()
 	{
+		foreach (IDisposable item in _disposables) item.Dispose();
 		_database.Dispose();
 		try { File.Delete(_path); } catch (IOException) { /* 临时库删不掉不影响断言 */ }
 	}
@@ -78,22 +81,38 @@ public sealed class AgentEngineLuoLiCoreTests : IDisposable
 	///
 	/// 构造函数只做字段赋值，不解引用这几项，所以这样构造是安全的。
 	/// </summary>
-	private AgentEngine BuildEngine(LuoLiCoreConversation? conversation)
+	private AgentEngine BuildEngine(
+		LuoLiCoreConversation? conversation,
+		ReplyReactionService? reaction = null,
+		IReadOnlyList<string>? motions = null,
+		IReadOnlyList<string>? expressions = null,
+		bool motionsThrow = false)
 	{
 		ChatService chat = new(new HttpClient(), _database, _config);
+		// 补表情那条路会读情绪，给它一个真的；其余四项仍然是 null 断言。
+		EmotionManager? emotion = reaction is null ? null : Track(new EmotionManager(_config));
 		return new AgentEngine(
 			new HttpClient(),
 			_config,
 			chat,
 			tools: null!,
 			skills: null!,
-			emotion: null!,
+			emotion: emotion!,
 			memory: null!,
 			pet: null,
-			motionNames: () => [],
-			expressionNames: () => [],
+			motionNames: motionsThrow
+				? () => throw new InvalidOperationException("模型还没加载好")
+				: () => motions ?? [],
+			expressionNames: () => expressions ?? [],
 			adapterFactory: ExplodingAdapter,
-			luoLiCore: conversation);
+			luoLiCore: conversation,
+			replyReaction: reaction);
+	}
+
+	private EmotionManager Track(EmotionManager emotion)
+	{
+		_disposables.Add(emotion);
+		return emotion;
 	}
 
 	[Fact]
@@ -189,6 +208,93 @@ public sealed class AgentEngineLuoLiCoreTests : IDisposable
 
 		await Assert.ThrowsAsync<InvalidOperationException>(
 			() => engine.RunAsync("在吗", "session-7", new AgentCallbacks(), CancellationToken.None));
+	}
+
+	// ---- 表情动作：远端只给文本，这几项由本地补 ----
+
+	private void ConfigureLocalLlm()
+	{
+		_config.Set(AiSettingsStore.KeyLlmBaseUrl, new ConfigValue.Text("https://llm.example/v1"));
+		_config.Set(AiSettingsStore.KeyLlmApiKey, new ConfigValue.Text("sk-local"));
+		_config.Set(AiSettingsStore.KeyLlmModel, new ConfigValue.Text("m"));
+	}
+
+	private sealed class FixedReplyAdapter(string reply) : ILlmAdapter
+	{
+		public Task<string> CompleteAsync(
+			string baseUrl, string apiKey, string model, string systemPrompt,
+			IReadOnlyList<ChatMessageInput> messages, CancellationToken cancellationToken = default) =>
+			Task.FromResult(reply);
+
+		public Task<string> StreamAsync(
+			string baseUrl, string apiKey, string model, string systemPrompt,
+			IReadOnlyList<ChatMessageInput> messages, Action<string> onChunk,
+			Action<LlmUsageInfo>? onUsage = null, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+
+		public Task<IReadOnlyList<string>> FetchModelsAsync(
+			string baseUrl, string apiKey, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+	}
+
+	private ReplyReactionService Reaction(string json) =>
+		new(new HttpClient(), _config, (_, _) => new FixedReplyAdapter(json));
+
+	[Fact]
+	public async Task 远端只给文本_表情动作在本地补上()
+	{
+		EnableLuoLiCore();
+		ConfigureLocalLlm();
+		AgentEngine engine = BuildEngine(
+			Conversation(_ => Sse("event: done\ndata: {\"text\":\"我在\"}\n\n")),
+			reaction: Reaction("{\"emotion\":\"happy\",\"expression\":\"smile\",\"action\":\"Tap\"}"),
+			motions: ["Tap"],
+			expressions: ["smile"]);
+
+		ProtocolMessage message = await engine.RunAsync("在吗", "session-8", new AgentCallbacks(), CancellationToken.None);
+
+		Assert.Equal("我在", message.Text);
+		Assert.Equal("happy", message.Emotion);
+		Assert.Equal("smile", message.Expression);
+		Assert.Equal("Tap", message.Action);
+	}
+
+	/// <summary>
+	/// 取候选名单要读当前模型，模型还没加载好时会抛。
+	///
+	/// 「挑表情失败」和「她没话说」在用户那边看起来一模一样，所以这条必须退化成没有表情，
+	/// 而不是让整轮对话失败。
+	/// </summary>
+	[Fact]
+	public async Task 挑表情时出错不影响这一轮()
+	{
+		EnableLuoLiCore();
+		ConfigureLocalLlm();
+		AgentEngine engine = BuildEngine(
+			Conversation(_ => Sse("event: done\ndata: {\"text\":\"我在\"}\n\n")),
+			reaction: Reaction("{\"expression\":\"smile\"}"),
+			motionsThrow: true);
+
+		ProtocolMessage message = await engine.RunAsync("在吗", "session-9", new AgentCallbacks(), CancellationToken.None);
+
+		Assert.Equal("我在", message.Text);
+		Assert.Null(message.Expression);
+	}
+
+	/// <summary>没有候选名单时不该凭空冒出一个动作名。</summary>
+	[Fact]
+	public async Task 没有候选名单时保持空值()
+	{
+		EnableLuoLiCore();
+		ConfigureLocalLlm();
+		AgentEngine engine = BuildEngine(
+			Conversation(_ => Sse("event: done\ndata: {\"text\":\"我在\"}\n\n")),
+			reaction: Reaction("{\"expression\":\"smile\",\"action\":\"Tap\"}"));
+
+		ProtocolMessage message = await engine.RunAsync("在吗", "session-10", new AgentCallbacks(), CancellationToken.None);
+
+		Assert.Null(message.Expression);
+		Assert.Null(message.Action);
 	}
 
 	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler

--- a/app/desktop/Nori.Core.Tests/AgentToolIterationsTests.cs
+++ b/app/desktop/Nori.Core.Tests/AgentToolIterationsTests.cs
@@ -1,0 +1,120 @@
+using Nori.Core.Agent;
+using Nori.Core.Chat;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Security;
+
+namespace Nori.Core.Tests;
+
+/// <summary>
+/// 一轮对话里的工具轮数上限。
+///
+/// 原先写死 5。一个「先搜、再读、再改、再验」的任务在第五轮刚好卡在验证之前 —— 她做了一半
+/// 就停下，对用户表现成「没做完也没说为什么」。放宽不增加简单对话的开销：模型不调工具时
+/// 循环自己就结束了，上限只决定它最多能走多远。
+/// </summary>
+public sealed class AgentToolIterationsTests : IDisposable
+{
+	private readonly string _path = Path.Combine(Path.GetTempPath(), $"nori-iter-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+
+	private sealed class FixedKeyStore : ISecretKeyStore
+	{
+		private readonly byte[] _key = Enumerable.Range(0, SecretKeyStore.KeySize).Select(index => (byte)index).ToArray();
+
+		public byte[] LoadOrCreate() => _key;
+
+		public bool IsFileFallback => true;
+	}
+
+	public AgentToolIterationsTests()
+	{
+		_database = NoriDatabase.Open(_path);
+		_config = new ConfigStore(_database, new FixedKeyStore());
+		_config.InitDefaults("test");
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_path); } catch (IOException) { /* 临时库删不掉不影响断言 */ }
+	}
+
+	/// <summary>
+	/// 通过反射读私有属性。
+	///
+	/// 这条判据本身是「配置能不能改到循环上限」，而把它做成公开 API 只是为了方便测试 ——
+	/// 那会让一个内部决定变成对外承诺。
+	/// </summary>
+	private int Budget(AgentEngine engine) =>
+		(int)typeof(AgentEngine)
+			.GetProperty("ToolIterations", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+			.GetValue(engine)!;
+
+	private AgentEngine Build(int? explicitLimit = null)
+	{
+		ChatService chat = new(new HttpClient(), _database, _config);
+		return explicitLimit is null
+			? new AgentEngine(
+				new HttpClient(), _config, chat,
+				tools: null!, skills: null!, emotion: null!, memory: null!,
+				pet: null, motionNames: () => [], expressionNames: () => [])
+			: new AgentEngine(
+				new HttpClient(), _config, chat,
+				tools: null!, skills: null!, emotion: null!, memory: null!,
+				pet: null, motionNames: () => [], expressionNames: () => [],
+				maxToolIterations: explicitLimit.Value);
+	}
+
+	[Fact]
+	public void 没配过时用默认值()
+	{
+		Assert.Equal(AgentEngine.DefaultToolIterations, Budget(Build()));
+	}
+
+	[Fact]
+	public void 配置能改到循环上限()
+	{
+		_config.Set(ConfigStore.KeyAgentMaxToolIterations, new ConfigValue.Text("20"));
+
+		Assert.Equal(20, Budget(Build()));
+	}
+
+	/// <summary>上界不是为了省钱，是为了让一个跑飞的循环有个尽头。</summary>
+	[Theory]
+	[InlineData("0", AgentEngine.MinToolIterations)]
+	[InlineData("-5", AgentEngine.MinToolIterations)]
+	[InlineData("999", AgentEngine.MaxToolIterationsLimit)]
+	public void 超出范围的配置被夹回边界(string configured, int expected)
+	{
+		_config.Set(ConfigStore.KeyAgentMaxToolIterations, new ConfigValue.Text(configured));
+
+		Assert.Equal(expected, Budget(Build()));
+	}
+
+	/// <summary>一个打错的配置值不该让整条对话路径失败。</summary>
+	[Fact]
+	public void 配的不是数就退回默认()
+	{
+		_config.Set(ConfigStore.KeyAgentMaxToolIterations, new ConfigValue.Text("很多次"));
+
+		Assert.Equal(AgentEngine.DefaultToolIterations, Budget(Build()));
+	}
+
+	/// <summary>构造时显式给了值就以它为准，不受用户配置干扰。</summary>
+	[Fact]
+	public void 显式传入的上限盖过配置()
+	{
+		_config.Set(ConfigStore.KeyAgentMaxToolIterations, new ConfigValue.Text("20"));
+
+		Assert.Equal(3, Budget(Build(explicitLimit: 3)));
+	}
+
+	[Fact]
+	public void 默认值比原先的五轮宽()
+	{
+		// 这一条钉住的是这次改动的意图本身：五轮不够。
+		Assert.True(AgentEngine.DefaultToolIterations > 5);
+	}
+}

--- a/app/desktop/Nori.Core.Tests/LuoLiCoreConversationTests.cs
+++ b/app/desktop/Nori.Core.Tests/LuoLiCoreConversationTests.cs
@@ -199,6 +199,114 @@ public sealed class LuoLiCoreConversationTests : IDisposable
 		Assert.Contains("连不上", failure.Message, StringComparison.Ordinal);
 	}
 
+	// ---- 清空聊天记录时一起清掉对端记着的这段对话 ----
+
+	[Fact]
+	public async Task 重置打到reset端点()
+	{
+		Configure(sessionId: "sess_old");
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.Method + " " + request.RequestUri!.AbsolutePath);
+			return Json(HttpStatusCode.OK, "{\"ok\":true,\"commitId\":\"c1\"}");
+		});
+
+		Assert.True(await conversation.ResetAsync(CancellationToken.None));
+		Assert.Equal(["POST /sdk/v1/sessions/sess_old/reset"], paths);
+	}
+
+	/// <summary>reset 清的是上下文，会话与它挂着的长期记忆都留着，下一轮接着用同一个。</summary>
+	[Fact]
+	public async Task 重置之后仍然复用同一个会话()
+	{
+		Configure(sessionId: "sess_old");
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return request.RequestUri!.AbsolutePath.EndsWith("/reset", StringComparison.Ordinal)
+				? Json(HttpStatusCode.OK, "{\"ok\":true,\"commitId\":\"c1\"}")
+				: Sse("event: done\ndata: {\"text\":\"在的\"}\n\n");
+		});
+
+		await conversation.ResetAsync(CancellationToken.None);
+		await conversation.RunAsync("在吗", null, CancellationToken.None);
+
+		Assert.Equal(
+			["/sdk/v1/sessions/sess_old/reset", "/sdk/v1/sessions/sess_old/messages/stream"],
+			paths);
+		Assert.Equal("sess_old", _settings.Read().SessionId);
+	}
+
+	[Fact]
+	public async Task 还没建过会话就没有要清的东西()
+	{
+		Configure();
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return Json(HttpStatusCode.OK, "{\"ok\":true,\"commitId\":\"c1\"}");
+		});
+
+		Assert.False(await conversation.ResetAsync(CancellationToken.None));
+		Assert.Empty(paths);
+	}
+
+	/// <summary>关掉开关之后清空本地记录，不该再去碰远端。</summary>
+	[Fact]
+	public async Task 未启用时不碰远端()
+	{
+		Configure(enabled: false, sessionId: "sess_old");
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return Json(HttpStatusCode.OK, "{\"ok\":true,\"commitId\":\"c1\"}");
+		});
+
+		Assert.False(await conversation.ResetAsync(CancellationToken.None));
+		Assert.Empty(paths);
+	}
+
+	/// <summary>重置失败必须报出来：吞掉的话本地被清空而远端还记着，两边就此分叉。</summary>
+	[Fact]
+	public async Task 重置失败照原样报出()
+	{
+		Configure(sessionId: "sess_old");
+		LuoLiCoreConversation conversation = Build(_ => Json(
+			HttpStatusCode.NotFound,
+			"{\"code\":\"session_deleted\",\"message\":\"会话已停用\",\"retryable\":false}"));
+
+		ChatException failure = await Assert.ThrowsAsync<ChatException>(
+			() => conversation.ResetAsync(CancellationToken.None));
+
+		Assert.Contains("session_deleted", failure.Message, StringComparison.Ordinal);
+	}
+
+	/// <summary>
+	/// 排队要说出来。
+	///
+	/// 排队可能长达数秒，而这条流在轮次执行期间没有任何保活帧 —— 不回调的话界面在这段
+	/// 时间里既没有文字也没有状态变化，看起来就是卡住了。
+	/// </summary>
+	[Fact]
+	public async Task 排队时回调一次()
+	{
+		Configure(sessionId: "s");
+		int queued = 0;
+		LuoLiCoreConversation conversation = Build(_ => Sse(
+			"event: queued\ndata: {}\n\n"
+			+ "event: delta\ndata: {\"text\":\"在\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"在的\"}\n\n"));
+
+		ProtocolMessage message = await conversation.RunAsync("在吗", null, () => queued++, CancellationToken.None);
+
+		Assert.Equal(1, queued);
+		Assert.Equal("在的", message.Text);
+	}
+
 	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
 	{
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>

--- a/app/desktop/Nori.Core.Tests/LuoLiCoreConversationTests.cs
+++ b/app/desktop/Nori.Core.Tests/LuoLiCoreConversationTests.cs
@@ -307,6 +307,110 @@ public sealed class LuoLiCoreConversationTests : IDisposable
 		Assert.Equal("在的", message.Text);
 	}
 
+	// ---- 够不到远端时本地会话必须作废（review 要求）----
+
+	/// <summary>
+	/// 关掉 LuoLiCore 之后清空聊天，旧会话不能被留下。
+	///
+	/// 留下的话是一个很隐蔽的状态：用户聊过一阵、关掉、清空，本地空了但会话 id 还在；等他
+	/// 再打开，那段「已经清掉」的上下文原样回来。
+	/// </summary>
+	[Fact]
+	public async Task 关闭状态下清空会作废本地会话()
+	{
+		Configure(sessionId: "sess_old");
+		Assert.Equal("sess_old", _settings.Read().SessionId);
+
+		// 用户关掉 LuoLiCore。
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(false));
+
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return Json(HttpStatusCode.OK, "{\"ok\":true,\"commitId\":\"c1\"}");
+		});
+
+		Assert.False(await conversation.ResetAsync(CancellationToken.None));
+
+		// 关掉就该意味着不再产生外部调用。
+		Assert.Empty(paths);
+		Assert.Equal("", _settings.Read().SessionId);
+	}
+
+	/// <summary>
+	/// 会话 id 与身份指纹必须一起失效。
+	///
+	/// 只删 id 的话指纹留在库里；只删指纹更糟 —— 旧 id 会被当成「同一台服务端的会话」继续用。
+	/// </summary>
+	[Fact]
+	public async Task 会话id与身份指纹一起失效()
+	{
+		Configure();
+		_settings.SaveSessionId("sess_old");
+		Assert.NotEqual("", _config.GetStringOr(LuoLiCoreSettingsStore.KeySessionOwner, ""));
+
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(false));
+		await Build(_ => Json(HttpStatusCode.OK, "{}")).ResetAsync(CancellationToken.None);
+
+		Assert.Equal("", _config.GetStringOr(LuoLiCoreSettingsStore.KeySessionId, ""));
+		Assert.Equal("", _config.GetStringOr(LuoLiCoreSettingsStore.KeySessionOwner, ""));
+	}
+
+	/// <summary>重新启用之后建的是新会话，不是接着用旧的那条。</summary>
+	[Fact]
+	public async Task 重新启用后新建会话而不是复用旧的()
+	{
+		Configure(sessionId: "sess_old");
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(false));
+		await Build(_ => Json(HttpStatusCode.OK, "{}")).ResetAsync(CancellationToken.None);
+
+		// 用户又打开了。
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(true));
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return request.RequestUri!.AbsolutePath.EndsWith("/sessions", StringComparison.Ordinal)
+				? Json(HttpStatusCode.OK, "{\"id\":\"sess_new\",\"label\":null,\"modelAlias\":null,\"outputFormat\":\"plain\",\"createdAt\":0,\"deletedAt\":null}")
+				: Sse("event: done\ndata: {\"text\":\"在的\"}\n\n");
+		});
+
+		await conversation.RunAsync("你在吗", null, CancellationToken.None);
+
+		Assert.Equal(["/sdk/v1/sessions", "/sdk/v1/sessions/sess_new/messages/stream"], paths);
+		Assert.Equal("sess_new", _settings.Read().SessionId);
+	}
+
+	/// <summary>启用着、但还没建过会话时同样不发请求，也不留下半截状态。</summary>
+	[Fact]
+	public async Task 启用但没有会话时也不发请求()
+	{
+		Configure();
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return Json(HttpStatusCode.OK, "{}");
+		});
+
+		Assert.False(await conversation.ResetAsync(CancellationToken.None));
+		Assert.Empty(paths);
+	}
+
+	/// <summary>只作废本地、完全不联网的那条路。安全模式下的清空走它。</summary>
+	[Fact]
+	public void 只忘掉本地会话不联网()
+	{
+		Configure(sessionId: "sess_old");
+		LuoLiCoreConversation conversation = Build(_ => throw new InvalidOperationException("不该发请求"));
+
+		conversation.ForgetSession();
+
+		Assert.Equal("", _settings.Read().SessionId);
+		Assert.Equal("", _config.GetStringOr(LuoLiCoreSettingsStore.KeySessionOwner, ""));
+	}
+
 	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
 	{
 		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>

--- a/app/desktop/Nori.Core.Tests/LuoLiCoreConversationTests.cs
+++ b/app/desktop/Nori.Core.Tests/LuoLiCoreConversationTests.cs
@@ -1,0 +1,207 @@
+using System.Net;
+using System.Text;
+using Nori.Core.Agent;
+using Nori.Core.Chat;
+using Nori.Core.Chat.LuoLiCore;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Security;
+
+namespace Nori.Core.Tests;
+
+/// <summary>把一轮对话交给 LuoLiCore 这条路。用假的 HTTP 处理器，不需要真实服务端。</summary>
+public sealed class LuoLiCoreConversationTests : IDisposable
+{
+	private readonly string _path = Path.Combine(Path.GetTempPath(), $"nori-luoli-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+	private readonly LuoLiCoreSettingsStore _settings;
+
+	/// <summary>
+	/// 测试用固定主密钥。
+	///
+	/// `luolicore_api_key` 以 `_api_key` 结尾，因此和 `llm_api_key` 一样按敏感字段加密存储；
+	/// 不给固定密钥的话，测试环境里密钥库不可用，写进去的密钥读回来是空，表现成「配置不完整」。
+	/// </summary>
+	private sealed class FixedKeyStore : ISecretKeyStore
+	{
+		private readonly byte[] _key = Enumerable.Range(0, SecretKeyStore.KeySize).Select(index => (byte)index).ToArray();
+
+		public byte[] LoadOrCreate() => _key;
+
+		public bool IsFileFallback => true;
+	}
+
+	public LuoLiCoreConversationTests()
+	{
+		_database = NoriDatabase.Open(_path);
+		_config = new ConfigStore(_database, new FixedKeyStore());
+		_config.InitDefaults("test");
+		_settings = new LuoLiCoreSettingsStore(_config);
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_path); } catch (IOException) { /* 临时库删不掉不影响断言 */ }
+	}
+
+	private void Configure(bool enabled = true, string sessionId = "")
+	{
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(enabled));
+		_config.Set(LuoLiCoreSettingsStore.KeyBaseUrl, new ConfigValue.Text("http://127.0.0.1:3000"));
+		_config.Set(LuoLiCoreSettingsStore.KeyApiKey, new ConfigValue.Text("sk-test"));
+		if (sessionId.Length > 0) _config.Set(LuoLiCoreSettingsStore.KeySessionId, new ConfigValue.Text(sessionId));
+	}
+
+	private LuoLiCoreConversation Build(Func<HttpRequestMessage, HttpResponseMessage> responder)
+	{
+		HttpClient http = new(new StubHandler(responder));
+		return new LuoLiCoreConversation(_settings, options => new LuoLiCoreSdkClient(http, options));
+	}
+
+	private static HttpResponseMessage Sse(string body) => new(HttpStatusCode.OK)
+	{
+		Content = new StringContent(body, Encoding.UTF8, "text/event-stream"),
+	};
+
+	private static HttpResponseMessage Json(HttpStatusCode code, string body) => new(code)
+	{
+		Content = new StringContent(body, Encoding.UTF8, "application/json"),
+	};
+
+	[Fact]
+	public void 未启用时不接管对话()
+	{
+		Configure(enabled: false);
+		LuoLiCoreConversation conversation = Build(_ => Json(HttpStatusCode.OK, "{}"));
+
+		Assert.False(conversation.IsActive);
+	}
+
+	[Fact]
+	public void 配置不全时即便开了开关也不接管()
+	{
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(true));
+		// 只填地址不填密钥
+		_config.Set(LuoLiCoreSettingsStore.KeyBaseUrl, new ConfigValue.Text("http://127.0.0.1:3000"));
+
+		Assert.False(_settings.Read().IsActive);
+	}
+
+	[Fact]
+	public async Task 首轮建会话并把id写回配置()
+	{
+		Configure();
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return request.RequestUri!.AbsolutePath.EndsWith("/sessions", StringComparison.Ordinal)
+				? Json(HttpStatusCode.OK, "{\"id\":\"sess_1\",\"label\":null,\"modelAlias\":null,\"outputFormat\":\"plain\",\"createdAt\":0,\"deletedAt\":null}")
+				: Sse("event: done\ndata: {\"text\":\"在的\"}\n\n");
+		});
+
+		ProtocolMessage message = await conversation.RunAsync("你在吗", null, CancellationToken.None);
+
+		Assert.Equal("在的", message.Text);
+		Assert.Equal("sess_1", _settings.Read().SessionId);
+		Assert.Equal(["/sdk/v1/sessions", "/sdk/v1/sessions/sess_1/messages/stream"], paths);
+	}
+
+	[Fact]
+	public async Task 已有会话就复用_不再新建()
+	{
+		Configure(sessionId: "sess_old");
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return Sse("event: done\ndata: {\"text\":\"记得\"}\n\n");
+		});
+
+		await conversation.RunAsync("还记得吗", null, CancellationToken.None);
+
+		// 每轮新建会话等价于每轮失忆，这一条防的就是那个。
+		Assert.DoesNotContain("/sdk/v1/sessions", paths);
+		Assert.Equal(["/sdk/v1/sessions/sess_old/messages/stream"], paths);
+	}
+
+	[Fact]
+	public async Task 增量逐块回调_最终文本以done为准()
+	{
+		Configure(sessionId: "s");
+		List<string> chunks = [];
+		LuoLiCoreConversation conversation = Build(_ => Sse(
+			"event: delta\ndata: {\"text\":\"你\"}\n\n"
+			+ "event: delta\ndata: {\"text\":\"好\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"你好\"}\n\n"));
+
+		ProtocolMessage message = await conversation.RunAsync("嗨", chunks.Add, CancellationToken.None);
+
+		Assert.Equal(["你", "好"], chunks);
+		Assert.Equal("你好", message.Text);
+	}
+
+	/// <summary>动作与表情不从这条流来 —— 合法名随当前模型变化，只有宿主知道。</summary>
+	[Fact]
+	public async Task 协议消息只带文本_表情动作留给宿主决定()
+	{
+		Configure(sessionId: "s");
+		LuoLiCoreConversation conversation = Build(_ => Sse("event: done\ndata: {\"text\":\"嗯\"}\n\n"));
+
+		ProtocolMessage message = await conversation.RunAsync("在吗", null, CancellationToken.None);
+
+		Assert.Null(message.Emotion);
+		Assert.Null(message.Expression);
+		Assert.Null(message.Action);
+	}
+
+	[Fact]
+	public async Task 错误事件变成可读的失败而不是半截文本()
+	{
+		Configure(sessionId: "s");
+		LuoLiCoreConversation conversation = Build(_ => Sse(
+			"event: delta\ndata: {\"text\":\"说到一半\"}\n\n"
+			+ "event: error\ndata: {\"code\":\"provider_error\",\"message\":\"上游挂了\",\"retryable\":false}\n\n"));
+
+		ChatException failure = await Assert.ThrowsAsync<ChatException>(
+			() => conversation.RunAsync("在吗", null, CancellationToken.None));
+
+		Assert.Contains("provider_error", failure.Message, StringComparison.Ordinal);
+		Assert.Contains("上游挂了", failure.Message, StringComparison.Ordinal);
+	}
+
+	/// <summary>配额拒绝发生在响应头写出之前，所以它仍是普通 HTTP 错误，不是 SSE 事件。</summary>
+	[Fact]
+	public async Task 配额拒绝按http错误报出()
+	{
+		Configure(sessionId: "s");
+		LuoLiCoreConversation conversation = Build(_ => Json(
+			HttpStatusCode.TooManyRequests,
+			"{\"code\":\"quota_exceeded\",\"message\":\"额度用完了\",\"retryable\":false}"));
+
+		ChatException failure = await Assert.ThrowsAsync<ChatException>(
+			() => conversation.RunAsync("在吗", null, CancellationToken.None));
+
+		Assert.Contains("quota_exceeded", failure.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 连不上时报连接失败而不是抛原始异常()
+	{
+		Configure(sessionId: "s");
+		LuoLiCoreConversation conversation = Build(_ => throw new HttpRequestException("connection refused"));
+
+		ChatException failure = await Assert.ThrowsAsync<ChatException>(
+			() => conversation.RunAsync("在吗", null, CancellationToken.None));
+
+		Assert.Contains("连不上", failure.Message, StringComparison.Ordinal);
+	}
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+}

--- a/app/desktop/Nori.Core.Tests/LuoLiCoreSettingsEnvTests.cs
+++ b/app/desktop/Nori.Core.Tests/LuoLiCoreSettingsEnvTests.cs
@@ -1,0 +1,146 @@
+using Nori.Core.Chat.LuoLiCore;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Security;
+
+namespace Nori.Core.Tests;
+
+/// <summary>
+/// LuoLiCore 配置的环境变量兜底。
+///
+/// 原生 UI 迁移期间还没有填这几项的地方，密钥本来也不该写进文件。规则只有一条：
+/// **配置优先、环境变量兜底** —— 反过来的话，将来设置页改了值却不生效，那种错位很难查。
+/// </summary>
+public sealed class LuoLiCoreSettingsEnvTests : IDisposable
+{
+	private readonly string _path = Path.Combine(Path.GetTempPath(), $"nori-luoli-env-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+
+	private sealed class FixedKeyStore : ISecretKeyStore
+	{
+		private readonly byte[] _key = Enumerable.Range(0, SecretKeyStore.KeySize).Select(index => (byte)index).ToArray();
+
+		public byte[] LoadOrCreate() => _key;
+
+		public bool IsFileFallback => true;
+	}
+
+	public LuoLiCoreSettingsEnvTests()
+	{
+		_database = NoriDatabase.Open(_path);
+		_config = new ConfigStore(_database, new FixedKeyStore());
+		_config.InitDefaults("test");
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_path); } catch (IOException) { /* 临时库删不掉不影响断言 */ }
+	}
+
+	/// <summary>不去改进程环境：那会串到并行跑的其他测试里，表现成偶发失败。</summary>
+	private LuoLiCoreSettingsStore Store(params (string Name, string Value)[] environment)
+	{
+		Dictionary<string, string> table = environment.ToDictionary(item => item.Name, item => item.Value, StringComparer.Ordinal);
+		return new LuoLiCoreSettingsStore(_config, name => table.GetValueOrDefault(name));
+	}
+
+	[Fact]
+	public void 环境变量给齐地址与密钥就自动启用()
+	{
+		LuoLiCoreSettings settings = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env")).Read();
+
+		// 迁移期没有界面可点，还要求单独设一个开关只会让人以为没生效。
+		Assert.True(settings.IsActive);
+		Assert.Equal("http://127.0.0.1:3000", settings.BaseUrl);
+		Assert.Equal("sk-env", settings.ApiKey);
+	}
+
+	[Fact]
+	public void 只给一半不算启用()
+	{
+		Assert.False(Store((LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000")).Read().IsActive);
+		Assert.False(Store((LuoLiCoreSettingsStore.EnvApiKey, "sk-env")).Read().IsActive);
+	}
+
+	[Fact]
+	public void 环境变量里显式关掉就不启用()
+	{
+		LuoLiCoreSettings settings = Store(
+			(LuoLiCoreSettingsStore.EnvEnabled, "0"),
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env")).Read();
+
+		Assert.False(settings.IsActive);
+		// 关掉的只是开关，地址密钥仍然读得到 —— 打开就能用，不用重填。
+		Assert.True(settings.IsConfigured);
+	}
+
+	[Fact]
+	public void 配置优先于环境变量()
+	{
+		_config.Set(LuoLiCoreSettingsStore.KeyBaseUrl, new ConfigValue.Text("http://127.0.0.1:4000"));
+		_config.Set(LuoLiCoreSettingsStore.KeyApiKey, new ConfigValue.Text("sk-config"));
+
+		LuoLiCoreSettings settings = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env")).Read();
+
+		Assert.Equal("http://127.0.0.1:4000", settings.BaseUrl);
+		Assert.Equal("sk-config", settings.ApiKey);
+	}
+
+	/// <summary>配置里显式关掉，环境变量不该把它顶回开。</summary>
+	[Fact]
+	public void 配置里关掉时环境变量顶不开()
+	{
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(false));
+
+		LuoLiCoreSettings settings = Store(
+			(LuoLiCoreSettingsStore.EnvEnabled, "1"),
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env")).Read();
+
+		Assert.False(settings.IsActive);
+	}
+
+	[Fact]
+	public void 会话id也能从环境变量来()
+	{
+		LuoLiCoreSettings settings = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env"),
+			(LuoLiCoreSettingsStore.EnvSessionId, "sess_env"),
+			(LuoLiCoreSettingsStore.EnvModelAlias, "fast")).Read();
+
+		Assert.Equal("sess_env", settings.SessionId);
+		Assert.Equal("fast", settings.ToOptions().ModelAlias);
+	}
+
+	/// <summary>写回会话 id 之后就归配置管，换一台机器的环境变量不该再顶回去。</summary>
+	[Fact]
+	public void 写回的会话id盖过环境变量()
+	{
+		LuoLiCoreSettingsStore store = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env"),
+			(LuoLiCoreSettingsStore.EnvSessionId, "sess_env"));
+
+		store.SaveSessionId("sess_saved");
+
+		Assert.Equal("sess_saved", store.Read().SessionId);
+	}
+
+	[Fact]
+	public void 地址末尾的斜杠被去掉()
+	{
+		LuoLiCoreSettings settings = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000/"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env")).Read();
+
+		Assert.Equal("http://127.0.0.1:3000", settings.BaseUrl);
+	}
+}

--- a/app/desktop/Nori.Core.Tests/LuoLiCoreSettingsEnvTests.cs
+++ b/app/desktop/Nori.Core.Tests/LuoLiCoreSettingsEnvTests.cs
@@ -143,4 +143,82 @@ public sealed class LuoLiCoreSettingsEnvTests : IDisposable
 
 		Assert.Equal("http://127.0.0.1:3000", settings.BaseUrl);
 	}
+
+	// ---- 会话 id 绑在建它的那台服务端与那把密钥上（codex review，P2）----
+
+	/// <summary>
+	/// 换了地址之后旧会话 id 属于另一台服务端，继续拿它发消息只会一直 404 —— 而那个失败看
+	/// 起来像「服务端坏了」，不像「你改了配置」。
+	/// </summary>
+	[Fact]
+	public void 换了地址之后旧会话作废()
+	{
+		LuoLiCoreSettingsStore first = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env"));
+		first.SaveSessionId("sess_old");
+		Assert.Equal("sess_old", first.Read().SessionId);
+
+		LuoLiCoreSettingsStore moved = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:4000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env"));
+
+		Assert.Equal("", moved.Read().SessionId);
+	}
+
+	[Fact]
+	public void 换了密钥之后旧会话同样作废()
+	{
+		LuoLiCoreSettingsStore first = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-old"));
+		first.SaveSessionId("sess_old");
+
+		LuoLiCoreSettingsStore rekeyed = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-new"));
+
+		Assert.Equal("", rekeyed.Read().SessionId);
+	}
+
+	[Fact]
+	public void 地址与密钥都没变时会话照旧()
+	{
+		(string, string)[] env =
+		[
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env"),
+		];
+		Store(env).SaveSessionId("sess_old");
+
+		Assert.Equal("sess_old", Store(env).Read().SessionId);
+	}
+
+	/// <summary>指纹这一列不加密，把密钥原样写进去等于绕开 `_api_key` 那套加密存储。</summary>
+	[Fact]
+	public void 指纹里不含密钥原文()
+	{
+		LuoLiCoreSettingsStore store = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-super-secret"));
+		store.SaveSessionId("sess_old");
+
+		string stored = _config.GetStringOr(LuoLiCoreSettingsStore.KeySessionOwner, "");
+
+		Assert.DoesNotContain("sk-super-secret", stored, StringComparison.Ordinal);
+		Assert.DoesNotContain("127.0.0.1", stored, StringComparison.Ordinal);
+		Assert.Equal(64, stored.Length);
+	}
+
+	/// <summary>运维显式用环境变量指定会话 id 时不受指纹判据影响：那是他自己定的。</summary>
+	[Fact]
+	public void 环境变量指定的会话id不受指纹影响()
+	{
+		LuoLiCoreSettings settings = Store(
+			(LuoLiCoreSettingsStore.EnvBaseUrl, "http://127.0.0.1:3000"),
+			(LuoLiCoreSettingsStore.EnvApiKey, "sk-env"),
+			(LuoLiCoreSettingsStore.EnvSessionId, "sess_env")).Read();
+
+		Assert.Equal("sess_env", settings.SessionId);
+	}
 }

--- a/app/desktop/Nori.Core.Tests/LuoLiCoreSseReaderTests.cs
+++ b/app/desktop/Nori.Core.Tests/LuoLiCoreSseReaderTests.cs
@@ -1,0 +1,161 @@
+using Nori.Core.Chat;
+using Nori.Core.Chat.LuoLiCore;
+
+namespace Nori.Core.Tests;
+
+/// <summary>
+/// LuoLiCore SDK 流的解析与顺序不变量。
+///
+/// 这条流的三条约束来自对端契约：`queued`（如果出现）先于任何 `delta`；`delta` 零至多次；
+/// 末尾恰好 `done` 或 `error` 之一。违反时必须抛而不是静默吞 —— 一个半开的流在界面上
+/// 表现为「她说到一半不动了」，没有任何错误可查，那是最贵的一类故障。
+/// </summary>
+public sealed class LuoLiCoreSseReaderTests
+{
+	private static async Task<List<LuoLiCoreStreamEvent>> ReadAsync(string sse)
+	{
+		using StringReader reader = new(sse);
+		List<LuoLiCoreStreamEvent> items = [];
+		await foreach (LuoLiCoreStreamEvent item in LuoLiCoreSseReader.ReadAsync(reader))
+		{
+			items.Add(item);
+		}
+
+		return items;
+	}
+
+	private static Task<ChatException> ReadFailureAsync(string sse) =>
+		Assert.ThrowsAsync<ChatException>(() => ReadAsync(sse));
+
+	[Fact]
+	public async Task 正常一轮_排队在前_增量在中_done收尾()
+	{
+		List<LuoLiCoreStreamEvent> items = await ReadAsync(
+			"event: queued\ndata: {}\n\n"
+			+ "event: delta\ndata: {\"text\":\"你\"}\n\n"
+			+ "event: delta\ndata: {\"text\":\"好\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"你好\",\"usage\":{\"inputTokens\":12,\"outputTokens\":3}}\n\n");
+
+		Assert.Equal(
+			[LuoLiCoreStreamEventKind.Queued, LuoLiCoreStreamEventKind.Delta, LuoLiCoreStreamEventKind.Delta, LuoLiCoreStreamEventKind.Done],
+			items.Select(i => i.Kind));
+		Assert.Equal("你好", string.Concat(items.Where(i => i.Kind == LuoLiCoreStreamEventKind.Delta).Select(i => i.Text)));
+
+		LuoLiCoreStreamEvent done = items[^1];
+		Assert.Equal("你好", done.Text);
+		Assert.Equal(12, done.InputTokens);
+		Assert.Equal(3, done.OutputTokens);
+	}
+
+	[Fact]
+	public async Task 没有排队事件也合法()
+	{
+		List<LuoLiCoreStreamEvent> items = await ReadAsync(
+			"event: delta\ndata: {\"text\":\"嗯\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"嗯\"}\n\n");
+
+		Assert.Equal([LuoLiCoreStreamEventKind.Delta, LuoLiCoreStreamEventKind.Done], items.Select(i => i.Kind));
+	}
+
+	[Fact]
+	public async Task 零个增量也合法()
+	{
+		List<LuoLiCoreStreamEvent> items = await ReadAsync("event: done\ndata: {\"text\":\"\"}\n\n");
+
+		LuoLiCoreStreamEvent only = Assert.Single(items);
+		Assert.Equal(LuoLiCoreStreamEventKind.Done, only.Kind);
+	}
+
+	[Fact]
+	public async Task 排队事件排在增量之后就是协议被破坏()
+	{
+		ChatException failure = await ReadFailureAsync(
+			"event: delta\ndata: {\"text\":\"半\"}\n\n"
+			+ "event: queued\ndata: {}\n\n"
+			+ "event: done\ndata: {\"text\":\"半\"}\n\n");
+
+		Assert.Contains("queued", failure.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 终结事件之后还有数据就是协议被破坏()
+	{
+		ChatException failure = await ReadFailureAsync(
+			"event: done\ndata: {\"text\":\"完\"}\n\n"
+			+ "event: delta\ndata: {\"text\":\"又来\"}\n\n");
+
+		Assert.Contains("终结事件", failure.Message, StringComparison.Ordinal);
+	}
+
+	/// <summary>连接被中途掐断。这一条是「无心跳帧 + 反代空闲超时」最常见的落地形态。</summary>
+	[Fact]
+	public async Task 流没有以done或error结束就是被中断()
+	{
+		ChatException failure = await ReadFailureAsync(
+			"event: delta\ndata: {\"text\":\"说到一半\"}\n\n");
+
+		Assert.Contains("中断", failure.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 错误事件终结流并摊平成字段()
+	{
+		List<LuoLiCoreStreamEvent> items = await ReadAsync(
+			"event: queued\ndata: {}\n\n"
+			+ "event: error\ndata: {\"code\":\"turn_queue_full\",\"message\":\"排队已满\",\"retryable\":true}\n\n");
+
+		LuoLiCoreStreamEvent failure = items[^1];
+		Assert.Equal(LuoLiCoreStreamEventKind.Error, failure.Kind);
+		Assert.Equal("turn_queue_full", failure.ErrorCode);
+		Assert.Equal("排队已满", failure.ErrorMessage);
+		Assert.True(failure.Retryable);
+
+		// 队列满在流式端点上不是 HTTP 429，调用方只能靠这个判据退避。
+		Assert.True(failure.IsQueueFull);
+	}
+
+	[Fact]
+	public async Task 未知事件名忽略而不是抛()
+	{
+		List<LuoLiCoreStreamEvent> items = await ReadAsync(
+			"event: heartbeat\ndata: {}\n\n"
+			+ "event: done\ndata: {\"text\":\"在\"}\n\n");
+
+		LuoLiCoreStreamEvent only = Assert.Single(items);
+		Assert.Equal(LuoLiCoreStreamEventKind.Done, only.Kind);
+	}
+
+	[Fact]
+	public async Task 注释帧忽略()
+	{
+		List<LuoLiCoreStreamEvent> items = await ReadAsync(
+			": 反代插的保活注释\n\n"
+			+ "event: done\ndata: {\"text\":\"在\"}\n\n");
+
+		Assert.Single(items);
+	}
+
+	[Fact]
+	public async Task 半个帧不吐出去()
+	{
+		// data 缺失：这不是一个事件，读到流末尾应当按「被中断」处理。
+		await ReadFailureAsync("event: delta\n\n");
+	}
+
+	[Fact]
+	public async Task 载荷不是合法json就报解析失败而不是当成空文本()
+	{
+		ChatException failure = await ReadFailureAsync("event: delta\ndata: {不是json}\n\n");
+
+		Assert.Contains("解析失败", failure.Message, StringComparison.Ordinal);
+	}
+
+	/// <summary>SSE 规范里 `data:` 之后的单个空格属于分隔符，不是正文。</summary>
+	[Fact]
+	public async Task 字段冒号后的单个空格被剥掉()
+	{
+		List<LuoLiCoreStreamEvent> items = await ReadAsync("event: done\ndata: {\"text\":\" 前导空格保留\"}\n\n");
+
+		Assert.Equal(" 前导空格保留", items[^1].Text);
+	}
+}

--- a/app/desktop/Nori.Core.Tests/LuoLiCoreToolsTests.cs
+++ b/app/desktop/Nori.Core.Tests/LuoLiCoreToolsTests.cs
@@ -1,0 +1,259 @@
+using System.Net;
+using System.Text;
+using Nori.Core.Agent;
+using Nori.Core.Chat.LuoLiCore;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Security;
+
+namespace Nori.Core.Tests;
+
+/// <summary>
+/// 把对端的工具能力接进来的两件事：问「我能用什么」，以及跑起来时知道「她正在跑什么」。
+/// </summary>
+public sealed class LuoLiCoreToolsTests : IDisposable
+{
+	private readonly string _path = Path.Combine(Path.GetTempPath(), $"nori-luoli-tools-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+	private readonly LuoLiCoreSettingsStore _settings;
+
+	private sealed class FixedKeyStore : ISecretKeyStore
+	{
+		private readonly byte[] _key = Enumerable.Range(0, SecretKeyStore.KeySize).Select(index => (byte)index).ToArray();
+
+		public byte[] LoadOrCreate() => _key;
+
+		public bool IsFileFallback => true;
+	}
+
+	public LuoLiCoreToolsTests()
+	{
+		_database = NoriDatabase.Open(_path);
+		_config = new ConfigStore(_database, new FixedKeyStore());
+		_config.InitDefaults("test");
+		_settings = new LuoLiCoreSettingsStore(_config);
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_path); } catch (IOException) { /* 临时库删不掉不影响断言 */ }
+	}
+
+	private void Configure(bool enabled = true, string sessionId = "s")
+	{
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(enabled));
+		_config.Set(LuoLiCoreSettingsStore.KeyBaseUrl, new ConfigValue.Text("http://127.0.0.1:3000"));
+		_config.Set(LuoLiCoreSettingsStore.KeyApiKey, new ConfigValue.Text("sk-test"));
+		if (sessionId.Length > 0) _config.Set(LuoLiCoreSettingsStore.KeySessionId, new ConfigValue.Text(sessionId));
+	}
+
+	private LuoLiCoreConversation Build(Func<HttpRequestMessage, HttpResponseMessage> responder)
+	{
+		HttpClient http = new(new StubHandler(responder));
+		return new LuoLiCoreConversation(_settings, options => new LuoLiCoreSdkClient(http, options));
+	}
+
+	private static HttpResponseMessage Sse(string body) => new(HttpStatusCode.OK)
+	{
+		Content = new StringContent(body, Encoding.UTF8, "text/event-stream"),
+	};
+
+	private static HttpResponseMessage Json(HttpStatusCode code, string body) => new(code)
+	{
+		Content = new StringContent(body, Encoding.UTF8, "application/json"),
+	};
+
+	// ---- GET /sdk/v1/tools ----
+
+	[Fact]
+	public async Task 列出对端可用的工具()
+	{
+		Configure();
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return Json(
+				HttpStatusCode.OK,
+				"{\"ok\":true,\"tools\":["
+					+ "{\"name\":\"grep\",\"description\":\"按内容搜文件\",\"approval\":\"never\"},"
+					+ "{\"name\":\"delete_file\",\"description\":\"删文件\",\"approval\":\"always\"}"
+					+ "]}");
+		});
+
+		IReadOnlyList<LuoLiCoreTool> tools = await conversation.ListToolsAsync(CancellationToken.None);
+
+		Assert.Equal(["/sdk/v1/tools"], paths);
+		Assert.Equal(["grep", "delete_file"], tools.Select(tool => tool.Name));
+		Assert.False(tools[0].NeedsApproval);
+		// SDK 会话没有人工审批通道，需要审批的那件调了就是被拒 —— 界面得能提前标出来。
+		Assert.True(tools[1].NeedsApproval);
+	}
+
+	/// <summary>对端版本旧、还没有这个端点时，不该让设置页或启动流程失败。</summary>
+	[Fact]
+	public async Task 对端没有这个端点时返回空列表而不是抛()
+	{
+		Configure();
+		LuoLiCoreConversation conversation = Build(_ => Json(HttpStatusCode.NotFound, "{}"));
+
+		Assert.Empty(await conversation.ListToolsAsync(CancellationToken.None));
+	}
+
+	[Fact]
+	public async Task 未启用时不去碰远端()
+	{
+		Configure(enabled: false);
+		List<string> paths = [];
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			paths.Add(request.RequestUri!.AbsolutePath);
+			return Json(HttpStatusCode.OK, "{\"ok\":true,\"tools\":[]}");
+		});
+
+		Assert.Empty(await conversation.ListToolsAsync(CancellationToken.None));
+		Assert.Empty(paths);
+	}
+
+	// ---- SSE tool 事件 ----
+
+	[Fact]
+	public async Task 请求里显式要了工具事件()
+	{
+		Configure();
+		string body = "";
+		LuoLiCoreConversation conversation = Build(request =>
+		{
+			body = request.Content!.ReadAsStringAsync(CancellationToken.None).Result;
+			return Sse("event: done\ndata: {\"text\":\"好\"}\n\n");
+		});
+
+		await conversation.RunAsync("在吗", null, CancellationToken.None);
+
+		// 对端缺省不发工具事件，所以这一项必须真的发出去，否则整条特性静默失效。
+		Assert.Contains("\"events\":[\"tool\"]", body, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 工具事件逐条回调()
+	{
+		Configure();
+		List<string> tools = [];
+		List<string> chunks = [];
+		LuoLiCoreConversation conversation = Build(_ => Sse(
+			"event: tool\ndata: {\"name\":\"grep\"}\n\n"
+			+ "event: delta\ndata: {\"text\":\"找到了\"}\n\n"
+			+ "event: tool\ndata: {\"name\":\"read_file\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"找到了\"}\n\n"));
+
+		await conversation.RunAsync("搜一下", chunks.Add, null, tools.Add, CancellationToken.None);
+
+		Assert.Equal(["grep", "read_file"], tools);
+		Assert.Equal(["找到了"], chunks);
+	}
+
+	/// <summary>它不参与顺序不变量：夹在 delta 之间、或出现在没有 delta 的轮次里都合法。</summary>
+	[Fact]
+	public async Task 没有任何文本增量的一轮也能有工具事件()
+	{
+		Configure();
+		List<string> tools = [];
+		LuoLiCoreConversation conversation = Build(_ => Sse(
+			"event: tool\ndata: {\"name\":\"bash\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"跑完了\"}\n\n"));
+
+		ProtocolMessage message = await conversation.RunAsync("跑一下", null, null, tools.Add, CancellationToken.None);
+
+		Assert.Equal(["bash"], tools);
+		Assert.Equal("跑完了", message.Text);
+	}
+
+	[Fact]
+	public async Task 名字为空的工具事件被丢掉()
+	{
+		Configure();
+		List<string> tools = [];
+		LuoLiCoreConversation conversation = Build(_ => Sse(
+			"event: tool\ndata: {\"name\":\"\"}\n\n"
+			+ "event: done\ndata: {\"text\":\"好\"}\n\n"));
+
+		await conversation.RunAsync("在吗", null, null, tools.Add, CancellationToken.None);
+
+		Assert.Empty(tools);
+	}
+
+	// ---- 建议清单 ----
+
+	[Fact]
+	public void 建议清单覆盖选定的六组()
+	{
+		Assert.Contains("read_file", LuoLiCoreToolPreset.Recommended);
+		Assert.Contains("bash", LuoLiCoreToolPreset.Recommended);
+		Assert.Contains("web_fetch", LuoLiCoreToolPreset.Recommended);
+		Assert.Contains("search_messages", LuoLiCoreToolPreset.Recommended);
+		Assert.Contains("memory_write", LuoLiCoreToolPreset.Recommended);
+		Assert.Contains("install_mcp", LuoLiCoreToolPreset.Recommended);
+	}
+
+	/// <summary>
+	/// 这两件的 minRole 是 owner，而 SDK 会话恒 trusted —— 配了也调不到。
+	/// 列进建议清单只会让人以为自己开了。
+	/// </summary>
+	[Fact]
+	public void 建议清单不含角色轴挡住的两件()
+	{
+		foreach (string name in LuoLiCoreToolPreset.BlockedByRole)
+			Assert.DoesNotContain(name, LuoLiCoreToolPreset.Recommended);
+	}
+
+	[Fact]
+	public void 建议清单不含结构性禁止的那两族()
+	{
+		// 派发与 Telegram 输出在对端是配了也不生效的，出现在这里等于在教人配一份无效清单。
+		foreach (string name in new[] { "spawn_worker", "read_worker_result", "send_message", "stay_silent" })
+			Assert.DoesNotContain(name, LuoLiCoreToolPreset.Recommended);
+	}
+
+	[Fact]
+	public void 建议清单去重且有序()
+	{
+		Assert.Equal(LuoLiCoreToolPreset.Recommended.Distinct(StringComparer.Ordinal), LuoLiCoreToolPreset.Recommended);
+		Assert.Equal(
+			LuoLiCoreToolPreset.Recommended.OrderBy(name => name, StringComparer.Ordinal),
+			LuoLiCoreToolPreset.Recommended);
+	}
+
+	/// <summary>「你以为开了、其实没开」是这个集成里最难查的一类不一致。</summary>
+	[Fact]
+	public void 缺口算得出来()
+	{
+		LuoLiCoreTool[] available =
+		[
+			new("read_file", "读文件", false),
+			new("grep", "搜文件", false),
+		];
+
+		IReadOnlyList<string> missing = LuoLiCoreToolPreset.Missing(available);
+
+		Assert.DoesNotContain("read_file", missing);
+		Assert.Contains("bash", missing);
+		Assert.Equal(LuoLiCoreToolPreset.Recommended.Count - 2, missing.Count);
+	}
+
+	[Fact]
+	public void 全都给齐时缺口为空()
+	{
+		LuoLiCoreTool[] available =
+			[.. LuoLiCoreToolPreset.Recommended.Select(name => new LuoLiCoreTool(name, "", false))];
+
+		Assert.Empty(LuoLiCoreToolPreset.Missing(available));
+	}
+
+	private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+	{
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+			Task.FromResult(responder(request));
+	}
+}

--- a/app/desktop/Nori.Core.Tests/ReplyReactionServiceTests.cs
+++ b/app/desktop/Nori.Core.Tests/ReplyReactionServiceTests.cs
@@ -1,0 +1,205 @@
+using System.Text.Json;
+using Nori.Core.Agent;
+using Nori.Core.Chat;
+using Nori.Core.Configuration;
+using Nori.Core.Data;
+using Nori.Core.Security;
+
+namespace Nori.Core.Tests;
+
+/// <summary>
+/// 回复文本 → 表情动作。
+///
+/// 两个方向都要钉住：名单外的名字必须被夹掉（目录过滤不是边界）；挑不出来时必须退化成
+/// 空反应而不是抛（挑表情失败不该让整轮对话失败）。
+/// </summary>
+public sealed class ReplyReactionServiceTests : IDisposable
+{
+	private readonly string _path = Path.Combine(Path.GetTempPath(), $"nori-reply-reaction-{Guid.NewGuid():N}.db");
+	private readonly NoriDatabase _database;
+	private readonly ConfigStore _config;
+
+	private sealed class FixedKeyStore : ISecretKeyStore
+	{
+		private readonly byte[] _key = Enumerable.Range(0, SecretKeyStore.KeySize).Select(index => (byte)index).ToArray();
+
+		public byte[] LoadOrCreate() => _key;
+
+		public bool IsFileFallback => true;
+	}
+
+	public ReplyReactionServiceTests()
+	{
+		_database = NoriDatabase.Open(_path);
+		_config = new ConfigStore(_database, new FixedKeyStore());
+		_config.InitDefaults("test");
+	}
+
+	public void Dispose()
+	{
+		_database.Dispose();
+		try { File.Delete(_path); } catch (IOException) { /* 临时库删不掉不影响断言 */ }
+	}
+
+	private void ConfigureLocalLlm()
+	{
+		_config.Set(AiSettingsStore.KeyLlmBaseUrl, new ConfigValue.Text("https://llm.example/v1"));
+		_config.Set(AiSettingsStore.KeyLlmApiKey, new ConfigValue.Text("sk-local"));
+		_config.Set(AiSettingsStore.KeyLlmModel, new ConfigValue.Text("m"));
+	}
+
+	/// <summary>固定回一段 JSON 的适配器；同时记下收到的用户提示，供断言最小输入用。</summary>
+	private sealed class ScriptedAdapter(string reply, List<string> prompts) : ILlmAdapter
+	{
+		public Task<string> CompleteAsync(
+			string baseUrl, string apiKey, string model, string systemPrompt,
+			IReadOnlyList<ChatMessageInput> messages, CancellationToken cancellationToken = default)
+		{
+			prompts.Add(messages[^1].Content);
+			return Task.FromResult(reply);
+		}
+
+		public Task<string> StreamAsync(
+			string baseUrl, string apiKey, string model, string systemPrompt,
+			IReadOnlyList<ChatMessageInput> messages, Action<string> onChunk,
+			Action<LlmUsageInfo>? onUsage = null, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException("表情挑选只走非流式");
+
+		public Task<IReadOnlyList<string>> FetchModelsAsync(
+			string baseUrl, string apiKey, CancellationToken cancellationToken = default) =>
+			throw new NotSupportedException();
+	}
+
+	private ReplyReactionService Build(string reply, List<string>? prompts = null) =>
+		new(new HttpClient(), _config, (_, _) => new ScriptedAdapter(reply, prompts ?? []));
+
+	private static ReplyReactionRequest Request(string text = "今天真不错") => new()
+	{
+		ReplyText = text,
+		AvailableMotions = ["Tap", "Idle"],
+		AvailableExpressions = ["smile", "sad"],
+	};
+
+	[Fact]
+	public async Task 名单内的选择被采纳()
+	{
+		ConfigureLocalLlm();
+		ReplyReactionService service = Build("{\"emotion\":\"happy\",\"expression\":\"smile\",\"action\":\"Tap\"}");
+
+		PetInteractionReaction reaction = await service.ReactAsync(Request(), CancellationToken.None);
+
+		Assert.Equal("happy", reaction.Emotion);
+		Assert.Equal("smile", reaction.Expression);
+		Assert.Equal("Tap", reaction.Motion);
+	}
+
+	/// <summary>提示词里写了「不要捏造」不等于它不会捏造。</summary>
+	[Fact]
+	public async Task 名单外的名字被夹掉()
+	{
+		ConfigureLocalLlm();
+		ReplyReactionService service = Build("{\"emotion\":\"happy\",\"expression\":\"wink\",\"action\":\"Dance\"}");
+
+		PetInteractionReaction reaction = await service.ReactAsync(Request(), CancellationToken.None);
+
+		Assert.Equal("happy", reaction.Emotion);
+		Assert.Null(reaction.Expression);
+		Assert.Null(reaction.Motion);
+	}
+
+	[Fact]
+	public async Task 语气平淡时全空也是合法结果()
+	{
+		ConfigureLocalLlm();
+		ReplyReactionService service = Build("{\"emotion\":\"\",\"expression\":\"\",\"action\":\"\"}");
+
+		PetInteractionReaction reaction = await service.ReactAsync(Request(), CancellationToken.None);
+
+		Assert.Null(reaction.Emotion);
+		Assert.Null(reaction.Expression);
+		Assert.Null(reaction.Motion);
+	}
+
+	/// <summary>只配了 LuoLiCore 的人本来就没有本机三项，不该因此整轮失败。</summary>
+	[Fact]
+	public async Task 没有本机LLM配置时退化成空反应而不是抛()
+	{
+		ReplyReactionService service = Build("{\"expression\":\"smile\"}");
+
+		PetInteractionReaction reaction = await service.ReactAsync(Request(), CancellationToken.None);
+
+		Assert.Null(reaction.Expression);
+	}
+
+	[Fact]
+	public async Task 上游故障退化成空反应()
+	{
+		ConfigureLocalLlm();
+		ReplyReactionService service = new(
+			new HttpClient(), _config, (_, _) => throw new ChatException("上游挂了"));
+
+		PetInteractionReaction reaction = await service.ReactAsync(Request(), CancellationToken.None);
+
+		Assert.Null(reaction.Expression);
+		Assert.Null(reaction.Motion);
+	}
+
+	[Fact]
+	public async Task 返回的不是json也退化成空反应()
+	{
+		ConfigureLocalLlm();
+		ReplyReactionService service = Build("我觉得应该是 smile 吧");
+
+		PetInteractionReaction reaction = await service.ReactAsync(Request(), CancellationToken.None);
+
+		Assert.Null(reaction.Expression);
+	}
+
+	[Fact]
+	public async Task 候选名单为空时不发请求()
+	{
+		ConfigureLocalLlm();
+		List<string> prompts = [];
+		ReplyReactionService service = Build("{\"expression\":\"smile\"}", prompts);
+
+		await service.ReactAsync(
+			new ReplyReactionRequest { ReplyText = "在的" },
+			CancellationToken.None);
+
+		Assert.Empty(prompts);
+	}
+
+	[Fact]
+	public async Task 回复为空时不发请求()
+	{
+		ConfigureLocalLlm();
+		List<string> prompts = [];
+		ReplyReactionService service = Build("{\"expression\":\"smile\"}", prompts);
+
+		await service.ReactAsync(Request("   "), CancellationToken.None);
+
+		Assert.Empty(prompts);
+	}
+
+	/// <summary>输入是可审计的最小集合：只有这句回复和两张候选名单，没有历史也没有秘密。</summary>
+	[Fact]
+	public void 提示词不带历史与秘密()
+	{
+		JsonElement prompt = JsonDocument.Parse(ReplyReactionService.BuildUserPrompt(Request("今天真不错"))).RootElement;
+
+		Assert.Equal("今天真不错", prompt.GetProperty("reply").GetString());
+		Assert.Equal(new[] { "smile", "sad" }, prompt.GetProperty("availableExpressions").EnumerateArray().Select(item => item.GetString()!));
+		// 字段就这三个（currentEmotion 为空时不序列化）：多一个都意味着有东西被顺带送了出去。
+		Assert.Equal(
+			new[] { "availableExpressions", "availableMotions", "reply" },
+			prompt.EnumerateObject().Select(field => field.Name).Order(StringComparer.Ordinal));
+	}
+
+	[Fact]
+	public void 过长的回复被截断()
+	{
+		JsonElement prompt = JsonDocument.Parse(ReplyReactionService.BuildUserPrompt(Request(new string('字', 900)))).RootElement;
+
+		Assert.Equal(400, prompt.GetProperty("reply").GetString()!.Length);
+	}
+}

--- a/app/desktop/Nori.Core.Tests/WorkspaceToolsTests.cs
+++ b/app/desktop/Nori.Core.Tests/WorkspaceToolsTests.cs
@@ -131,6 +131,90 @@ public sealed class WorkspaceToolsTests : IDisposable
 		Assert.False(new WorkspaceAccess(Path.Combine(_root, "并不存在")).IsConfigured);
 	}
 
+	// ---- review 指出的两处越界 ----
+
+	/// <summary>
+	/// 遍历过程中的目录链接必须逐个复验。
+	///
+	/// `Resolve` 只覆盖调用方给出的相对路径；`Directory.GetDirectories` 返回的绝对路径不经过
+	/// 它，而其中可能有指向工作目录之外的链接。搜索是 `safe` 档、不经确认，这条路径上的越界
+	/// 等于无确认的任意文件读取。
+	/// </summary>
+	[Fact]
+	public async Task 搜索不跟随指向目录外的链接()
+	{
+		File.WriteAllText(Path.Combine(_outside, "leak.txt"), "越界内容 needle");
+		Write("inside.txt", "界内内容 needle");
+		try
+		{
+			Directory.CreateSymbolicLink(Path.Combine(_root, "escape"), _outside);
+		}
+		catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
+		{
+			return; // 该环境不允许建符号链接
+		}
+
+		JsonElement found = await CallAsync(Registry(), "searchFiles", new { query = "needle" });
+		string[] paths = [.. found.GetProperty("hits").EnumerateArray().Select(e => e.GetProperty("path").GetString()!)];
+
+		Assert.Contains("inside.txt", paths);
+		Assert.DoesNotContain(paths, path => path.Contains("leak", StringComparison.Ordinal));
+	}
+
+	[Fact]
+	public async Task 列目录不列出指向目录外的链接()
+	{
+		try
+		{
+			Directory.CreateSymbolicLink(Path.Combine(_root, "escape"), _outside);
+		}
+		catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
+		{
+			return;
+		}
+
+		JsonElement listed = await CallAsync(Registry(), "listFiles", new { });
+		string[] names = [.. listed.GetProperty("entries").EnumerateArray().Select(e => e.GetProperty("name").GetString()!)];
+
+		Assert.DoesNotContain("escape", names);
+	}
+
+	/// <summary>
+	/// 大小写敏感的文件系统上，同级目录不能因为只有大小写差异就被当成界内。
+	///
+	/// 另有一处：`Path.Combine` 不做规范化，`<root>/..` 这个字符串仍以根为前缀，逐段校验时
+	/// 必须显式拒绝 `..` 与 `.`，不能交给前缀比较。
+	/// </summary>
+	[Fact]
+	public void 逐段校验拒绝点段()
+	{
+		WorkspaceAccess access = Access();
+
+		Assert.Null(access.Resolve("sub/../../outside.txt"));
+		Assert.Null(access.Resolve("./../escape"));
+		Assert.Null(access.Resolve("a/./../../b"));
+	}
+
+	[Fact]
+	public void 路径比较的大小写口径按平台取()
+	{
+		string sibling = _root.ToUpperInvariant();
+		WorkspaceAccess access = Access();
+
+		// Windows 上大小写不敏感，同一目录的大写形式仍是它自己；其余平台上是另一个目录。
+		Assert.Equal(OperatingSystem.IsWindows(), access.Inside(sibling));
+	}
+
+	/// <summary>遍历拿到的绝对路径与相对路径走同一道判据。</summary>
+	[Fact]
+	public void 界外的绝对路径不被接受()
+	{
+		WorkspaceAccess access = Access();
+
+		Assert.Null(access.Accept(Path.Combine(_outside, "secret.txt")));
+		Assert.NotNull(access.Accept(Path.Combine(_root, "a.txt")));
+	}
+
 	// ---- 权限档位 ----
 
 	/// <summary>

--- a/app/desktop/Nori.Core.Tests/WorkspaceToolsTests.cs
+++ b/app/desktop/Nori.Core.Tests/WorkspaceToolsTests.cs
@@ -1,0 +1,333 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Nori.Core.Tools;
+
+namespace Nori.Core.Tests;
+
+/// <summary>
+/// 工作目录文件工具。
+///
+/// 这一族的全部安全性压在 <see cref="WorkspaceAccess.Resolve"/> 上：模型给的路径是不可信
+/// 输入，一次越界读取泄露的是用户磁盘上的任意文件。所以越界那几条是本文件的重点，其余是
+/// 可用性判据。
+/// </summary>
+public sealed class WorkspaceToolsTests : IDisposable
+{
+	private readonly string _root = Path.Combine(Path.GetTempPath(), $"nori-ws-{Guid.NewGuid():N}");
+	private readonly string _outside = Path.Combine(Path.GetTempPath(), $"nori-out-{Guid.NewGuid():N}");
+
+	public WorkspaceToolsTests()
+	{
+		Directory.CreateDirectory(_root);
+		Directory.CreateDirectory(_outside);
+		File.WriteAllText(Path.Combine(_outside, "secret.txt"), "不该被读到");
+	}
+
+	public void Dispose()
+	{
+		foreach (string directory in new[] { _root, _outside })
+		{
+			try { Directory.Delete(directory, recursive: true); } catch (IOException) { /* 清理失败不影响断言 */ }
+		}
+	}
+
+	private WorkspaceAccess Access() => new(_root);
+
+	private void Write(string relative, string content)
+	{
+		string full = Path.Combine(_root, relative.Replace('/', Path.DirectorySeparatorChar));
+		Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+		File.WriteAllText(full, content);
+	}
+
+	private ToolRegistry Registry()
+	{
+		ToolRegistry registry = new();
+		WorkspaceTools.RegisterAll(registry, Access());
+		return registry;
+	}
+
+	private static async Task<JsonElement> CallAsync(ToolRegistry registry, string name, object args)
+	{
+		ToolResult result = await registry.ExecuteAsync(
+			name,
+			JsonNode.Parse(JsonSerializer.Serialize(args)),
+			new ToolContext { Approve = _ => Task.FromResult(true) });
+		Assert.True(result.IsSuccess, result.Error);
+		return JsonSerializer.SerializeToElement(result.Result);
+	}
+
+	private static async Task<string> FailAsync(ToolRegistry registry, string name, object args)
+	{
+		ToolResult result = await registry.ExecuteAsync(
+			name,
+			JsonNode.Parse(JsonSerializer.Serialize(args)),
+			new ToolContext { Approve = _ => Task.FromResult(true) });
+		Assert.False(result.IsSuccess);
+		return result.Error ?? "";
+	}
+
+	// ---- 边界 ----
+
+	[Theory]
+	[InlineData("../secret.txt")]
+	[InlineData("../../etc/passwd")]
+	[InlineData("sub/../../outside.txt")]
+	[InlineData("C:/Windows/System32/drivers/etc/hosts")]
+	[InlineData("/etc/passwd")]
+	public void 越界路径一律解析失败(string path)
+	{
+		Assert.Null(Access().Resolve(path));
+	}
+
+	[Fact]
+	public void 目录内的路径正常解析()
+	{
+		WorkspaceAccess access = Access();
+
+		Assert.NotNull(access.Resolve("a.txt"));
+		Assert.NotNull(access.Resolve("sub/b.txt"));
+		// 反斜杠也收：Windows 上的模型很容易给出这种写法。
+		Assert.NotNull(access.Resolve("sub\\b.txt"));
+		Assert.Equal(access.Root, access.Resolve("."));
+	}
+
+	/// <summary>
+	/// 前缀比较挡不住符号链接：工作目录里放一个指向外面的链接，`GetFullPath` 之后它仍然
+	/// 是界内路径。必须解引用之后再比一次。
+	/// </summary>
+	[Fact]
+	public void 指向目录外的符号链接被拦下()
+	{
+		string link = Path.Combine(_root, "escape");
+		try
+		{
+			Directory.CreateSymbolicLink(link, _outside);
+		}
+		catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
+		{
+			// Windows 上建符号链接要开发者模式或管理员权限，建不了就跳过 —— 这一条在能建的
+			// 环境里才有意义，而判据本身由上面几条覆盖。
+			return;
+		}
+
+		Assert.Null(Access().Resolve("escape/secret.txt"));
+	}
+
+	[Fact]
+	public void 没配工作目录时整族工具不注册()
+	{
+		ToolRegistry registry = new();
+		WorkspaceTools.RegisterAll(registry, new WorkspaceAccess(""));
+
+		// 让模型看见一件永远失败的工具只会让它反复试。
+		Assert.Empty(registry.List());
+	}
+
+	[Fact]
+	public void 目录不存在时同样视为未配置()
+	{
+		Assert.False(new WorkspaceAccess(Path.Combine(_root, "并不存在")).IsConfigured);
+	}
+
+	// ---- 权限档位 ----
+
+	/// <summary>
+	/// 读是 safe、写是 confirm。
+	///
+	/// 配工作目录本身就是用户那次同意；再让每次读都弹框，「看看这个项目」会变成五十次点击，
+	/// 用户会直接关掉这个功能 —— 那比没有还糟。写改的是用户的东西，每次都问。
+	/// </summary>
+	[Fact]
+	public void 读是safe写要确认()
+	{
+		ToolRegistry registry = Registry();
+
+		Assert.Equal("safe", registry.Get("readFile")!.PermissionLevel);
+		Assert.Equal("safe", registry.Get("listFiles")!.PermissionLevel);
+		Assert.Equal("safe", registry.Get("searchFiles")!.PermissionLevel);
+		Assert.Equal("confirm", registry.Get("writeFile")!.PermissionLevel);
+	}
+
+	[Fact]
+	public async Task 没有授权通道时写入被拒()
+	{
+		ToolResult result = await Registry().ExecuteAsync(
+			"writeFile",
+			JsonNode.Parse("{\"path\":\"a.txt\",\"content\":\"x\"}"),
+			new ToolContext());
+
+		Assert.False(result.IsSuccess);
+		Assert.False(File.Exists(Path.Combine(_root, "a.txt")));
+	}
+
+	[Fact]
+	public async Task 用户拒绝时不写入()
+	{
+		ToolResult result = await Registry().ExecuteAsync(
+			"writeFile",
+			JsonNode.Parse("{\"path\":\"a.txt\",\"content\":\"x\"}"),
+			new ToolContext { Approve = _ => Task.FromResult(false) });
+
+		Assert.False(result.IsSuccess);
+		Assert.False(File.Exists(Path.Combine(_root, "a.txt")));
+	}
+
+	// ---- 可用性 ----
+
+	[Fact]
+	public async Task 列目录区分文件与文件夹并跳过噪音目录()
+	{
+		Write("a.txt", "甲");
+		Write("src/b.cs", "乙");
+		Write("node_modules/pkg/index.js", "丙");
+		Write(".git/config", "丁");
+
+		JsonElement listed = await CallAsync(Registry(), "listFiles", new { });
+		string[] names = [.. listed.GetProperty("entries").EnumerateArray().Select(e => e.GetProperty("name").GetString()!)];
+
+		Assert.Contains("a.txt", names);
+		Assert.Contains("src", names);
+		Assert.DoesNotContain("node_modules", names);
+		Assert.DoesNotContain(".git", names);
+	}
+
+	[Fact]
+	public async Task 读文件返回内容与相对路径()
+	{
+		Write("src/b.cs", "class B {}");
+
+		JsonElement read = await CallAsync(Registry(), "readFile", new { path = "src/b.cs" });
+
+		Assert.Equal("class B {}", read.GetProperty("content").GetString());
+		Assert.Equal("src/b.cs", read.GetProperty("path").GetString());
+		Assert.False(read.GetProperty("truncated").GetBoolean());
+	}
+
+	[Fact]
+	public async Task 二进制文件不读进上下文()
+	{
+		File.WriteAllBytes(Path.Combine(_root, "a.bin"), [0x00, 0x01, 0x02, 0x00]);
+
+		Assert.Contains("二进制", await FailAsync(Registry(), "readFile", new { path = "a.bin" }), StringComparison.Ordinal);
+	}
+
+	/// <summary>
+	/// 超大文件截断之后返回的必须仍然是**结构**。
+	///
+	/// `ToolRegistry` 有一道 48,000 字符的结果上限，超了就把整个结果序列化再截断 —— 模型拿到
+	/// 的会是一段半截 JSON 文本，既读不出文件名也读不全内容，而且看不出发生了什么。所以工具
+	/// 自己要先把结果收进这个预算里。
+	/// </summary>
+	[Fact]
+	public async Task 超大文件截断后仍是结构化结果()
+	{
+		File.WriteAllText(Path.Combine(_root, "big.txt"), new string('x', WorkspaceAccess.MaxReadBytes + 5000));
+
+		JsonElement read = await CallAsync(Registry(), "readFile", new { path = "big.txt" });
+
+		Assert.Equal(JsonValueKind.Object, read.ValueKind);
+		Assert.Equal("big.txt", read.GetProperty("path").GetString());
+		Assert.True(read.GetProperty("truncated").GetBoolean());
+		Assert.NotEmpty(read.GetProperty("content").GetString()!);
+	}
+
+	/// <summary>非 ASCII 会被 JSON 转义成 6 个字符一枚，膨胀率和纯英文完全不同。</summary>
+	[Fact]
+	public async Task 中文大文件同样收进预算()
+	{
+		File.WriteAllText(Path.Combine(_root, "big-zh.txt"), new string('文', 60_000));
+
+		JsonElement read = await CallAsync(Registry(), "readFile", new { path = "big-zh.txt" });
+
+		Assert.Equal(JsonValueKind.Object, read.ValueKind);
+		Assert.True(read.GetProperty("truncated").GetBoolean());
+		Assert.NotEmpty(read.GetProperty("content").GetString()!);
+	}
+
+	[Fact]
+	public async Task 命中过多时丢掉尾部而不是整个结果被压扁()
+	{
+		for (int index = 0; index < 300; index++)
+		{
+			Write($"f{index}.txt", "目标目标目标目标目标目标目标目标目标目标目标目标目标目标目标目标");
+		}
+
+		JsonElement found = await CallAsync(Registry(), "searchFiles", new { query = "目标" });
+
+		Assert.Equal(JsonValueKind.Object, found.ValueKind);
+		Assert.True(found.GetProperty("truncated").GetBoolean());
+		Assert.NotEmpty(found.GetProperty("hits").EnumerateArray().ToArray());
+	}
+
+	[Fact]
+	public async Task 搜索给出文件行号与该行内容()
+	{
+		Write("src/b.cs", "class B {}\nvoid 找我() {}\n");
+		Write("src/c.txt", "无关内容");
+
+		JsonElement found = await CallAsync(Registry(), "searchFiles", new { query = "找我" });
+		JsonElement[] hits = [.. found.GetProperty("hits").EnumerateArray()];
+
+		Assert.Single(hits);
+		Assert.Equal("src/b.cs", hits[0].GetProperty("path").GetString());
+		Assert.Equal(2, hits[0].GetProperty("line").GetInt32());
+		Assert.Contains("找我", hits[0].GetProperty("text").GetString()!, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public async Task 搜索能按扩展名收窄且跳过噪音目录()
+	{
+		Write("a.cs", "目标");
+		Write("a.txt", "目标");
+		Write("node_modules/x.cs", "目标");
+
+		JsonElement found = await CallAsync(Registry(), "searchFiles", new { query = "目标", extension = "cs" });
+		string[] paths = [.. found.GetProperty("hits").EnumerateArray().Select(e => e.GetProperty("path").GetString()!)];
+
+		Assert.Equal(["a.cs"], paths);
+	}
+
+	[Fact]
+	public async Task 写入并能读回且报告是否覆盖()
+	{
+		ToolRegistry registry = Registry();
+
+		JsonElement first = await CallAsync(registry, "writeFile", new { path = "notes/n.md", content = "第一版" });
+		Assert.False(first.GetProperty("overwritten").GetBoolean());
+
+		JsonElement second = await CallAsync(registry, "writeFile", new { path = "notes/n.md", content = "第二版" });
+		Assert.True(second.GetProperty("overwritten").GetBoolean());
+
+		Assert.Equal("第二版", File.ReadAllText(Path.Combine(_root, "notes", "n.md")));
+	}
+
+	[Fact]
+	public async Task 写入越界路径被拒()
+	{
+		string error = await FailAsync(Registry(), "writeFile", new { path = "../escaped.txt", content = "x" });
+
+		Assert.Contains("超出工作目录", error, StringComparison.Ordinal);
+		Assert.False(File.Exists(Path.Combine(_outside, "..", "escaped.txt")));
+	}
+
+	[Fact]
+	public async Task 写入超过上限被拒()
+	{
+		string error = await FailAsync(
+			Registry(),
+			"writeFile",
+			new { path = "big.txt", content = new string('x', WorkspaceAccess.MaxWriteBytes + 10) });
+
+		Assert.Contains("上限", error, StringComparison.Ordinal);
+		Assert.False(File.Exists(Path.Combine(_root, "big.txt")));
+	}
+
+	[Fact]
+	public void 二进制判据认NUL字节()
+	{
+		Assert.True(WorkspaceAccess.LooksBinary(new byte[] { 0x41, 0x00, 0x42 }));
+		Assert.False(WorkspaceAccess.LooksBinary(Encoding.UTF8.GetBytes("纯文本 plain text")));
+	}
+}

--- a/app/desktop/Nori.Core.Tests/WorkspaceToolsTests.cs
+++ b/app/desktop/Nori.Core.Tests/WorkspaceToolsTests.cs
@@ -70,11 +70,19 @@ public sealed class WorkspaceToolsTests : IDisposable
 
 	// ---- 边界 ----
 
+	/// <summary>
+	/// 这些形式在 Windows 与非 Windows 上必须得到同一个结论。
+	///
+	/// 盘符那三条不能交给 <c>Path.IsPathRooted</c>：非 Windows 上它对 `C:/x` 返回 false，
+	/// 该串会被当作名为 `C:` 的相对目录落进工作目录。判据由 <c>IsDriveQualified</c> 补齐。
+	/// </summary>
 	[Theory]
 	[InlineData("../secret.txt")]
 	[InlineData("../../etc/passwd")]
 	[InlineData("sub/../../outside.txt")]
 	[InlineData("C:/Windows/System32/drivers/etc/hosts")]
+	[InlineData("c:/temp/x")]
+	[InlineData("C:report.txt")]
 	[InlineData("/etc/passwd")]
 	public void 越界路径一律解析失败(string path)
 	{

--- a/app/desktop/Nori.Core/Agent/AgentEngine.cs
+++ b/app/desktop/Nori.Core/Agent/AgentEngine.cs
@@ -69,6 +69,47 @@ public sealed class AgentEngine
 	private const int DefaultContextTokens = 12_000;
 	private const int DefaultReservedOutputTokens = 2_000;
 	private readonly int _maxToolIterations;
+
+
+	/// <summary>工具轮数上限的可配范围。上界用于约束异常情况下的无限重试。</summary>
+	public const int MinToolIterations = 1;
+	public const int MaxToolIterationsLimit = 32;
+
+	/// <summary>没配过时的取值。</summary>
+	public const int DefaultToolIterations = 12;
+
+	/// <summary>
+	/// 本轮允许的工具轮数。
+	///
+	/// 每轮读取一次配置而非在构造时固定：配置变更在下一轮生效，无需重启。开销为一次本地
+	/// SQLite 读取，与该路径上已有的配置读取同量级。
+	///
+	/// 构造函数显式传值时以该值为准，供测试与特定场景收窄，不受用户配置影响。
+	/// </summary>
+	private static int Clamp(long value) =>
+		(int)Math.Clamp(value, MinToolIterations, MaxToolIterationsLimit);
+
+	/// <summary>当前生效的工具轮数上限，供设置界面显示。与 <see cref="ToolIterations"/> 同一取数。</summary>
+	public int ConfiguredToolIterations => ToolIterations;
+
+	private int ToolIterations
+	{
+		get
+		{
+			if (_maxToolIterations != DefaultToolIterations) return _maxToolIterations;
+			// 直接读取 ConfigValue 而非 GetStringOr：后者路径上 "0" / "1" 会被解析为布尔并
+			// 渲染为 "false" / "true"，配置值 0 读回后解析失败并回退默认值，表现为配置未生效。
+			return _config.Get(ConfigStore.KeyAgentMaxToolIterations) switch
+			{
+				ConfigValue.Integer integer => Clamp(integer.Value),
+				// 布尔为上述解析的产物：true 对应 1，false 对应 0，均落在下界。
+				ConfigValue.Boolean boolean => Clamp(boolean.Value ? 1 : 0),
+				ConfigValue.Text text when long.TryParse(text.Value.Trim(), out long parsed) => Clamp(parsed),
+				// 非数值时回退默认值而不抛出：配置值书写错误不应使整条对话路径失败。
+				_ => DefaultToolIterations,
+			};
+		}
+	}
 	private readonly AgentSessionCoordinator _sessionCoordinator;
 	private readonly AgentTraceSink _trace;
 	private readonly Func<LlmProvider, HttpClient, ILlmAdapter> _adapterFactory;
@@ -111,7 +152,7 @@ public sealed class AgentEngine
 		IPetActions? pet,
 		Func<IReadOnlyList<string>> motionNames,
 		Func<IReadOnlyList<string>> expressionNames,
-		int maxToolIterations = 5,
+		int maxToolIterations = DefaultToolIterations,
 		AgentSessionCoordinator? sessionCoordinator = null,
 		AgentTraceSink? trace = null,
 		Func<LlmProvider, HttpClient, ILlmAdapter>? adapterFactory = null,
@@ -281,7 +322,8 @@ public sealed class AgentEngine
 				}
 			}
 
-			for (int iteration = 0; iteration < _maxToolIterations; iteration++)
+			int iterationBudget = ToolIterations;
+			for (int iteration = 0; iteration < iterationBudget; iteration++)
 			{
 				currentIteration = iteration;
 				runToken.ThrowIfCancellationRequested();
@@ -422,9 +464,9 @@ public sealed class AgentEngine
 
 				// 若本轮没有触发新的工具调用，说明已产出最终回复，跳出循环
 				if (!hasToolCall) break;
-				if (iteration == _maxToolIterations - 1)
+				if (iteration == iterationBudget - 1)
 				{
-					throw new AgentToolRoundsExceededException(_maxToolIterations);
+					throw new AgentToolRoundsExceededException(iterationBudget);
 				}
 			}
 

--- a/app/desktop/Nori.Core/Agent/AgentEngine.cs
+++ b/app/desktop/Nori.Core/Agent/AgentEngine.cs
@@ -519,14 +519,23 @@ public sealed class AgentEngine
 
 			if (message.Text.Length == 0) throw new InvalidOperationException("LuoLiCore 未产出最终回复");
 
+			// **先落库，再挑表情。**
+			//
+			// 顺序反过来的话有一个真实的丢数据窗口：done 已经到了，对端那一轮**已经提交**，
+			// 界面上也已经有流式文本了，而挑表情是可取消的 —— 用户此刻按停止，取消会从那次
+			// await 抛出来，这一轮就永远不会落进本地历史。结果是远端记着、界面显示过、本地
+			// 没有，下一轮的远端上下文与用户看到的对不上。
+			//
+			// 落库只存文本，与表情无关，因此提前没有任何代价。
+			_chat.SaveMessage("user", userText);
+			_chat.SaveMessage("assistant", message.Text);
+
 			// 远端只给文本，表情动作在本地挑：合法名随当前 Live2D 模型变化，只有宿主知道。
-			// 挑不出来（没配本机模型、超时、返回的不是 JSON）就保持空值 —— 退化成没有表情，
-			// 不影响这一轮对话。
+			// 挑不出来（没配本机模型、超时、返回的不是 JSON、这一刻被取消）就保持空值 ——
+			// 退化成没有表情，不影响这一轮对话。
 			message = await AttachReactionAsync(message, runToken);
 
 			SetState(AgentRunState.Idle);
-			_chat.SaveMessage("user", userText);
-			_chat.SaveMessage("assistant", message.Text);
 			DispatchEffects(message);
 			callbacks.OnComplete?.Invoke(message);
 			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "completed");
@@ -567,6 +576,13 @@ public sealed class AgentEngine
 		_luoLiCore is null ? Task.FromResult(false) : _luoLiCore.ResetAsync(cancellationToken);
 
 	/// <summary>
+	/// 对端那边是否有一段会话在记着东西。
+	///
+	/// 给调用方区分「没接外部后端」与「接了但这次没去重置」用 —— 后者需要提示用户，前者不用。
+	/// </summary>
+	public bool HasRemoteContext => _luoLiCore?.HasSession ?? false;
+
+	/// <summary>
 	/// 给一条只有文本的回复补上表情与动作。
 	///
 	/// 挑选本身绝不允许影响这一轮：服务内部已经把超时与故障吞成空反应，这里再兜一层，
@@ -596,12 +612,11 @@ public sealed class AgentEngine
 				Action = reaction.Motion,
 			};
 		}
-		catch (OperationCanceledException)
-		{
-			throw;
-		}
 		catch (Exception)
 		{
+			// 含取消：走到这里时对端那一轮已经提交、文本已经落库，没有什么还能「停下来」。
+			// 把取消当成「这次没挑出表情」，而不是让整轮失败 —— 后者会把一段已经发生过的
+			// 对话报成取消，界面与远端就此分叉。
 			return message;
 		}
 	}

--- a/app/desktop/Nori.Core/Agent/AgentEngine.cs
+++ b/app/desktop/Nori.Core/Agent/AgentEngine.cs
@@ -81,6 +81,12 @@ public sealed class AgentEngine
 	/// </summary>
 	private readonly Chat.LuoLiCore.LuoLiCoreConversation? _luoLiCore;
 
+	/// <summary>
+	/// 回复文本 → 表情动作。只在走 LuoLiCore 那条路时用到：本机那条由模型在协议里直接给。
+	/// 为 null 时不挑，退化成只有物理摆动与口型。
+	/// </summary>
+	private readonly ReplyReactionService? _replyReaction;
+
 	private readonly HttpClient _http;
 	private readonly ConfigStore _config;
 	private readonly ChatService _chat;
@@ -109,7 +115,8 @@ public sealed class AgentEngine
 		AgentSessionCoordinator? sessionCoordinator = null,
 		AgentTraceSink? trace = null,
 		Func<LlmProvider, HttpClient, ILlmAdapter>? adapterFactory = null,
-		Chat.LuoLiCore.LuoLiCoreConversation? luoLiCore = null)
+		Chat.LuoLiCore.LuoLiCoreConversation? luoLiCore = null,
+		ReplyReactionService? replyReaction = null)
 	{
 		_http = http;
 		_config = config;
@@ -127,6 +134,7 @@ public sealed class AgentEngine
 		_trace = trace ?? AgentTraceSink.Noop;
 		_adapterFactory = adapterFactory ?? LlmClient.CreateAdapter;
 		_luoLiCore = luoLiCore;
+		_replyReaction = replyReaction;
 	}
 
 	/// <summary>
@@ -480,13 +488,14 @@ public sealed class AgentEngine
 
 			if (message.Text.Length == 0) throw new InvalidOperationException("LuoLiCore 未产出最终回复");
 
+			// 远端只给文本，表情动作在本地挑：合法名随当前 Live2D 模型变化，只有宿主知道。
+			// 挑不出来（没配本机模型、超时、返回的不是 JSON）就保持空值 —— 退化成没有表情，
+			// 不影响这一轮对话。
+			message = await AttachReactionAsync(message, runToken);
+
 			SetState(AgentRunState.Idle);
 			_chat.SaveMessage("user", userText);
 			_chat.SaveMessage("assistant", message.Text);
-
-			// 情绪、表情、动作三项为空，DispatchEffects 会逐项跳过；表情动作由宿主另行决定
-			// （合法名随当前 Live2D 模型变化，只有宿主知道）。这里照样调，是为了不在两条
-			// 路径之间制造「一条有副作用、一条没有」的差异。
 			DispatchEffects(message);
 			callbacks.OnComplete?.Invoke(message);
 			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "completed");
@@ -508,6 +517,46 @@ public sealed class AgentEngine
 			SetState(AgentRunState.Error);
 			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "error", FailureCategory(exception));
 			throw;
+		}
+	}
+
+	/// <summary>
+	/// 给一条只有文本的回复补上表情与动作。
+	///
+	/// 挑选本身绝不允许影响这一轮：服务内部已经把超时与故障吞成空反应，这里再兜一层，
+	/// 是因为「挑表情失败」和「她没话说」在用户那边看起来一模一样，而前者根本不该让
+	/// 整轮失败。
+	/// </summary>
+	private async Task<ProtocolMessage> AttachReactionAsync(ProtocolMessage message, CancellationToken cancellationToken)
+	{
+		if (_replyReaction is null) return message;
+
+		try
+		{
+			PetInteractionReaction reaction = await _replyReaction.ReactAsync(
+				new ReplyReactionRequest
+				{
+					ReplyText = message.Text,
+					CurrentEmotion = _emotion?.CurrentType,
+					AvailableMotions = _motionNames(),
+					AvailableExpressions = _expressionNames(),
+				},
+				cancellationToken);
+
+			return message with
+			{
+				Emotion = reaction.Emotion,
+				Expression = reaction.Expression,
+				Action = reaction.Motion,
+			};
+		}
+		catch (OperationCanceledException)
+		{
+			throw;
+		}
+		catch (Exception)
+		{
+			return message;
 		}
 	}
 

--- a/app/desktop/Nori.Core/Agent/AgentEngine.cs
+++ b/app/desktop/Nori.Core/Agent/AgentEngine.cs
@@ -483,8 +483,28 @@ public sealed class AgentEngine
 
 		try
 		{
-			SetState(AgentRunState.Streaming);
-			ProtocolMessage message = await _luoLiCore!.RunAsync(userText, text => callbacks.OnTextChunk?.Invoke(text), runToken);
+			// 状态跟本机那条一致：入口已经是 Thinking，见到第一个增量才算开始说话。
+			//
+			// 不在这里直接置 Streaming：对端的排队闸可能让轮次等上数秒，而那条流在轮次执行
+			// 期间没有任何保活帧 —— 一上来就说「正在说」，界面会长时间停在一个不动的说话态。
+			bool streaming = false;
+			void EnterStreaming()
+			{
+				if (streaming) return;
+				streaming = true;
+				SetState(AgentRunState.Streaming);
+			}
+
+			ProtocolMessage message = await _luoLiCore!.RunAsync(
+				userText,
+				text =>
+				{
+					EnterStreaming();
+					callbacks.OnTextChunk?.Invoke(text);
+				},
+				// 排了队就明确退回 Thinking，让界面知道这一轮还没轮到。
+				() => SetState(AgentRunState.Thinking),
+				runToken);
 
 			if (message.Text.Length == 0) throw new InvalidOperationException("LuoLiCore 未产出最终回复");
 
@@ -519,6 +539,13 @@ public sealed class AgentEngine
 			throw;
 		}
 	}
+
+	/// <summary>
+	/// 清掉对端记着的这段对话。清空本地聊天记录时一起调用。
+	/// </summary>
+	/// <returns>远端确实被重置了返回 true；没启用或还没建过会话返回 false。</returns>
+	public Task<bool> ResetRemoteContextAsync(CancellationToken cancellationToken) =>
+		_luoLiCore is null ? Task.FromResult(false) : _luoLiCore.ResetAsync(cancellationToken);
 
 	/// <summary>
 	/// 给一条只有文本的回复补上表情与动作。

--- a/app/desktop/Nori.Core/Agent/AgentEngine.cs
+++ b/app/desktop/Nori.Core/Agent/AgentEngine.cs
@@ -73,6 +73,14 @@ public sealed class AgentEngine
 	private readonly AgentTraceSink _trace;
 	private readonly Func<LlmProvider, HttpClient, ILlmAdapter> _adapterFactory;
 
+	/// <summary>
+	/// 把对话交给 LuoLiCore 的那条路。为 null 或未启用时本类行为不变。
+	///
+	/// 可选而不是必填：这条路是一个可选后端，缺省时桌宠仍然完整可用，
+	/// 不该让一个没配它的实例连构造都过不去。
+	/// </summary>
+	private readonly Chat.LuoLiCore.LuoLiCoreConversation? _luoLiCore;
+
 	private readonly HttpClient _http;
 	private readonly ConfigStore _config;
 	private readonly ChatService _chat;
@@ -100,7 +108,8 @@ public sealed class AgentEngine
 		int maxToolIterations = 5,
 		AgentSessionCoordinator? sessionCoordinator = null,
 		AgentTraceSink? trace = null,
-		Func<LlmProvider, HttpClient, ILlmAdapter>? adapterFactory = null)
+		Func<LlmProvider, HttpClient, ILlmAdapter>? adapterFactory = null,
+		Chat.LuoLiCore.LuoLiCoreConversation? luoLiCore = null)
 	{
 		_http = http;
 		_config = config;
@@ -117,6 +126,7 @@ public sealed class AgentEngine
 		_sessionCoordinator = sessionCoordinator ?? new AgentSessionCoordinator();
 		_trace = trace ?? AgentTraceSink.Noop;
 		_adapterFactory = adapterFactory ?? LlmClient.CreateAdapter;
+		_luoLiCore = luoLiCore;
 	}
 
 	/// <summary>
@@ -136,6 +146,15 @@ public sealed class AgentEngine
 		void SetState(AgentRunState state) => callbacks.OnState?.Invoke(state);
 
 		SetState(AgentRunState.Thinking);
+
+		// 0. 对话是否交给 LuoLiCore。
+		//
+		// 判定放在读取 LLM 配置之前：那一段要求 BaseUrl / ApiKey / Model 三项齐全，
+		// 而只配了 LuoLiCore 的实例本来就没有这三项，放在后面会先被那条检查挡掉。
+		if (_luoLiCore is { IsActive: true })
+		{
+			return await RunViaLuoLiCoreAsync(userText, sessionId, callbacks, runToken, runClock, cancellationToken);
+		}
 
 		// 1. 读取 AI 与用户自定义人设配置 (秘密只在后端流转)
 		Stopwatch configClock = Stopwatch.StartNew();
@@ -419,6 +438,64 @@ public sealed class AgentEngine
 			// 非用户取消的超时: 转成可读错误而不是当作正常中止
 			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "error", "timeout");
 			throw new ChatException($"回复超时 ({CallTimeoutSeconds}s), 请稍后重试");
+		}
+		catch (OperationCanceledException)
+		{
+			SetState(AgentRunState.Idle);
+			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "cancelled", "cancelled");
+			throw;
+		}
+		catch (Exception exception)
+		{
+			SetState(AgentRunState.Error);
+			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "error", FailureCategory(exception));
+			throw;
+		}
+	}
+
+	/// <summary>
+	/// 把这一轮整个交给 LuoLiCore。
+	///
+	/// 不跑本机的工具循环 —— 对端一次「发消息」等于它自己跑完一整轮（含它那侧的工具、
+	/// 记忆与审批）。两套 agent 同时持有工具循环的控制权是两套记忆、两套工具注册表、
+	/// 两条审批路径打架的起点。
+	///
+	/// 收尾与本机那条保持一致：同样落库、同样回调 OnComplete、同样记 trace。区别只有
+	/// 「谁生成了这段文本」，对上层与界面是透明的。
+	/// </summary>
+	private async Task<ProtocolMessage> RunViaLuoLiCoreAsync(
+		string userText,
+		string sessionId,
+		AgentCallbacks callbacks,
+		CancellationToken runToken,
+		Stopwatch runClock,
+		CancellationToken cancellationToken)
+	{
+		void SetState(AgentRunState state) => callbacks.OnState?.Invoke(state);
+
+		try
+		{
+			SetState(AgentRunState.Streaming);
+			ProtocolMessage message = await _luoLiCore!.RunAsync(userText, text => callbacks.OnTextChunk?.Invoke(text), runToken);
+
+			if (message.Text.Length == 0) throw new InvalidOperationException("LuoLiCore 未产出最终回复");
+
+			SetState(AgentRunState.Idle);
+			_chat.SaveMessage("user", userText);
+			_chat.SaveMessage("assistant", message.Text);
+
+			// 情绪、表情、动作三项为空，DispatchEffects 会逐项跳过；表情动作由宿主另行决定
+			// （合法名随当前 Live2D 模型变化，只有宿主知道）。这里照样调，是为了不在两条
+			// 路径之间制造「一条有副作用、一条没有」的差异。
+			DispatchEffects(message);
+			callbacks.OnComplete?.Invoke(message);
+			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "completed");
+			return message;
+		}
+		catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+		{
+			WriteTrace(sessionId, "run", runClock.ElapsedMilliseconds, null, null, "error", "timeout");
+			throw new ChatException("LuoLiCore 这一轮超时了, 请稍后重试");
 		}
 		catch (OperationCanceledException)
 		{

--- a/app/desktop/Nori.Core/Agent/AgentEngine.cs
+++ b/app/desktop/Nori.Core/Agent/AgentEngine.cs
@@ -504,6 +504,17 @@ public sealed class AgentEngine
 				},
 				// 排了队就明确退回 Thinking，让界面知道这一轮还没轮到。
 				() => SetState(AgentRunState.Thinking),
+				// 对端开始跑一个工具。走本机那条路一样的两个回调，界面不必分辨这一轮是谁在执行。
+				//
+				// 只有开始没有结束：对端那条流上没有「工具跑完了」这个事件。补一个假的结束回调
+				// 会让界面显示一个它并不知道的事实；下一个增量到来时状态自然回到 Streaming，
+				// 而一直没有增量的话，状态停在 ToolExecuting 恰好是真的。
+				name =>
+				{
+					streaming = false;
+					SetState(AgentRunState.ToolExecuting);
+					callbacks.OnToolExecuting?.Invoke(name, null);
+				},
 				runToken);
 
 			if (message.Text.Length == 0) throw new InvalidOperationException("LuoLiCore 未产出最终回复");
@@ -539,6 +550,14 @@ public sealed class AgentEngine
 			throw;
 		}
 	}
+
+	/// <summary>
+	/// 对端这一侧能调哪些工具。没接这条路或未启用时返回空列表。
+	/// </summary>
+	public Task<IReadOnlyList<Chat.LuoLiCore.LuoLiCoreTool>> ListRemoteToolsAsync(CancellationToken cancellationToken) =>
+		_luoLiCore is null
+			? Task.FromResult<IReadOnlyList<Chat.LuoLiCore.LuoLiCoreTool>>([])
+			: _luoLiCore.ListToolsAsync(cancellationToken);
 
 	/// <summary>
 	/// 清掉对端记着的这段对话。清空本地聊天记录时一起调用。

--- a/app/desktop/Nori.Core/Agent/AgentEngine.cs
+++ b/app/desktop/Nori.Core/Agent/AgentEngine.cs
@@ -576,6 +576,11 @@ public sealed class AgentEngine
 		_luoLiCore is null ? Task.FromResult(false) : _luoLiCore.ResetAsync(cancellationToken);
 
 	/// <summary>
+	/// 只作废本地记着的远端会话，不联网。安全模式下清空聊天记录走这条。
+	/// </summary>
+	public void ForgetRemoteSession() => _luoLiCore?.ForgetSession();
+
+	/// <summary>
 	/// 对端那边是否有一段会话在记着东西。
 	///
 	/// 给调用方区分「没接外部后端」与「接了但这次没去重置」用 —— 后者需要提示用户，前者不用。

--- a/app/desktop/Nori.Core/Agent/ReplyReactionService.cs
+++ b/app/desktop/Nori.Core/Agent/ReplyReactionService.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using Nori.Core.Chat;
+using Nori.Core.Configuration;
+using Nori.Core.Live2D;
+
+namespace Nori.Core.Agent;
+
+/// <summary>选表情动作所需的最小上下文。</summary>
+public sealed record ReplyReactionRequest
+{
+	/// <summary>她这一轮说的话。</summary>
+	public required string ReplyText { get; init; }
+
+	public string? CurrentEmotion { get; init; }
+
+	public IReadOnlyList<string> AvailableMotions { get; init; } = [];
+
+	public IReadOnlyList<string> AvailableExpressions { get; init; } = [];
+}
+
+/// <summary>
+/// 根据一段回复文本挑一个表情与动作。
+///
+/// 为什么需要它：对话交给 LuoLiCore 之后，回来的是纯文本。合法的动作与表情名随当前
+/// Live2D 模型变化，只有宿主知道；而 LuoLiCore 的内核把用户正文里的指令当作数据处理
+/// （提示注入防护），把可用动作列表塞进消息里既不会被采纳，也违背那条防护的用意。
+/// 所以「她说什么」在远端决定，「她怎么表现」留在本地。
+///
+/// 形状照 <see cref="PetInteractionReactionService"/>：同样不带聊天历史、不带工具、
+/// 不写库、短超时，解析也复用同一个解析器。区别只在上下文是一段回复而不是一次触摸。
+///
+/// **拿不到本机 LLM 配置时返回空反应，而不是抛。** 只配了 LuoLiCore 的人本来就没有那三项，
+/// 让桌宠因为「挑不出表情」而整轮失败是本末倒置 —— 退化成没有表情，对话照常。
+/// </summary>
+public sealed class ReplyReactionService(
+	HttpClient httpClient,
+	ConfigStore config,
+	Func<LlmProvider, HttpClient, ILlmAdapter>? adapterFactory = null)
+{
+	/// <summary>比触摸那条更短：它排在回复之后，等它就是让她把已经想好的话憋着。</summary>
+	public const int TimeoutSeconds = 5;
+
+	private const string SystemPrompt = """
+		你是 Nori 桌面伴侣的表情选择器。下面给你她刚说出口的一句话。
+		只根据这句话的语气决定她此刻的表情与动作。
+		严格只输出一个 JSON 对象，不要 Markdown、解释、代码块或工具调用。
+		JSON 字段只能使用 emotion、expression、action，不要输出 text。
+		emotion 是可选的短情绪名称。
+		expression 必须从 availableExpressions 中选择；没有合适的就返回空字符串。
+		action 必须从 availableMotions 中选择；没有合适的就返回空字符串。
+		不要捏造列表之外的动作或表情。语气平淡时全部返回空字符串，不要硬凑。
+		""";
+
+	private readonly HttpClient _httpClient = httpClient;
+	private readonly ConfigStore _config = config;
+	private readonly Func<LlmProvider, HttpClient, ILlmAdapter> _adapterFactory = adapterFactory ?? LlmClient.CreateAdapter;
+
+	/// <summary>挑一个。任何失败都退化成空反应，绝不让它影响这一轮对话。</summary>
+	public async Task<PetInteractionReaction> ReactAsync(
+		ReplyReactionRequest request,
+		CancellationToken cancellationToken = default)
+	{
+		ArgumentNullException.ThrowIfNull(request);
+		if (string.IsNullOrWhiteSpace(request.ReplyText)) return new PetInteractionReaction();
+		if (request.AvailableMotions.Count == 0 && request.AvailableExpressions.Count == 0)
+		{
+			// 一个都没有就没什么可挑的，省掉这次调用。
+			return new PetInteractionReaction();
+		}
+
+		AiChatSettings chat = new AiSettingsStore(_config).Read().Chat;
+		if (!chat.IsConfigured) return new PetInteractionReaction();
+
+		try
+		{
+			ILlmAdapter adapter = _adapterFactory(chat.Provider, _httpClient);
+			using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+			timeout.CancelAfter(TimeSpan.FromSeconds(TimeoutSeconds));
+
+			string raw = await adapter.CompleteAsync(
+				chat.BaseUrl.TrimEnd('/'),
+				chat.ApiKey,
+				chat.Model,
+				SystemPrompt,
+				[new ChatMessageInput { Role = "user", Content = BuildUserPrompt(request) }],
+				timeout.Token).ConfigureAwait(false);
+
+			return Clamp(PetInteractionReactionParser.Parse(raw), request);
+		}
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+		{
+			// 整轮被取消要如实传播，不能吞。
+			throw;
+		}
+		catch (Exception)
+		{
+			// 超时、上游故障、返回的不是 JSON —— 都只是这一次没挑出表情。
+			return new PetInteractionReaction();
+		}
+	}
+
+	/// <summary>可审计的最小输入：只有这一句回复和两张候选名单，没有历史、屏幕或秘密。</summary>
+	public static string BuildUserPrompt(ReplyReactionRequest request)
+	{
+		object payload = new
+		{
+			reply = Limit(request.ReplyText, 400),
+			currentEmotion = Limit(request.CurrentEmotion, PetInteractionReactionParser.MaxEmotionLength),
+			availableMotions = request.AvailableMotions,
+			availableExpressions = request.AvailableExpressions,
+		};
+		return JsonSerializer.Serialize(payload, PetInteractionJson.Options);
+	}
+
+	/// <summary>
+	/// 把模型挑的名字夹回候选名单。
+	///
+	/// 目录过滤不是边界：提示词里写了「不要捏造」不等于它不会捏造，一个名单外的动作名
+	/// 传下去只会在渲染层被静默忽略，表现成「有时候有动作有时候没有」，很难查。
+	/// </summary>
+	private static PetInteractionReaction Clamp(PetInteractionReaction reaction, ReplyReactionRequest request) => new()
+	{
+		Text = null,
+		Emotion = Blank(reaction.Emotion) ? null : reaction.Emotion,
+		Expression = request.AvailableExpressions.Contains(reaction.Expression ?? "", StringComparer.Ordinal)
+			? reaction.Expression
+			: null,
+		Motion = request.AvailableMotions.Contains(reaction.Motion ?? "", StringComparer.Ordinal)
+			? reaction.Motion
+			: null,
+	};
+
+	private static bool Blank(string? value) => string.IsNullOrWhiteSpace(value);
+
+	private static string? Limit(string? value, int max) =>
+		value is null ? null : value.Length <= max ? value : value[..max];
+}

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
@@ -28,6 +28,18 @@ public sealed class LuoLiCoreConversation(
 		string userText,
 		Action<string>? onChunk,
 		CancellationToken cancellationToken)
+		=> await RunAsync(userText, onChunk, null, cancellationToken);
+
+	/// <inheritdoc cref="RunAsync(string, Action{string}, CancellationToken)"/>
+	/// <param name="onQueued">
+	/// 轮次进了对端的排队闸时回调一次。排队可能长达数秒而流上没有任何保活帧，不把这件事
+	/// 说出去的话，界面在这段时间里既没有文字也没有状态变化，看起来就是卡住了。
+	/// </param>
+	public async Task<ProtocolMessage> RunAsync(
+		string userText,
+		Action<string>? onChunk,
+		Action? onQueued,
+		CancellationToken cancellationToken)
 	{
 		LuoLiCoreSettings settings = _settingsStore.Read();
 		if (!settings.IsActive) throw new ChatException("LuoLiCore 未启用或配置不完整");
@@ -42,8 +54,26 @@ public sealed class LuoLiCoreConversation(
 			_settingsStore.SaveSessionId(sessionId);
 		}
 
-		string text = await StreamWithQueueRetryAsync(client, sessionId, userText, onChunk, cancellationToken);
+		string text = await StreamWithQueueRetryAsync(client, sessionId, userText, onChunk, onQueued, cancellationToken);
 		return new ProtocolMessage(text, null, null, null);
+	}
+
+	/// <summary>
+	/// 清掉对端记着的这段对话。
+	///
+	/// 本地清空聊天记录时必须一起做：对端把上下文记在自己那边，只删本地表的话她下一句仍然
+	/// 接得上前面聊过的内容，而界面上什么都没有了 —— 用户会以为清空没生效。
+	///
+	/// 还没建过会话（没有 id）就没有要清的东西，返回 false；未启用时同样不做任何事，
+	/// 免得关掉开关之后清空记录还去碰远端。
+	/// </summary>
+	public async Task<bool> ResetAsync(CancellationToken cancellationToken)
+	{
+		LuoLiCoreSettings settings = _settingsStore.Read();
+		if (!settings.IsActive || settings.SessionId.Length == 0) return false;
+
+		await _clientFactory(settings.ToOptions()).ResetSessionAsync(settings.SessionId, cancellationToken);
+		return true;
 	}
 
 	/// <summary>
@@ -58,11 +88,12 @@ public sealed class LuoLiCoreConversation(
 		string sessionId,
 		string userText,
 		Action<string>? onChunk,
+		Action? onQueued,
 		CancellationToken cancellationToken)
 	{
 		for (int attempt = 0; ; attempt++)
 		{
-			(string? text, LuoLiCoreStreamEvent failure) = await StreamOnceAsync(client, sessionId, userText, onChunk, cancellationToken);
+			(string? text, LuoLiCoreStreamEvent failure) = await StreamOnceAsync(client, sessionId, userText, onChunk, onQueued, cancellationToken);
 			if (text is not null) return text;
 
 			bool canRetry = failure.IsQueueFull && attempt < MaxQueueRetries;
@@ -84,6 +115,7 @@ public sealed class LuoLiCoreConversation(
 		string sessionId,
 		string userText,
 		Action<string>? onChunk,
+		Action? onQueued,
 		CancellationToken cancellationToken)
 	{
 		System.Text.StringBuilder buffer = new();
@@ -106,6 +138,9 @@ public sealed class LuoLiCoreConversation(
 					return (null, item);
 
 				case LuoLiCoreStreamEventKind.Queued:
+					onQueued?.Invoke();
+					break;
+
 				default:
 					break;
 			}

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
@@ -1,0 +1,117 @@
+using Nori.Core.Agent;
+
+namespace Nori.Core.Chat.LuoLiCore;
+
+/// <summary>把一轮对话交给 LuoLiCore，并把结果还原成宿主的协议消息。</summary>
+public sealed class LuoLiCoreConversation(
+	LuoLiCoreSettingsStore settingsStore,
+	Func<LuoLiCoreSdkOptions, LuoLiCoreSdkClient> clientFactory)
+{
+	private readonly LuoLiCoreSettingsStore _settingsStore = settingsStore;
+	private readonly Func<LuoLiCoreSdkOptions, LuoLiCoreSdkClient> _clientFactory = clientFactory;
+
+	/// <summary>队列满时最多重试几次。再多只是让人干等，不如把失败说出来。</summary>
+	private const int MaxQueueRetries = 2;
+
+	/// <summary>当前配置是否应当接管对话。</summary>
+	public bool IsActive => _settingsStore.Read().IsActive;
+
+	/// <summary>
+	/// 跑一轮。
+	///
+	/// 返回的协议消息**只带文本**：情绪、表情、动作三项留空，由宿主另行决定。合法的动作与
+	/// 表情名随当前 Live2D 模型变化，只有宿主知道；而 LuoLiCore 的内核明确把用户正文里的
+	/// 指令当作数据处理（提示注入防护），把可用动作列表塞进消息里既不会被采纳，也违背
+	/// 那条防护的用意。
+	/// </summary>
+	public async Task<ProtocolMessage> RunAsync(
+		string userText,
+		Action<string>? onChunk,
+		CancellationToken cancellationToken)
+	{
+		LuoLiCoreSettings settings = _settingsStore.Read();
+		if (!settings.IsActive) throw new ChatException("LuoLiCore 未启用或配置不完整");
+
+		LuoLiCoreSdkClient client = _clientFactory(settings.ToOptions());
+
+		string sessionId = settings.SessionId;
+		if (sessionId.Length == 0)
+		{
+			sessionId = await client.CreateSessionAsync("Nori Desktop", cancellationToken);
+			// 立刻写回：会话建好却没落盘的话，下一轮又会建一个新的，等价于每轮失忆。
+			_settingsStore.SaveSessionId(sessionId);
+		}
+
+		string text = await StreamWithQueueRetryAsync(client, sessionId, userText, onChunk, cancellationToken);
+		return new ProtocolMessage(text, null, null, null);
+	}
+
+	/// <summary>
+	/// 队列满时退避重试。
+	///
+	/// 队列满在流式端点上不是 HTTP 429 —— 响应头在配额判定通过、流开始建立时就锁定成了
+	/// 200，之后只能以 SSE error 事件表达。所以这里只能读到终结事件才知道被拒，退避常量
+    /// 与对端客户端一致。
+	/// </summary>
+	private static async Task<string> StreamWithQueueRetryAsync(
+		LuoLiCoreSdkClient client,
+		string sessionId,
+		string userText,
+		Action<string>? onChunk,
+		CancellationToken cancellationToken)
+	{
+		for (int attempt = 0; ; attempt++)
+		{
+			(string? text, LuoLiCoreStreamEvent failure) = await StreamOnceAsync(client, sessionId, userText, onChunk, cancellationToken);
+			if (text is not null) return text;
+
+			bool canRetry = failure.IsQueueFull && attempt < MaxQueueRetries;
+			if (!canRetry)
+			{
+				string detail = string.IsNullOrWhiteSpace(failure.ErrorMessage)
+					? failure.ErrorCode ?? "unknown"
+					: $"{failure.ErrorCode}: {failure.ErrorMessage}";
+				throw new ChatException($"LuoLiCore 这一轮没跑完, {detail}");
+			}
+
+			await Task.Delay(LuoLiCoreSdkProtocol.QueueFullBackoff, cancellationToken);
+		}
+	}
+
+	/// <summary>跑一次流。成功返回文本，失败返回那条终结用的错误事件。</summary>
+	private static async Task<(string? Text, LuoLiCoreStreamEvent Failure)> StreamOnceAsync(
+		LuoLiCoreSdkClient client,
+		string sessionId,
+		string userText,
+		Action<string>? onChunk,
+		CancellationToken cancellationToken)
+	{
+		System.Text.StringBuilder buffer = new();
+
+		await foreach (LuoLiCoreStreamEvent item in client.StreamAsync(sessionId, userText, cancellationToken))
+		{
+			switch (item.Kind)
+			{
+				case LuoLiCoreStreamEventKind.Delta:
+					buffer.Append(item.Text);
+					onChunk?.Invoke(item.Text);
+					break;
+
+				case LuoLiCoreStreamEventKind.Done:
+					// done 带的是完整文本。以它为准而不是拼接增量：两者理论上一致，
+					// 但只有它是对端认定的最终结果。
+					return (item.Text.Length > 0 ? item.Text : buffer.ToString(), default);
+
+				case LuoLiCoreStreamEventKind.Error:
+					return (null, item);
+
+				case LuoLiCoreStreamEventKind.Queued:
+				default:
+					break;
+			}
+		}
+
+		// 读取层保证流必定以 done 或 error 结束，走到这里说明那条不变量被破坏了。
+		throw new ChatException("LuoLiCore 流没有终结事件");
+	}
+}

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
@@ -17,6 +17,20 @@ public sealed class LuoLiCoreConversation(
 	public bool IsActive => _settingsStore.Read().IsActive;
 
 	/// <summary>
+	/// 对端那边是否已经有一段会话在记着东西。
+	///
+	/// 供调用方区分「没接外部后端」与「接了但这次没去重置」—— 后者需要提示用户，前者不用。
+	/// </summary>
+	public bool HasSession
+	{
+		get
+		{
+			LuoLiCoreSettings settings = _settingsStore.Read();
+			return settings.IsActive && settings.SessionId.Length > 0;
+		}
+	}
+
+	/// <summary>
 	/// 跑一轮。
 	///
 	/// 返回的协议消息**只带文本**：情绪、表情、动作三项留空，由宿主另行决定。合法的动作与

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
@@ -136,7 +136,7 @@ public sealed class LuoLiCoreConversation(
 	///
 	/// 队列满在流式端点上不是 HTTP 429 —— 响应头在配额判定通过、流开始建立时就锁定成了
 	/// 200，之后只能以 SSE error 事件表达。所以这里只能读到终结事件才知道被拒，退避常量
-    /// 与对端客户端一致。
+	/// 与对端客户端一致。
 	/// </summary>
 	private static async Task<string> StreamWithQueueRetryAsync(
 		LuoLiCoreSdkClient client,

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
@@ -107,11 +107,29 @@ public sealed class LuoLiCoreConversation(
 	public async Task<bool> ResetAsync(CancellationToken cancellationToken)
 	{
 		LuoLiCoreSettings settings = _settingsStore.Read();
-		if (!settings.IsActive || settings.SessionId.Length == 0) return false;
+		if (!settings.IsActive || settings.SessionId.Length == 0)
+		{
+			// 够不到远端的时候，至少把本地记着的会话作废。
+			//
+			// 不这么做会留下一个很隐蔽的状态：用户聊过一阵、关掉 LuoLiCore、清空聊天记录，
+			// 本地空了但会话 id 还在；等他再打开，那段「已经清掉」的上下文原样回来。
+			//
+			// 这条路径**不发任何请求** —— 关掉就该意味着不再产生外部调用。旧会话留在原服务端
+			// 不动，下次启用时新建一个。
+			ForgetSession();
+			return false;
+		}
 
 		await _clientFactory(settings.ToOptions()).ResetSessionAsync(settings.SessionId, cancellationToken);
 		return true;
 	}
+
+	/// <summary>
+	/// 只作废本地记着的会话，不联网。
+	///
+	/// 给「不该去碰远端但必须忘掉这段对话」的调用方用：安全模式下的清空聊天记录走的就是这条。
+	/// </summary>
+	public void ForgetSession() => _settingsStore.ClearSession();
 
 	/// <summary>
 	/// 队列满时退避重试。

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreConversation.cs
@@ -40,6 +40,19 @@ public sealed class LuoLiCoreConversation(
 		Action<string>? onChunk,
 		Action? onQueued,
 		CancellationToken cancellationToken)
+		=> await RunAsync(userText, onChunk, onQueued, null, cancellationToken);
+
+	/// <inheritdoc cref="RunAsync(string, Action{string}, Action, CancellationToken)"/>
+	/// <param name="onTool">
+	/// 对端开始执行一个工具时回调，参数是工具名。工具可能跑上几十秒，这段时间里流上没有文本 ——
+	/// 不把它说出去，界面就只能显示一个不动的「正在想」。
+	/// </param>
+	public async Task<ProtocolMessage> RunAsync(
+		string userText,
+		Action<string>? onChunk,
+		Action? onQueued,
+		Action<string>? onTool,
+		CancellationToken cancellationToken)
 	{
 		LuoLiCoreSettings settings = _settingsStore.Read();
 		if (!settings.IsActive) throw new ChatException("LuoLiCore 未启用或配置不完整");
@@ -54,8 +67,18 @@ public sealed class LuoLiCoreConversation(
 			_settingsStore.SaveSessionId(sessionId);
 		}
 
-		string text = await StreamWithQueueRetryAsync(client, sessionId, userText, onChunk, onQueued, cancellationToken);
+		string text = await StreamWithQueueRetryAsync(client, sessionId, userText, onChunk, onQueued, onTool, cancellationToken);
 		return new ProtocolMessage(text, null, null, null);
+	}
+
+	/// <summary>
+	/// 本来源能调哪些工具。未启用时返回空列表，不去碰远端。
+	/// </summary>
+	public async Task<IReadOnlyList<LuoLiCoreTool>> ListToolsAsync(CancellationToken cancellationToken)
+	{
+		LuoLiCoreSettings settings = _settingsStore.Read();
+		if (!settings.IsActive) return [];
+		return await _clientFactory(settings.ToOptions()).ListToolsAsync(cancellationToken);
 	}
 
 	/// <summary>
@@ -89,11 +112,12 @@ public sealed class LuoLiCoreConversation(
 		string userText,
 		Action<string>? onChunk,
 		Action? onQueued,
+		Action<string>? onTool,
 		CancellationToken cancellationToken)
 	{
 		for (int attempt = 0; ; attempt++)
 		{
-			(string? text, LuoLiCoreStreamEvent failure) = await StreamOnceAsync(client, sessionId, userText, onChunk, onQueued, cancellationToken);
+			(string? text, LuoLiCoreStreamEvent failure) = await StreamOnceAsync(client, sessionId, userText, onChunk, onQueued, onTool, cancellationToken);
 			if (text is not null) return text;
 
 			bool canRetry = failure.IsQueueFull && attempt < MaxQueueRetries;
@@ -116,6 +140,7 @@ public sealed class LuoLiCoreConversation(
 		string userText,
 		Action<string>? onChunk,
 		Action? onQueued,
+		Action<string>? onTool,
 		CancellationToken cancellationToken)
 	{
 		System.Text.StringBuilder buffer = new();
@@ -139,6 +164,10 @@ public sealed class LuoLiCoreConversation(
 
 				case LuoLiCoreStreamEventKind.Queued:
 					onQueued?.Invoke();
+					break;
+
+				case LuoLiCoreStreamEventKind.Tool:
+					onTool?.Invoke(item.Text);
 					break;
 
 				default:

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkClient.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkClient.cs
@@ -1,0 +1,148 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+
+namespace Nori.Core.Chat.LuoLiCore;
+
+/// <summary>LuoLiCore 接入所需的连接参数。</summary>
+public sealed record LuoLiCoreSdkOptions
+{
+	/// <summary>服务根地址，例如 <c>http://127.0.0.1:3000</c>。路径 <c>/sdk/v1</c> 由本类补。</summary>
+	public required string BaseUrl { get; init; }
+
+	/// <summary>`sk-` 开头的来源密钥。与 WebUI 的 cookie 通道互斥，一把密钥对应一个来源。</summary>
+	public required string ApiKey { get; init; }
+
+	/// <summary>
+	/// 发起人标识。落库前服务端会加 <c>&lt;sourceId&gt;:</c> 前缀，所以这里只要在本来源内唯一。
+	///
+	/// 桌面端是单用户的，固定一个常量即可；换成随机值会让记忆按人分叉。
+	/// </summary>
+	public string EndUserId { get; init; } = "desktop";
+
+	/// <summary>模型别名。留空则用服务端会话上的默认值。</summary>
+	public string? ModelAlias { get; init; }
+}
+
+/// <summary>
+/// LuoLiCore <c>/sdk/v1</c> 的最小客户端。
+///
+/// 只做本集成用得上的三件事：建会话、发消息（流式与非流式）。会话的增删查改留给
+/// 设置页那条路，不在对话链路上。
+///
+/// **这不是 IChatClient。** 对端一次「发消息」等于它自己跑完一整轮（含它那侧的工具循环），
+/// 语义是「把这一轮交出去」，不是「给我一次补全」。硬塞进 IChatClient 会让上层以为自己
+/// 还持有工具循环的控制权 —— 那正是两套 agent 打架的起点。上层怎么用见调用方。
+/// </summary>
+public sealed class LuoLiCoreSdkClient(HttpClient httpClient, LuoLiCoreSdkOptions options)
+{
+	private readonly HttpClient _httpClient = httpClient;
+	private readonly LuoLiCoreSdkOptions _options = options;
+
+	private string Root => _options.BaseUrl.TrimEnd('/') + "/sdk/v1";
+
+	private HttpRequestMessage NewRequest(HttpMethod method, string path)
+	{
+		HttpRequestMessage request = new(method, Root + path);
+		request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.ApiKey);
+		return request;
+	}
+
+	/// <summary>建一个会话。<c>outputFormat</c> 建后不可改，所以在这里定死。</summary>
+	public async Task<string> CreateSessionAsync(string? label = null, CancellationToken cancellationToken = default)
+	{
+		using HttpRequestMessage request = NewRequest(HttpMethod.Post, "/sessions");
+		request.Content = JsonContent.Create(
+			// plain 而不是 markdown：这条流最终要念出来并驱动口型，
+			// 星号和井号会被 TTS 读成字符。
+			new SdkCreateSessionInput(_options.ModelAlias, "plain", label),
+			options: LuoLiCoreSdkProtocol.Json);
+
+		using HttpResponseMessage response = await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
+		await ThrowIfFailedAsync(response, cancellationToken);
+
+		SdkSession? session = await response.Content.ReadFromJsonAsync<SdkSession>(
+			LuoLiCoreSdkProtocol.Json, cancellationToken);
+		if (session is null || string.IsNullOrWhiteSpace(session.Id)) throw new ChatException("SDK 建会话成功但没有返回 id");
+		return session.Id;
+	}
+
+	/// <summary>
+	/// 发一条消息并流式读回。
+	///
+	/// 取消时主动断连 —— 对端把客户端断连映射到轮次取消，所以这里不需要另外调取消接口。
+	/// </summary>
+	public async IAsyncEnumerable<LuoLiCoreStreamEvent> StreamAsync(
+		string sessionId,
+		string text,
+		[EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		using HttpRequestMessage request = NewRequest(HttpMethod.Post, $"/sessions/{Uri.EscapeDataString(sessionId)}/messages/stream");
+		request.Content = JsonContent.Create(
+			new SdkSendMessageInput(_options.EndUserId, text, _options.ModelAlias),
+			options: LuoLiCoreSdkProtocol.Json);
+		request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+		// 流在轮次执行期间没有保活帧，用默认超时会把正常的长轮次当成断流掐掉。
+		using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeout.CancelAfter(LuoLiCoreSdkProtocol.StreamReadTimeout);
+
+		using HttpResponseMessage response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+
+		// 配额拒绝发生在响应头写出之前，所以这一支仍是普通 HTTP 错误。
+		// 队列满则不然：它已经是 200 + SSE，要等 error 事件才看得到。
+		await ThrowIfFailedAsync(response, timeout.Token);
+
+		await using Stream stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+		using StreamReader reader = new(stream, Encoding.UTF8);
+
+		await foreach (LuoLiCoreStreamEvent item in LuoLiCoreSseReader.ReadAsync(reader, timeout.Token))
+		{
+			yield return item;
+		}
+	}
+
+	private async Task<HttpResponseMessage> SendAsync(
+		HttpRequestMessage request,
+		HttpCompletionOption completion,
+		CancellationToken cancellationToken)
+	{
+		try
+		{
+			return await _httpClient.SendAsync(request, completion, cancellationToken);
+		}
+		catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException && !cancellationToken.IsCancellationRequested)
+		{
+			throw new ChatException($"连不上 LuoLiCore: {exception.Message}", exception);
+		}
+	}
+
+	/// <summary>
+	/// 失败响应统一走错误信封。
+	///
+	/// HTTP 错误体与 SSE <c>error</c> 事件同形，所以两条路径解出来是同一个类型；解不出来时
+	/// 退回状态码，不把一段 HTML 错误页当成消息抛给上层。
+	/// </summary>
+	private static async Task ThrowIfFailedAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+	{
+		if (response.IsSuccessStatusCode) return;
+
+		string body = string.Empty;
+		try { body = await response.Content.ReadAsStringAsync(cancellationToken); }
+		catch (Exception exception) when (exception is not OperationCanceledException) { /* 读不到就只报状态码 */ }
+
+		SdkError? error = null;
+		if (body.Length > 0)
+		{
+			try { error = JsonSerializer.Deserialize<SdkError>(body, LuoLiCoreSdkProtocol.Json); }
+			catch (JsonException) { /* 不是信封 */ }
+		}
+
+		string detail = error is not null
+			? $"{error.Code}{(string.IsNullOrWhiteSpace(error.Message) ? "" : ": " + error.Message)}"
+			: body.Length > 0 ? body[..Math.Min(body.Length, 200)] : "无响应体";
+		throw new ChatException($"LuoLiCore 返回 HTTP {(int)response.StatusCode}, {detail}");
+	}
+}

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkClient.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkClient.cs
@@ -89,6 +89,34 @@ public sealed class LuoLiCoreSdkClient(HttpClient httpClient, LuoLiCoreSdkOption
 	}
 
 	/// <summary>
+	/// 本来源能调哪些工具。
+	///
+	/// 返回的是**上界**：对端按角色、运维禁用与来源白名单算出来的静态集合，不含轮次内才成立
+	/// 的收窄（连续失败后的停用、skill 收窄、目录截断）。当作「可能可用」看，不是「这一次调用
+	/// 一定成功」。
+	///
+	/// 对端没有这个端点时（版本较旧）返回空列表而不是抛：这条信息是锦上添花，拿不到不该让
+	/// 设置页或启动流程失败。
+	/// </summary>
+	public async Task<IReadOnlyList<LuoLiCoreTool>> ListToolsAsync(CancellationToken cancellationToken = default)
+	{
+		using HttpRequestMessage request = NewRequest(HttpMethod.Get, "/tools");
+		using HttpResponseMessage response = await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
+		if (!response.IsSuccessStatusCode) return [];
+
+		SdkToolListResponse? listed = await response.Content.ReadFromJsonAsync<SdkToolListResponse>(
+			LuoLiCoreSdkProtocol.Json, cancellationToken);
+		return listed?.Tools is null
+			? []
+			: [.. listed.Tools
+				.Where(tool => !string.IsNullOrWhiteSpace(tool.Name))
+				.Select(tool => new LuoLiCoreTool(
+					tool.Name,
+					tool.Description ?? string.Empty,
+					tool.Approval is "always" or "conditional"))];
+	}
+
+	/// <summary>
 	/// 发一条消息并流式读回。
 	///
 	/// 取消时主动断连 —— 对端把客户端断连映射到轮次取消，所以这里不需要另外调取消接口。
@@ -100,7 +128,13 @@ public sealed class LuoLiCoreSdkClient(HttpClient httpClient, LuoLiCoreSdkOption
 	{
 		using HttpRequestMessage request = NewRequest(HttpMethod.Post, $"/sessions/{Uri.EscapeDataString(sessionId)}/messages/stream");
 		request.Content = JsonContent.Create(
-			new SdkSendMessageInput(_options.EndUserId, text, _options.ModelAlias),
+			// 要工具事件。对端缺省不发，这一项是加法：发给还不支持它的服务端会被忽略，
+			// 行为退回到只有 delta / done / error / queued 四种。
+			new SdkSendMessageInput(
+				_options.EndUserId,
+				text,
+				_options.ModelAlias,
+				[LuoLiCoreSdkProtocol.OptInTool]),
 			options: LuoLiCoreSdkProtocol.Json);
 		request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
 
@@ -165,3 +199,11 @@ public sealed class LuoLiCoreSdkClient(HttpClient httpClient, LuoLiCoreSdkOption
 		throw new ChatException($"LuoLiCore 返回 HTTP {(int)response.StatusCode}, {detail}");
 	}
 }
+
+/// <summary>
+/// 对端的一件工具。
+///
+/// <c>NeedsApproval</c> 摊平自对端的三档 approval：SDK 会话没有人工审批通道，凡是需要审批的
+/// 调用都会被直接拒绝，所以对本地只有「会不会被拒」这一个区别，不必把三档原样搬过来。
+/// </summary>
+public sealed record LuoLiCoreTool(string Name, string Description, bool NeedsApproval);

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkClient.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkClient.cs
@@ -29,8 +29,8 @@ public sealed record LuoLiCoreSdkOptions
 /// <summary>
 /// LuoLiCore <c>/sdk/v1</c> 的最小客户端。
 ///
-/// 只做本集成用得上的三件事：建会话、发消息（流式与非流式）。会话的增删查改留给
-/// 设置页那条路，不在对话链路上。
+/// 只做本集成用得上的三件事：建会话、发消息、重置会话上下文。会话的列举、改名与彻底
+/// 删除留给设置页那条路，不在对话链路上。
 ///
 /// **这不是 IChatClient。** 对端一次「发消息」等于它自己跑完一整轮（含它那侧的工具循环），
 /// 语义是「把这一轮交出去」，不是「给我一次补全」。硬塞进 IChatClient 会让上层以为自己
@@ -67,6 +67,25 @@ public sealed class LuoLiCoreSdkClient(HttpClient httpClient, LuoLiCoreSdkOption
 			LuoLiCoreSdkProtocol.Json, cancellationToken);
 		if (session is null || string.IsNullOrWhiteSpace(session.Id)) throw new ChatException("SDK 建会话成功但没有返回 id");
 		return session.Id;
+	}
+
+	/// <summary>
+	/// 重置会话上下文。
+	///
+	/// 对端是 git 式的上下文引擎，reset 落一条新提交把工作上下文清空，历史提交仍在 —— 所以
+	/// 这是「她不再记得之前聊过什么」，不是「删掉这个会话」。会话 id 与它挂着的长期记忆都保留，
+	/// 下一轮接着用同一个会话。
+	/// </summary>
+	/// <returns>那条重置提交的 id。</returns>
+	public async Task<string> ResetSessionAsync(string sessionId, CancellationToken cancellationToken = default)
+	{
+		using HttpRequestMessage request = NewRequest(HttpMethod.Post, $"/sessions/{Uri.EscapeDataString(sessionId)}/reset");
+		using HttpResponseMessage response = await SendAsync(request, HttpCompletionOption.ResponseContentRead, cancellationToken);
+		await ThrowIfFailedAsync(response, cancellationToken);
+
+		SdkResetResult? result = await response.Content.ReadFromJsonAsync<SdkResetResult>(
+			LuoLiCoreSdkProtocol.Json, cancellationToken);
+		return result?.CommitId ?? string.Empty;
 	}
 
 	/// <summary>

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkProtocol.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkProtocol.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Nori.Core.Chat.LuoLiCore;
+
+/// <summary>
+/// LuoLiCore <c>/sdk/v1</c> 的线上形状。
+///
+/// 契约唯一来源是对端的 <c>packages/sdk-client/src/schema.ts</c>（zod），这里只镜像本
+/// 集成用到的那几个形状，不复刻整套十端点。字段名与 zod 逐一对齐；对端新增字段时
+/// 反序列化会忽略未知键，不会因为对端先行升级而整条失败。
+/// </summary>
+internal static class LuoLiCoreSdkProtocol
+{
+	/// <summary>SSE 事件名。顺序不变量见 <see cref="LuoLiCoreSseReader"/>。</summary>
+	internal const string EventQueued = "queued";
+	internal const string EventDelta = "delta";
+	internal const string EventDone = "done";
+	internal const string EventError = "error";
+
+	/// <summary>
+	/// 队列满在流式端点上不表现为 HTTP 429。
+	///
+	/// 响应头在配额判定通过、流开始建立时就锁定成了 200 + text/event-stream，之后再发现
+	/// 队列满已经改不了状态码，只能以 SSE <c>error</c> 事件表达。对端文档把这一点记为架构
+	/// 限制而非缺陷，并规定客户端固定按 5 秒退避。
+	/// </summary>
+	internal const string CodeTurnQueueFull = "turn_queue_full";
+
+	/// <summary>队列满时的固定退避。对端 <c>@luoli/sdk-client</c> 内置同一个常量。</summary>
+	internal static readonly TimeSpan QueueFullBackoff = TimeSpan.FromSeconds(5);
+
+	/// <summary>
+	/// 读超时必须给到对端的轮次超时之上。
+	///
+	/// 流在轮次执行期间**没有任何保活帧**（对端文档：「无心跳帧」）。按 HttpClient 默认的
+	/// 100 秒超时去读，一个跑满 10 分钟的轮次会在客户端这边被当成传输层中断掐掉，而且读到的
+	/// 不是 <c>error</c> 事件，是一次没有原因的断流。对端默认 <c>turnTimeoutMs = 600s</c>。
+	/// </summary>
+	internal static readonly TimeSpan StreamReadTimeout = TimeSpan.FromSeconds(660);
+
+	internal static readonly JsonSerializerOptions Json = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	};
+}
+
+/// <summary>建会话入参。三项都可选；<c>outputFormat</c> 建会话后不可改。</summary>
+internal sealed record SdkCreateSessionInput(
+	[property: JsonPropertyName("modelAlias")] string? ModelAlias,
+	[property: JsonPropertyName("outputFormat")] string? OutputFormat,
+	[property: JsonPropertyName("label")] string? Label);
+
+/// <summary>会话。</summary>
+internal sealed record SdkSession(
+	[property: JsonPropertyName("id")] string Id,
+	[property: JsonPropertyName("label")] string? Label,
+	[property: JsonPropertyName("modelAlias")] string? ModelAlias,
+	[property: JsonPropertyName("outputFormat")] string? OutputFormat,
+	[property: JsonPropertyName("createdAt")] long CreatedAt,
+	[property: JsonPropertyName("deletedAt")] long? DeletedAt);
+
+/// <summary>发消息入参。<c>endUserId</c> 落库前由服务端加 <c>&lt;sourceId&gt;:</c> 前缀。</summary>
+internal sealed record SdkSendMessageInput(
+	[property: JsonPropertyName("endUserId")] string EndUserId,
+	[property: JsonPropertyName("text")] string Text,
+	[property: JsonPropertyName("modelAlias")] string? ModelAlias);
+
+/// <summary>用量。</summary>
+internal sealed record SdkUsage(
+	[property: JsonPropertyName("inputTokens")] int? InputTokens,
+	[property: JsonPropertyName("outputTokens")] int? OutputTokens);
+
+/// <summary>
+/// 统一错误信封。
+///
+/// 十个错误码共用这一个形状，HTTP 错误体与 SSE <c>error</c> 事件同形 —— 所以两条路径
+/// 可以用同一个类型解析，不必各写一份。
+/// </summary>
+internal sealed record SdkError(
+	[property: JsonPropertyName("code")] string Code,
+	[property: JsonPropertyName("message")] string? Message,
+	[property: JsonPropertyName("retryable")] bool Retryable);
+
+/// <summary>SSE <c>delta</c> 的载荷。</summary>
+internal sealed record SdkDelta(
+	[property: JsonPropertyName("text")] string Text);
+
+/// <summary>
+/// SSE <c>done</c> 的载荷。
+///
+/// **不含 turnId** —— 与非流式端点的响应不同，后者含。需要 turnId 时要经
+/// <c>GET /sdk/v1/sessions/:id/commits</c> 反查最近一条 <c>kind='turn'</c> 的提交。
+/// </summary>
+internal sealed record SdkDone(
+	[property: JsonPropertyName("text")] string Text,
+	[property: JsonPropertyName("usage")] SdkUsage? Usage);

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkProtocol.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkProtocol.cs
@@ -61,6 +61,11 @@ internal sealed record SdkSession(
 	[property: JsonPropertyName("createdAt")] long CreatedAt,
 	[property: JsonPropertyName("deletedAt")] long? DeletedAt);
 
+/// <summary>重置会话上下文的结果。<c>commitId</c> 是那条重置提交。</summary>
+internal sealed record SdkResetResult(
+	[property: JsonPropertyName("ok")] bool Ok,
+	[property: JsonPropertyName("commitId")] string? CommitId);
+
 /// <summary>发消息入参。<c>endUserId</c> 落库前由服务端加 <c>&lt;sourceId&gt;:</c> 前缀。</summary>
 internal sealed record SdkSendMessageInput(
 	[property: JsonPropertyName("endUserId")] string EndUserId,

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkProtocol.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSdkProtocol.cs
@@ -19,6 +19,17 @@ internal static class LuoLiCoreSdkProtocol
 	internal const string EventError = "error";
 
 	/// <summary>
+	/// 工具活动事件。**只有请求里显式要了才会收到**（见 <see cref="SdkSendMessageInput"/>）。
+	///
+	/// 它不参与顺序不变量：可以出现在任意两个 delta 之间，也可以出现在一个没有任何 delta 的
+	/// 轮次里，但仍然排在 done / error 之前。
+	/// </summary>
+	internal const string EventTool = "tool";
+
+	/// <summary>请求 <c>tool</c> 事件时填进 <c>events</c> 的取值。</summary>
+	internal const string OptInTool = "tool";
+
+	/// <summary>
 	/// 队列满在流式端点上不表现为 HTTP 429。
 	///
 	/// 响应头在配额判定通过、流开始建立时就锁定成了 200 + text/event-stream，之后再发现
@@ -66,11 +77,36 @@ internal sealed record SdkResetResult(
 	[property: JsonPropertyName("ok")] bool Ok,
 	[property: JsonPropertyName("commitId")] string? CommitId);
 
-/// <summary>发消息入参。<c>endUserId</c> 落库前由服务端加 <c>&lt;sourceId&gt;:</c> 前缀。</summary>
+/// <summary>
+/// 发消息入参。<c>endUserId</c> 落库前由服务端加 <c>&lt;sourceId&gt;:</c> 前缀。
+///
+/// <c>events</c> 是加法式的开关：不填就只收到 delta / done / error / queued 四种，与对端
+/// 未支持工具事件时的行为一致。因此这个字段发给旧版服务端也是安全的 —— 它会被 zod 的
+/// 宽松解析忽略（多余键不报错），行为退化成没有工具事件。
+/// </summary>
 internal sealed record SdkSendMessageInput(
 	[property: JsonPropertyName("endUserId")] string EndUserId,
 	[property: JsonPropertyName("text")] string Text,
-	[property: JsonPropertyName("modelAlias")] string? ModelAlias);
+	[property: JsonPropertyName("modelAlias")] string? ModelAlias,
+	[property: JsonPropertyName("events")] IReadOnlyList<string>? Events = null);
+
+/// <summary>SSE <c>tool</c> 的载荷。只有名字：入参与结果不出网。</summary>
+internal sealed record SdkStreamTool(
+	[property: JsonPropertyName("name")] string Name);
+
+/// <summary>
+/// <c>GET /sdk/v1/tools</c> 的一行。
+///
+/// <c>approval</c> 是 never / conditional / always 三档。SDK 会话没有人工审批通道，需要
+/// 审批的调用会直接被拒 —— 这一项让界面能提前把它标出来，而不是等一次失败。
+/// </summary>
+internal sealed record SdkToolInfo(
+	[property: JsonPropertyName("name")] string Name,
+	[property: JsonPropertyName("description")] string? Description,
+	[property: JsonPropertyName("approval")] string? Approval);
+
+internal sealed record SdkToolListResponse(
+	[property: JsonPropertyName("tools")] IReadOnlyList<SdkToolInfo>? Tools);
 
 /// <summary>用量。</summary>
 internal sealed record SdkUsage(

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
@@ -142,6 +142,24 @@ public sealed class LuoLiCoreSettingsStore(ConfigStore config, Func<string, stri
 	}
 
 	/// <summary>
+	/// 把本地记着的会话作废：id 与身份指纹一起删。
+	///
+	/// 用在「该忘掉这段对话、但不该（或不能）去碰远端」的时候 —— 用户关掉了 LuoLiCore，
+	/// 或者正处在安全模式。**不发任何请求。**
+	///
+	/// 两项必须一起删。只删 id 的话指纹留在库里，下次建了新会话再写回时两者短暂不一致；
+	/// 只删指纹更糟 —— 旧 id 会被当成「同一台服务端的会话」继续用。
+	///
+	/// 旧的那条会话留在原服务端不动：删它需要联网，而这条路径的前提正是不联网。它在对端
+	/// 会按自己的生命周期被清理。
+	/// </summary>
+	public void ClearSession()
+	{
+		_config.Delete(KeySessionId);
+		_config.Delete(KeySessionOwner);
+	}
+
+	/// <summary>
 	/// 首次对话建好会话后写回，下次接着用同一个。
 	///
 	/// 同时记下它属于哪台服务端、哪把密钥（指纹）。没有这一项的话，运维换了地址或换了密钥

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
@@ -48,7 +48,12 @@ public sealed record LuoLiCoreSettings
 }
 
 /// <summary>LuoLiCore 配置的读写。</summary>
-public sealed class LuoLiCoreSettingsStore(ConfigStore config)
+/// <param name="config">配置库。</param>
+/// <param name="environment">
+/// 环境变量读取入口。默认读进程环境；测试注入它是为了不去改进程级状态 —— 那会串到
+/// 并行跑的其他测试里，表现成偶发失败。
+/// </param>
+public sealed class LuoLiCoreSettingsStore(ConfigStore config, Func<string, string?>? environment = null)
 {
 	public const string KeyEnabled = "luolicore_enabled";
 	public const string KeyBaseUrl = "luolicore_base_url";
@@ -56,16 +61,53 @@ public sealed class LuoLiCoreSettingsStore(ConfigStore config)
 	public const string KeySessionId = "luolicore_session_id";
 	public const string KeyModelAlias = "luolicore_model_alias";
 
-	private readonly ConfigStore _config = config;
+	/// <summary>
+	/// 环境变量兜底。
+	///
+	/// 原生 UI 迁移期间还没有填这几项的地方，而密钥本来就该走环境变量而不是写进文件。
+	/// **配置优先、环境变量兜底**：将来设置页写了值就以设置页为准，不会出现「界面上改了
+	/// 却不生效」这种查起来很贵的错位。
+	/// </summary>
+	public const string EnvEnabled = "NORI_LUOLICORE_ENABLED";
+	public const string EnvBaseUrl = "NORI_LUOLICORE_BASE_URL";
+	public const string EnvApiKey = "NORI_LUOLICORE_API_KEY";
+	public const string EnvSessionId = "NORI_LUOLICORE_SESSION_ID";
+	public const string EnvModelAlias = "NORI_LUOLICORE_MODEL_ALIAS";
 
-	public LuoLiCoreSettings Read() => new()
+	private readonly ConfigStore _config = config;
+	private readonly Func<string, string?> _environment = environment ?? Environment.GetEnvironmentVariable;
+
+	private string Env(string name) => (_environment(name) ?? string.Empty).Trim();
+
+	/// <summary>配置里有就用配置的；没有才看环境变量。</summary>
+	private string ReadOr(string key, string envName)
 	{
-		Enabled = _config.GetBoolOr(KeyEnabled, false),
-		BaseUrl = _config.GetStringOr(KeyBaseUrl, "").Trim().TrimEnd('/'),
-		ApiKey = _config.GetStringOr(KeyApiKey, ""),
-		SessionId = _config.GetStringOr(KeySessionId, "").Trim(),
-		ModelAlias = _config.GetStringOr(KeyModelAlias, "").Trim(),
-	};
+		string stored = _config.GetStringOr(key, "").Trim();
+		return stored.Length > 0 ? stored : Env(envName);
+	}
+
+	public LuoLiCoreSettings Read()
+	{
+		// 开关没显式配过时，环境变量给了地址与密钥就视为打开 —— 迁移期没有界面可点，
+		// 要求再单独设一个开关只会让人以为没生效。
+		string envEnabled = Env(EnvEnabled);
+		string baseUrl = ReadOr(KeyBaseUrl, EnvBaseUrl).TrimEnd('/');
+		string apiKey = ReadOr(KeyApiKey, EnvApiKey);
+		bool enabled = _config.GetBoolOr(
+			KeyEnabled,
+			envEnabled.Length > 0
+				? envEnabled is "1" or "true" or "TRUE" or "True"
+				: baseUrl.Length > 0 && apiKey.Length > 0);
+
+		return new LuoLiCoreSettings
+		{
+			Enabled = enabled,
+			BaseUrl = baseUrl,
+			ApiKey = apiKey,
+			SessionId = ReadOr(KeySessionId, EnvSessionId),
+			ModelAlias = ReadOr(KeyModelAlias, EnvModelAlias),
+		};
+	}
 
 	/// <summary>首次对话建好会话后写回，下次接着用同一个。</summary>
 	public void SaveSessionId(string sessionId)

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
@@ -1,0 +1,77 @@
+using Nori.Core.Configuration;
+
+namespace Nori.Core.Chat.LuoLiCore;
+
+/// <summary>
+/// 把对话交给 LuoLiCore 的配置。
+///
+/// 单开一节而不是往 <see cref="AiChatSettings"/> 里加字段：那条记录被设置页、校验、
+/// 连接测试与多处测试共用，为一个可选后端改它的形状会波及一大片；而这一节和
+/// <c>AiEmbeddingSettings</c> 一样，是与聊天配置并列的独立运行时配置。
+///
+/// 未启用时本节完全不参与对话链路，桌宠照旧走本机 agent。
+/// </summary>
+public sealed record LuoLiCoreSettings
+{
+	/// <summary>是否把对话交给 LuoLiCore。默认关闭。</summary>
+	public required bool Enabled { get; init; }
+
+	/// <summary>服务根地址，例如 <c>http://127.0.0.1:3000</c>。</summary>
+	public required string BaseUrl { get; init; }
+
+	/// <summary>`sk-` 开头的来源密钥。</summary>
+	public required string ApiKey { get; init; }
+
+	/// <summary>
+	/// 会话 id。留空表示还没建过，首次对话时建一个并写回。
+	///
+	/// 固定一个会话而不是每次新建：记忆与上下文都挂在会话上，每次新建等于她每次都失忆。
+	/// </summary>
+	public required string SessionId { get; init; }
+
+	/// <summary>模型别名。留空用服务端会话上的默认值。</summary>
+	public required string ModelAlias { get; init; }
+
+	/// <summary>配置齐了才可能启用。地址与密钥缺一不可，会话 id 可以为空（首次会建）。</summary>
+	public bool IsConfigured => BaseUrl.Length > 0 && ApiKey.Length > 0;
+
+	/// <summary>真正生效的判据。设置页可以先填一半，不该因此就把对话切过去。</summary>
+	public bool IsActive => Enabled && IsConfigured;
+
+	/// <summary>转成客户端参数。</summary>
+	public LuoLiCoreSdkOptions ToOptions() => new()
+	{
+		BaseUrl = BaseUrl,
+		ApiKey = ApiKey,
+		ModelAlias = ModelAlias.Length == 0 ? null : ModelAlias,
+	};
+}
+
+/// <summary>LuoLiCore 配置的读写。</summary>
+public sealed class LuoLiCoreSettingsStore(ConfigStore config)
+{
+	public const string KeyEnabled = "luolicore_enabled";
+	public const string KeyBaseUrl = "luolicore_base_url";
+	public const string KeyApiKey = "luolicore_api_key";
+	public const string KeySessionId = "luolicore_session_id";
+	public const string KeyModelAlias = "luolicore_model_alias";
+
+	private readonly ConfigStore _config = config;
+
+	public LuoLiCoreSettings Read() => new()
+	{
+		Enabled = _config.GetBoolOr(KeyEnabled, false),
+		BaseUrl = _config.GetStringOr(KeyBaseUrl, "").Trim().TrimEnd('/'),
+		ApiKey = _config.GetStringOr(KeyApiKey, ""),
+		SessionId = _config.GetStringOr(KeySessionId, "").Trim(),
+		ModelAlias = _config.GetStringOr(KeyModelAlias, "").Trim(),
+	};
+
+	/// <summary>首次对话建好会话后写回，下次接着用同一个。</summary>
+	public void SaveSessionId(string sessionId)
+	{
+		string trimmed = (sessionId ?? string.Empty).Trim();
+		if (trimmed.Length == 0) return;
+		_config.Set(KeySessionId, new ConfigValue.Text(trimmed));
+	}
+}

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSettings.cs
@@ -62,6 +62,14 @@ public sealed class LuoLiCoreSettingsStore(ConfigStore config, Func<string, stri
 	public const string KeyModelAlias = "luolicore_model_alias";
 
 	/// <summary>
+	/// 会话 id 是跟着哪一台服务端、哪一把密钥建出来的。
+	///
+	/// 存的是指纹（SHA-256 十六进制）而不是原值：这一列不敏感、不加密，把密钥原样写进去
+	/// 等于绕开 `_api_key` 那套加密存储。
+	/// </summary>
+	public const string KeySessionOwner = "luolicore_session_owner";
+
+	/// <summary>
 	/// 环境变量兜底。
 	///
 	/// 原生 UI 迁移期间还没有填这几项的地方，而密钥本来就该走环境变量而不是写进文件。
@@ -86,6 +94,18 @@ public sealed class LuoLiCoreSettingsStore(ConfigStore config, Func<string, stri
 		return stored.Length > 0 ? stored : Env(envName);
 	}
 
+	/// <summary>
+	/// 一台服务端 + 一把密钥的身份指纹。换了任意一项，之前建的会话就不再属于这里。
+	/// </summary>
+	private static string Fingerprint(string baseUrl, string apiKey)
+	{
+		if (baseUrl.Length == 0 || apiKey.Length == 0) return string.Empty;
+		// 换行分隔，免得 ("http://a", "b") 与 ("http://ab", "") 这类拼接出同一个串。
+		byte[] digest = System.Security.Cryptography.SHA256.HashData(
+			System.Text.Encoding.UTF8.GetBytes(baseUrl + "\n" + apiKey));
+		return Convert.ToHexString(digest);
+	}
+
 	public LuoLiCoreSettings Read()
 	{
 		// 开关没显式配过时，环境变量给了地址与密钥就视为打开 —— 迁移期没有界面可点，
@@ -99,21 +119,43 @@ public sealed class LuoLiCoreSettingsStore(ConfigStore config, Func<string, stri
 				? envEnabled is "1" or "true" or "TRUE" or "True"
 				: baseUrl.Length > 0 && apiKey.Length > 0);
 
+		// 会话 id 绑在建它的那台服务端与那把密钥上。
+		//
+		// 换了 BaseUrl 或换了密钥之后，存量的会话 id 属于**另一个**服务端 —— 继续拿它发消息
+		// 只会一直 404，而且这个失败看起来像「服务端坏了」，不像「你改了配置」。指纹对不上
+		// 就当作没有会话，下一轮自然新建一个，旧的那条留在原服务端上不动。
+		//
+		// 环境变量直接给了会话 id 的情形不受此限：那是运维显式指定的，他知道自己在干什么。
+		string storedSession = _config.GetStringOr(KeySessionId, "").Trim();
+		string owner = _config.GetStringOr(KeySessionOwner, "").Trim();
+		string current = Fingerprint(baseUrl, apiKey);
+		if (storedSession.Length > 0 && owner.Length > 0 && owner != current) storedSession = "";
+
 		return new LuoLiCoreSettings
 		{
 			Enabled = enabled,
 			BaseUrl = baseUrl,
 			ApiKey = apiKey,
-			SessionId = ReadOr(KeySessionId, EnvSessionId),
+			SessionId = storedSession.Length > 0 ? storedSession : Env(EnvSessionId),
 			ModelAlias = ReadOr(KeyModelAlias, EnvModelAlias),
 		};
 	}
 
-	/// <summary>首次对话建好会话后写回，下次接着用同一个。</summary>
+	/// <summary>
+	/// 首次对话建好会话后写回，下次接着用同一个。
+	///
+	/// 同时记下它属于哪台服务端、哪把密钥（指纹）。没有这一项的话，运维换了地址或换了密钥
+	/// 之后旧 id 仍然会被拿去用，表现成持续 404。
+	/// </summary>
 	public void SaveSessionId(string sessionId)
 	{
 		string trimmed = (sessionId ?? string.Empty).Trim();
 		if (trimmed.Length == 0) return;
 		_config.Set(KeySessionId, new ConfigValue.Text(trimmed));
+
+		LuoLiCoreSettings current = Read();
+		_config.Set(
+			KeySessionOwner,
+			new ConfigValue.Text(Fingerprint(current.BaseUrl, current.ApiKey)));
 	}
 }

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSseReader.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSseReader.cs
@@ -1,0 +1,194 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace Nori.Core.Chat.LuoLiCore;
+
+/// <summary>一个已解析的 SSE 帧。</summary>
+internal readonly record struct SseFrame(string Event, string Data);
+
+/// <summary>
+/// LuoLiCore <c>/sdk/v1/.../messages/stream</c> 的 SSE 读取。
+///
+/// 独立成一个纯函数层，是因为这条流的**顺序不变量**是有约束的，而约束只有拿字符串喂进来
+/// 才测得动：
+///
+/// <list type="bullet">
+/// <item><c>queued</c>（如果出现）先于任何 <c>delta</c>。它在 acquire() 之前、turnId 产生
+/// 之前触发，排队可能长达数秒。</item>
+/// <item><c>delta</c> 零至多次。</item>
+/// <item>末尾**恰好** <c>done</c> 或 <c>error</c> 之一，二者互斥且终结这个流。</item>
+/// </list>
+///
+/// 违反这几条说明对端或中间层出了问题，这里宁可抛也不静默吞掉 —— 一个半开的流在上层
+/// 表现为「她开口说了一半就不动了」，没有任何错误可查。
+/// </summary>
+internal static class LuoLiCoreSseReader
+{
+	/// <summary>
+	/// 按帧读。只认 <c>event:</c> 与 <c>data:</c> 两个字段，空行分帧。
+	///
+	/// 不合并多行 <c>data:</c>：对端每个事件的载荷都是单行 JSON，而按 SSE 规范做多行拼接
+	/// 需要额外约定分隔符语义，这里用不到，写了反而多一处与对端不一致的可能。
+	/// </summary>
+	internal static async IAsyncEnumerable<SseFrame> ReadFramesAsync(
+		TextReader reader,
+		[EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		string? eventName = null;
+		string? data = null;
+
+		while (true)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			string? line = await reader.ReadLineAsync(cancellationToken);
+			if (line is null)
+			{
+				// 流结束。攒了一半的帧不吐出去 —— 半个帧不是事件。
+				yield break;
+			}
+
+			if (line.Length == 0)
+			{
+				if (eventName is not null && data is not null) yield return new SseFrame(eventName, data);
+				eventName = null;
+				data = null;
+				continue;
+			}
+
+			// 注释帧（以 ':' 开头）按规范忽略。对端目前不发，但反代可能插入保活注释。
+			if (line[0] == ':') continue;
+
+			int colon = line.IndexOf(':');
+			if (colon < 0) continue;
+
+			string field = line[..colon];
+			string value = line[(colon + 1)..];
+			if (value.StartsWith(' ')) value = value[1..];
+
+			if (field == "event") eventName = value;
+			else if (field == "data") data = value;
+		}
+	}
+
+	/// <summary>
+	/// 把帧流翻译成语义事件，并在翻译过程中强制顺序不变量。
+	///
+	/// 返回的序列里，<c>done</c> / <c>error</c> 一定是最后一项；没有终结事件就走到流末尾的，
+	/// 抛 <see cref="ChatException"/>：那是连接被掐断，不是一次正常的空回复。
+	/// </summary>
+	internal static async IAsyncEnumerable<LuoLiCoreStreamEvent> ReadAsync(
+		TextReader reader,
+		[EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		bool sawDelta = false;
+		bool terminated = false;
+
+		await foreach (SseFrame frame in ReadFramesAsync(reader, cancellationToken))
+		{
+			if (terminated)
+			{
+				// done/error 之后还有帧：对端规定 error 发出后立即 close()，done 同理终结流。
+				throw new ChatException("SDK 流在终结事件之后仍有数据，协议被破坏");
+			}
+
+			switch (frame.Event)
+			{
+				case LuoLiCoreSdkProtocol.EventQueued:
+					if (sawDelta) throw new ChatException("SDK 流的 queued 事件出现在 delta 之后，协议被破坏");
+					yield return LuoLiCoreStreamEvent.Queued();
+					break;
+
+				case LuoLiCoreSdkProtocol.EventDelta:
+				{
+					SdkDelta? delta = Deserialize<SdkDelta>(frame.Data, "delta");
+					sawDelta = true;
+					yield return LuoLiCoreStreamEvent.Delta(delta?.Text ?? string.Empty);
+					break;
+				}
+
+				case LuoLiCoreSdkProtocol.EventDone:
+				{
+					SdkDone? done = Deserialize<SdkDone>(frame.Data, "done");
+					terminated = true;
+					yield return LuoLiCoreStreamEvent.Done(done?.Text ?? string.Empty, done?.Usage);
+					break;
+				}
+
+				case LuoLiCoreSdkProtocol.EventError:
+				{
+					SdkError? error = Deserialize<SdkError>(frame.Data, "error");
+					terminated = true;
+					yield return LuoLiCoreStreamEvent.Failed(
+						error ?? new SdkError("unknown", "SDK 返回了无法解析的错误", false));
+					break;
+				}
+
+				default:
+					// 未知事件名：忽略而不是抛。对端加新事件时不该把老客户端打死。
+					break;
+			}
+		}
+
+		if (!terminated) throw new ChatException("SDK 流未以 done 或 error 结束，连接被中断");
+	}
+
+	private static T? Deserialize<T>(string data, string what)
+	{
+		try
+		{
+			return JsonSerializer.Deserialize<T>(data, LuoLiCoreSdkProtocol.Json);
+		}
+		catch (JsonException exception)
+		{
+			throw new ChatException($"SDK {what} 事件解析失败: {exception.Message}", exception);
+		}
+	}
+}
+
+/// <summary>
+/// 流式事件的判别联合。
+///
+/// 错误与用量在这里**摊平成普通字段**，不直接暴露线上 DTO —— 那几个类型是 `/sdk/v1` 的
+/// 形状，对端改字段时不该波及本项目的公开签名。
+/// </summary>
+public readonly record struct LuoLiCoreStreamEvent(
+	LuoLiCoreStreamEventKind Kind,
+	string Text,
+	int? InputTokens,
+	int? OutputTokens,
+	string? ErrorCode,
+	string? ErrorMessage,
+	bool Retryable)
+{
+	internal static LuoLiCoreStreamEvent Queued() =>
+		new(LuoLiCoreStreamEventKind.Queued, string.Empty, null, null, null, null, false);
+
+	internal static LuoLiCoreStreamEvent Delta(string text) =>
+		new(LuoLiCoreStreamEventKind.Delta, text, null, null, null, null, false);
+
+	internal static LuoLiCoreStreamEvent Done(string text, SdkUsage? usage) =>
+		new(LuoLiCoreStreamEventKind.Done, text, usage?.InputTokens, usage?.OutputTokens, null, null, false);
+
+	internal static LuoLiCoreStreamEvent Failed(SdkError error) =>
+		new(LuoLiCoreStreamEventKind.Error, string.Empty, null, null, error.Code, error.Message, error.Retryable);
+
+	/// <summary>队列满。对端把它表达成 SSE 错误而非 HTTP 429，调用方据此固定退避 5 秒。</summary>
+	public bool IsQueueFull => Kind == LuoLiCoreStreamEventKind.Error
+		&& string.Equals(ErrorCode, LuoLiCoreSdkProtocol.CodeTurnQueueFull, StringComparison.Ordinal);
+}
+
+/// <summary>流式事件类型。</summary>
+public enum LuoLiCoreStreamEventKind
+{
+	/// <summary>进入排队。至多一次，且一定在任何 Delta 之前。</summary>
+	Queued,
+
+	/// <summary>文本增量。零至多次。</summary>
+	Delta,
+
+	/// <summary>正常结束。与 Error 互斥，二者之一必定是最后一项。</summary>
+	Done,
+
+	/// <summary>失败结束。与 Done 互斥。</summary>
+	Error,
+}

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSseReader.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreSseReader.cs
@@ -106,6 +106,16 @@ internal static class LuoLiCoreSseReader
 					break;
 				}
 
+				case LuoLiCoreSdkProtocol.EventTool:
+				{
+					// 不参与顺序不变量：它可以夹在任意两个 delta 之间，也可以出现在没有 delta 的
+					// 轮次里。因此这里既不检查 sawDelta，也不置 terminated。
+					SdkStreamTool? tool = Deserialize<SdkStreamTool>(frame.Data, "tool");
+					if (!string.IsNullOrWhiteSpace(tool?.Name))
+						yield return LuoLiCoreStreamEvent.Tool(tool!.Name);
+					break;
+				}
+
 				case LuoLiCoreSdkProtocol.EventDone:
 				{
 					SdkDone? done = Deserialize<SdkDone>(frame.Data, "done");
@@ -166,6 +176,10 @@ public readonly record struct LuoLiCoreStreamEvent(
 	internal static LuoLiCoreStreamEvent Delta(string text) =>
 		new(LuoLiCoreStreamEventKind.Delta, text, null, null, null, null, false);
 
+	/// <summary>工具名借 <see cref="Text"/> 承载，不为它单开一个字段。</summary>
+	internal static LuoLiCoreStreamEvent Tool(string name) =>
+		new(LuoLiCoreStreamEventKind.Tool, name, null, null, null, null, false);
+
 	internal static LuoLiCoreStreamEvent Done(string text, SdkUsage? usage) =>
 		new(LuoLiCoreStreamEventKind.Done, text, usage?.InputTokens, usage?.OutputTokens, null, null, false);
 
@@ -185,6 +199,13 @@ public enum LuoLiCoreStreamEventKind
 
 	/// <summary>文本增量。零至多次。</summary>
 	Delta,
+
+	/// <summary>
+	/// 对端开始执行一个工具，<see cref="LuoLiCoreStreamEvent.Text"/> 是工具名。
+	///
+	/// 只有请求里显式要了才会出现。不参与顺序不变量 —— 可以夹在任意两个 Delta 之间。
+	/// </summary>
+	Tool,
 
 	/// <summary>正常结束。与 Error 互斥，二者之一必定是最后一项。</summary>
 	Done,

--- a/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreToolPreset.cs
+++ b/app/desktop/Nori.Core/Chat/LuoLiCore/LuoLiCoreToolPreset.cs
@@ -1,0 +1,83 @@
+namespace Nori.Core.Chat.LuoLiCore;
+
+/// <summary>
+/// 桌宠这个来源建议开放的工具清单。
+///
+/// 这份清单**不由本端强制**。工具白名单的权威在对端的 `sources.tools` 列，判据在它的
+/// `toolCallableBy()`；本端配不了别人的权限，也不该假装配得了。这里存在的理由只有两个：
+/// 一是运维照着它去配那一栏时不必回头翻文档，二是 <see cref="Missing"/> 能把「你以为开了、
+/// 其实没开」这件事在界面上说出来 —— 那种不一致排查起来很贵。
+///
+/// 怎么用：在 LuoLiCore 的 WebUI「SDK 接入」页点开桌宠这个来源，工具白名单一栏勾上
+/// <see cref="Recommended"/> 里的名字；或者直接
+/// <c>PATCH /api/sdk/sources/&lt;id&gt;/tools</c>，body 是 <c>{"tools": [...]}</c>。
+/// </summary>
+public static class LuoLiCoreToolPreset
+{
+	/// <summary>文件读写。桌宠最常用的一组 —— 「帮我看看这个文件」「把这段存下来」。</summary>
+	public static readonly IReadOnlyList<string> Files =
+	[
+		"read_file", "list_dir", "glob", "grep",
+		"write_file", "edit_file", "move_file", "delete_file",
+	];
+
+	/// <summary>执行代码。默认在对端的沙箱里跑，不是直接落在宿主机上。</summary>
+	public static readonly IReadOnlyList<string> Code = ["bash", "python"];
+
+	/// <summary>上网。</summary>
+	public static readonly IReadOnlyList<string> Web = ["web_search", "web_fetch"];
+
+	/// <summary>翻本会话的聊天记录。</summary>
+	public static readonly IReadOnlyList<string> Archive =
+	[
+		"search_messages", "read_messages", "get_message", "context_stats",
+	];
+
+	/// <summary>长期记忆。未配置白名单时对端默认给的就是这一组。</summary>
+	public static readonly IReadOnlyList<string> Memory = ["memory_read", "memory_write"];
+
+	/// <summary>
+	/// 自我扩展：她可以给自己写工具、写技能、装 MCP。
+	///
+	/// <c>write_plugin</c> 与 <c>install_mcp</c> 写完之后在对端是**禁用状态**，要 owner 在
+	/// WebUI 里看过源码才能启用 —— 插件以 bot 进程的完整权限运行。这道闸在对端，本端不重复。
+	/// </summary>
+	public static readonly IReadOnlyList<string> SelfExtend =
+	[
+		"define_tool", "delete_tool", "list_tools",
+		"write_skill", "install_skill", "write_plugin",
+		"install_mcp", "list_mcp",
+	];
+
+	/// <summary>上面六组的合集，去重后按名字排序。</summary>
+	public static readonly IReadOnlyList<string> Recommended =
+		[.. new[] { Files, Code, Web, Archive, Memory, SelfExtend }
+			.SelectMany(group => group)
+			.Distinct(StringComparer.Ordinal)
+			.OrderBy(name => name, StringComparer.Ordinal)];
+
+	/// <summary>
+	/// 角色轴挡住的两件，**配了也调不到**，所以不在 <see cref="Recommended"/> 里。
+	///
+	/// 对端的权限有两根正交的轴：角色轴问「这个身份够不够格」，来源白名单问「这一档 agent 该
+	/// 拿哪些」。SDK 会话的角色恒为 trusted，而这两件的 minRole 是 owner —— 角色轴先生效，
+	/// 白名单再怎么配都到不了。把它们列出来是为了让人知道「没给你」不是漏了。
+	/// </summary>
+	public static readonly IReadOnlyList<string> BlockedByRole =
+	[
+		"memory_list",            // 列出全部记忆文档，跨来源，owner 专属
+		"admin_search_messages",  // 跨会话搜聊天记录，owner 专属
+	];
+
+	/// <summary>
+	/// 建议开放但对端实际没给的那几件。
+	///
+	/// 传入 <c>GET /sdk/v1/tools</c> 的结果即可。差集不为空说明白名单没配全，或者对端的运维
+	/// 把某件工具整体禁用了 —— 两种情况在界面上都该说出来，而不是等她说「我做不到」。
+	/// </summary>
+	public static IReadOnlyList<string> Missing(IEnumerable<LuoLiCoreTool> available)
+	{
+		HashSet<string> have = [.. available.Select(tool => tool.Name)];
+		return [.. Recommended.Where(name => !have.Contains(name))];
+	}
+}

--- a/app/desktop/Nori.Core/Configuration/ConfigStore.cs
+++ b/app/desktop/Nori.Core/Configuration/ConfigStore.cs
@@ -40,6 +40,23 @@ public sealed class ConfigStore(NoriDatabase database, ISecretKeyStore? keyStore
 	public const string LegacyKeyLanguage = "app_language";
 
 	/// <summary>配置键: 伴侣模型。</summary>
+	/// <summary>
+	/// 文件工具的工作目录（绝对路径）。空串 = 整族文件工具不注册。
+	///
+	/// 默认空而不是给一个「用户目录」之类的值：那等于替用户做了一个他没同意过的决定。
+	/// 配这个目录本身就是用户那次同意，所以目录内的读取不再逐次弹框（写入仍然每次都问）。
+	/// </summary>
+	public const string KeyWorkspaceRoot = "workspace_root";
+
+	/// <summary>
+	/// 一轮对话里最多连续调用多少次工具。
+	///
+	/// 原先写死 5，而一个「先搜、再读、再改、再验」的任务在第五轮刚好卡在验证之前 —— 她做了
+	/// 一半就停下，对用户表现成「没做完也没说为什么」。放宽不增加简单对话的开销：模型不调
+	/// 工具时循环自己就结束了，上限只决定它最多能走多远。
+	/// </summary>
+	public const string KeyAgentMaxToolIterations = "agent_max_tool_iterations";
+
 	public const string KeySelectedModel = "selected_model";
 
 	/// <summary>配置键: 首次初始化是否已完成。</summary>

--- a/app/desktop/Nori.Core/Tools/WorkspaceAccess.cs
+++ b/app/desktop/Nori.Core/Tools/WorkspaceAccess.cs
@@ -64,7 +64,7 @@ public sealed class WorkspaceAccess
 	/// 把模型给的相对路径解析成工作目录内的绝对路径。越界返回 null。
 	///
 	/// 三层判据缺一不可：
-	/// 1. 拒绝绝对路径：工具契约要求相对路径，绝对路径一律视为越界；
+	/// 1. 拒绝绝对路径与盘符限定路径：工具契约要求相对路径，其余形式一律视为越界；
 	/// 2. `GetFullPath` 规范化后做前缀比较：拦截 `../` 形式的回溯；
 	/// 3. 逐段解引用符号链接后再比较：工作目录内指向外部的链接，前两层均无法拦截。
 	/// </summary>
@@ -74,6 +74,7 @@ public sealed class WorkspaceAccess
 		string path = (relative ?? string.Empty).Trim().Replace('\\', '/');
 		if (path.Length == 0 || path == ".") return Root;
 		if (Path.IsPathRooted(path)) return null;
+		if (IsDriveQualified(path)) return null;
 		if (path.Contains('\0')) return null;
 
 		string combined = Path.GetFullPath(Path.Combine(Root, path));
@@ -100,6 +101,18 @@ public sealed class WorkspaceAccess
 
 		return current;
 	}
+
+	/// <summary>
+	/// 盘符限定的路径（`C:/Windows`、`C:report.txt`）在所有平台上一律拒绝。
+	///
+	/// <see cref="Path.IsPathRooted"/> 的判定随平台变化：Windows 上 `C:/Windows` 是绝对路径，
+	/// 非 Windows 上盘符不成立，该串被当作名为 `C:` 的相对目录，拼接后落在工作目录之内并通过
+	/// 全部校验。判据在此统一，使同一个输入在两个平台上得到同一个结论。
+	///
+	/// 代价是非 Windows 上无法访问名为 `C:` 这种形式的目录。相对于判据分叉，该代价可接受。
+	/// </summary>
+	private static bool IsDriveQualified(string path) =>
+		path.Length >= 2 && path[1] == ':' && char.IsAsciiLetter(path[0]);
 
 	/// <summary>相对工作目录的路径，统一使用正斜杠：该值会被调用方在后续请求中原样回传。</summary>
 	public string Relative(string absolute)

--- a/app/desktop/Nori.Core/Tools/WorkspaceAccess.cs
+++ b/app/desktop/Nori.Core/Tools/WorkspaceAccess.cs
@@ -1,0 +1,170 @@
+using System.Text;
+
+namespace Nori.Core.Tools;
+
+/// <summary>
+/// 工作目录的边界判据。
+///
+/// 文件工具的全部安全性都压在这一个类上：模型给出的路径是不可信输入，而一次越界读取
+/// 泄露的是用户磁盘上的任意文件。因此判据集中在这里、只有一份，四个工具都从它拿路径，
+/// 没有第二条自己拼路径的路。
+///
+/// **未配置工作目录时整族工具不注册**（`Root` 为空）。默认关闭而不是默认给一个
+/// 「用户目录」之类的值：那等于替用户做了一个他没同意过的决定。
+/// </summary>
+public sealed class WorkspaceAccess
+{
+	/// <summary>
+	/// 单个文件最多读多少字节。超出即截断，不是拒绝 —— 看前面那一段往往就够了。
+	///
+	/// 调大这个数有前置条件：工具结果受 <see cref="ToolLimits.MaxResultCharacters"/> 约束
+	/// （48,000 字符），超限时 <c>ToolLimits.CapResult</c> 会把整个结果序列化后截断为字符串，
+	/// 调用方收到的不再是 <c>{path, content}</c> 对象。因此读取侧先自行收窄结果，由
+	/// <c>FitWithin</c> 逐级裁剪，本常量只是第一级粗筛。
+	/// </summary>
+	public const int MaxReadBytes = 128 * 1024;
+
+	/// <summary>一次列目录 / 搜索返回的条目上限。同样受结果长度约束，优先减少条目而非触发截断。</summary>
+	public const int MaxEntries = 80;
+
+	/// <summary>搜索时单个文件最多扫多少字节，超出的部分不看。</summary>
+	public const int MaxScanBytes = 1024 * 1024;
+
+	/// <summary>写入的内容上限。</summary>
+	public const int MaxWriteBytes = 1024 * 1024;
+
+	/// <summary>
+	/// 一律跳过的目录名。
+	///
+	/// 与安全无关，是结果质量约束：`node_modules` 与 `.git` 的命中数量通常远超源码目录，
+	/// 会占满条目上限，使真正相关的命中不进入结果集。
+	/// </summary>
+	private static readonly string[] SkippedDirectories =
+		[".git", ".svn", "node_modules", "bin", "obj", ".venv", "venv", "__pycache__", ".next", "dist", "target"];
+
+	/// <summary>工作目录的绝对路径。空串表示没有配置，整族工具不可用。</summary>
+	public string Root { get; }
+
+	public bool IsConfigured => Root.Length > 0;
+
+	public WorkspaceAccess(string? root)
+	{
+		string trimmed = (root ?? string.Empty).Trim();
+		if (trimmed.Length == 0 || !Directory.Exists(trimmed))
+		{
+			Root = string.Empty;
+			return;
+		}
+
+		// 根路径本身也需解引用：工作目录为符号链接时，未解引用的根会使后续前缀比较全部失配。
+		Root = ResolveFinal(Path.GetFullPath(trimmed));
+	}
+
+	/// <summary>
+	/// 把模型给的相对路径解析成工作目录内的绝对路径。越界返回 null。
+	///
+	/// 三层判据缺一不可：
+	/// 1. 拒绝绝对路径：工具契约要求相对路径，绝对路径一律视为越界；
+	/// 2. `GetFullPath` 规范化后做前缀比较：拦截 `../` 形式的回溯；
+	/// 3. 逐段解引用符号链接后再比较：工作目录内指向外部的链接，前两层均无法拦截。
+	/// </summary>
+	public string? Resolve(string? relative)
+	{
+		if (!IsConfigured) return null;
+		string path = (relative ?? string.Empty).Trim().Replace('\\', '/');
+		if (path.Length == 0 || path == ".") return Root;
+		if (Path.IsPathRooted(path)) return null;
+		if (path.Contains('\0')) return null;
+
+		string combined = Path.GetFullPath(Path.Combine(Root, path));
+		if (!Inside(combined)) return null;
+
+		// 逐段解引用，而非只解析末段。
+		//
+		// 只解析末段无法处理中间段为链接的情形：工作目录内存在指向外部的目录链接 `escape` 时，
+		// `escape/secret.txt` 自身不是链接，解析返回原值，前缀比较通过。逐段解析并比较，
+		// 链接出现在任意层级都会在该层被判定越界。
+		string current = Root;
+		foreach (string segment in Path.GetRelativePath(Root, combined)
+			.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
+		{
+			current = ResolveFinal(Path.Combine(current, segment));
+			if (!Inside(current)) return null;
+		}
+
+		return current;
+	}
+
+	/// <summary>相对工作目录的路径，统一使用正斜杠：该值会被调用方在后续请求中原样回传。</summary>
+	public string Relative(string absolute)
+	{
+		string relative = Path.GetRelativePath(Root, absolute).Replace('\\', '/');
+		return relative == "." ? "" : relative;
+	}
+
+	/// <summary>这个目录该不该跳过（噪音目录）。</summary>
+	public static bool IsSkipped(string directoryName) =>
+		SkippedDirectories.Contains(directoryName, StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// 看起来是不是二进制。
+	///
+	/// 判据为前 8KB 内是否出现 NUL 字节，与 grep 的判定一致，开销恒定。二进制内容进入上下文
+	/// 既无可读性，也会占用 token 预算。
+	/// </summary>
+	public static bool LooksBinary(ReadOnlySpan<byte> head)
+	{
+		int limit = Math.Min(head.Length, 8 * 1024);
+		for (int index = 0; index < limit; index++)
+		{
+			if (head[index] == 0) return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>读文本，超出上限就截断并标注。</summary>
+	public static (string Text, bool Truncated) ReadText(string path)
+	{
+		using FileStream stream = File.OpenRead(path);
+		int length = (int)Math.Min(stream.Length, MaxReadBytes);
+		byte[] buffer = new byte[length];
+		stream.ReadExactly(buffer, 0, length);
+		if (LooksBinary(buffer)) throw new InvalidOperationException("这是二进制文件，读不了");
+		return (new UTF8Encoding(false, false).GetString(buffer), stream.Length > MaxReadBytes);
+	}
+
+	private bool Inside(string candidate)
+	{
+		if (candidate.Equals(Root, StringComparison.OrdinalIgnoreCase)) return true;
+		string prefix = Root.EndsWith(Path.DirectorySeparatorChar) ? Root : Root + Path.DirectorySeparatorChar;
+		return candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
+	/// 解引用符号链接 / junction，拿到最终目标。
+	///
+	/// 路径不存在时原样返回：写入新文件的场景只要求父目录在界内，目标文件尚未创建。
+	/// </summary>
+	private static string ResolveFinal(string path)
+	{
+		try
+		{
+			FileSystemInfo? target = Directory.Exists(path)
+				? Directory.ResolveLinkTarget(path, returnFinalTarget: true)
+				: File.Exists(path)
+					? File.ResolveLinkTarget(path, returnFinalTarget: true)
+					: null;
+			return target is null ? path : Path.GetFullPath(target.FullName);
+		}
+		catch (IOException)
+		{
+			// 链接失效或权限不足时按原路径处理，后续前缀比较仍然有效。
+			return path;
+		}
+		catch (UnauthorizedAccessException)
+		{
+			return path;
+		}
+	}
+}

--- a/app/desktop/Nori.Core/Tools/WorkspaceAccess.cs
+++ b/app/desktop/Nori.Core/Tools/WorkspaceAccess.cs
@@ -88,6 +88,12 @@ public sealed class WorkspaceAccess
 		foreach (string segment in Path.GetRelativePath(Root, combined)
 			.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
 		{
+			// `..` 与 `.` 在此处一律拒绝，不交给后续的前缀比较。
+			//
+			// 大小写敏感的文件系统上，根为 `/tmp/work` 时 `../WORK/secret` 的规范化结果是
+			// `/tmp/WORK/secret`，`GetRelativePath` 会保留一个 `..` 段；而 `Path.Combine` 不做
+			// 规范化，`/tmp/work/..` 这个字符串仍以根为前缀，前缀比较会通过。
+			if (segment is ".." or ".") return null;
 			current = ResolveFinal(Path.Combine(current, segment));
 			if (!Inside(current)) return null;
 		}
@@ -134,11 +140,36 @@ public sealed class WorkspaceAccess
 		return (new UTF8Encoding(false, false).GetString(buffer), stream.Length > MaxReadBytes);
 	}
 
-	private bool Inside(string candidate)
+	/// <summary>
+	/// 路径比较的大小写口径按平台取，与 <c>ResourcePathSafety</c> 一致。
+	///
+	/// 恒用不区分大小写会在大小写敏感的文件系统上放行同级目录：根为 `/tmp/work` 时，
+	/// `/tmp/WORK` 是另一个目录，却会被判定为界内。
+	/// </summary>
+	private static StringComparison Comparison => OperatingSystem.IsWindows()
+		? StringComparison.OrdinalIgnoreCase
+		: StringComparison.Ordinal;
+
+	/// <summary>候选路径是否在工作目录之内。调用方须先保证它已规范化。</summary>
+	public bool Inside(string candidate)
 	{
-		if (candidate.Equals(Root, StringComparison.OrdinalIgnoreCase)) return true;
+		if (!IsConfigured) return false;
+		if (candidate.Equals(Root, Comparison)) return true;
 		string prefix = Root.EndsWith(Path.DirectorySeparatorChar) ? Root : Root + Path.DirectorySeparatorChar;
-		return candidate.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+		return candidate.StartsWith(prefix, Comparison);
+	}
+
+	/// <summary>
+	/// 遍历时校验一个已经拿到手的绝对路径：解引用之后仍在界内才放行。
+	///
+	/// 与 <see cref="Resolve"/> 分开，是因为遍历拿到的是 `Directory.GetDirectories` 的产物，
+	/// 不经过相对路径拼接；但它同样可能是指向外部的链接，必须过同一道判据。
+	/// </summary>
+	public string? Accept(string absolute)
+	{
+		if (!IsConfigured) return null;
+		string resolved = ResolveFinal(Path.GetFullPath(absolute));
+		return Inside(resolved) ? resolved : null;
 	}
 
 	/// <summary>

--- a/app/desktop/Nori.Core/Tools/WorkspaceTools.cs
+++ b/app/desktop/Nori.Core/Tools/WorkspaceTools.cs
@@ -73,6 +73,8 @@ public static class WorkspaceTools
 		{
 			string name = Path.GetFileName(directory);
 			if (WorkspaceAccess.IsSkipped(name)) continue;
+			// 枚举的产物同样可能是指向外部的链接，列出来即等于告诉调用方那个路径可读。
+			if (workspace.Accept(directory) is null) continue;
 			if (entries.Count >= WorkspaceAccess.MaxEntries) { truncated = true; break; }
 			entries.Add(new { name, kind = "folder", path = workspace.Relative(directory) });
 		}
@@ -81,6 +83,7 @@ public static class WorkspaceTools
 		{
 			foreach (string file in Directory.EnumerateFiles(resolved).Order(StringComparer.Ordinal))
 			{
+				if (workspace.Accept(file) is null) continue;
 				if (entries.Count >= WorkspaceAccess.MaxEntries) { truncated = true; break; }
 				entries.Add(new
 				{
@@ -156,7 +159,7 @@ public static class WorkspaceTools
 
 		List<object> hits = [];
 		bool truncated = false;
-		foreach (string file in Walk(root, cancellationToken))
+		foreach (string file in Walk(workspace, root, cancellationToken))
 		{
 			if (hits.Count >= WorkspaceAccess.MaxEntries) { truncated = true; break; }
 			if (suffix is not null && !file.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) continue;
@@ -207,8 +210,18 @@ public static class WorkspaceTools
 		return new { path = workspace.Relative(resolved), bytes = bytes.Length, overwritten = existed };
 	}
 
-	/// <summary>递归遍历，跳过排除目录；无访问权限的目录跳过，不使整次搜索失败。</summary>
-	private static IEnumerable<string> Walk(string root, CancellationToken cancellationToken)
+	/// <summary>
+	/// 递归遍历，跳过排除目录；无访问权限的目录跳过，不使整次搜索失败。
+	///
+	/// **每一个目录与文件都要过一次 <see cref="WorkspaceAccess.Accept"/>。**
+	/// `Directory.GetDirectories` 会返回指向工作目录之外的链接，`GetFiles` 与后续读取都会跟随
+	/// 它。搜索是 `safe` 档、不经确认，因此这条路径上的越界等于无确认的任意文件读取。
+	/// `Resolve` 只覆盖调用方给出的相对路径，遍历拿到的绝对路径必须单独校验。
+	/// </summary>
+	private static IEnumerable<string> Walk(
+		WorkspaceAccess workspace,
+		string root,
+		CancellationToken cancellationToken)
 	{
 		Stack<string> pending = new();
 		pending.Push(root);
@@ -231,10 +244,16 @@ public static class WorkspaceTools
 
 			foreach (string directory in directories)
 			{
-				if (!WorkspaceAccess.IsSkipped(Path.GetFileName(directory))) pending.Push(directory);
+				if (WorkspaceAccess.IsSkipped(Path.GetFileName(directory))) continue;
+				if (workspace.Accept(directory) is null) continue;
+				pending.Push(directory);
 			}
 
-			foreach (string file in files.Order(StringComparer.Ordinal)) yield return file;
+			foreach (string file in files.Order(StringComparer.Ordinal))
+			{
+				if (workspace.Accept(file) is null) continue;
+				yield return file;
+			}
 		}
 	}
 

--- a/app/desktop/Nori.Core/Tools/WorkspaceTools.cs
+++ b/app/desktop/Nori.Core/Tools/WorkspaceTools.cs
@@ -1,0 +1,308 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Nori.Core.Tools;
+
+/// <summary>
+/// 工作目录文件工具：看、找、读、写。
+///
+/// 此前 19 件内建工具均不具备本地文件访问能力，模型无法读取用户当前处理的文件。
+///
+/// 权限分档：读取、列目录、搜索为 `safe`，写入为 `confirm`。工作目录由用户显式配置，该配置
+/// 动作即为授权；若每次读取都触发授权对话框，一次代码浏览会产生数十次确认，实际效果是用户
+/// 关闭该功能。写入修改用户数据，逐次确认。
+///
+/// 不提供删除工具：删除的收益低于风险，清空内容可由写入空文件实现。
+/// </summary>
+public static class WorkspaceTools
+{
+	/// <summary>本组工具名。变更工作目录时据此先注销，避免残留持有旧目录的注册项。</summary>
+	public static readonly IReadOnlyList<string> ToolNames = ["listFiles", "readFile", "searchFiles", "writeFile"];
+
+	/// <summary>
+	/// 注册本组工具，注册前先注销同名项。工作目录被清空时必须真正移除：仅跳过注册的话，旧注册
+	/// 项仍在注册表中，其闭包持有旧目录，配置变更不生效。
+	///
+	/// 未配置工作目录时整组不注册：暴露一件必定失败的工具会导致模型反复重试。
+	/// </summary>
+	public static void RegisterAll(ToolRegistry registry, WorkspaceAccess workspace)
+	{
+		ArgumentNullException.ThrowIfNull(registry);
+		ArgumentNullException.ThrowIfNull(workspace);
+		foreach (string name in ToolNames) registry.Unregister(name);
+		if (!workspace.IsConfigured) return;
+
+		Register(registry, "listFiles",
+			"列出工作目录中某个文件夹下的文件与子文件夹。path 省略时列根目录。", "safe",
+			Schema(("path", "相对工作目录的文件夹路径，省略表示根目录", false)),
+			(args, _) => Task.FromResult<object?>(ListFiles(workspace, Str(args, "path"))));
+
+		Register(registry, "readFile",
+			"读取工作目录中一个文本文件的内容。文件过大时只返回开头部分。", "safe",
+			Schema(("path", "相对工作目录的文件路径", true)),
+			(args, _) => Task.FromResult<object?>(ReadFile(workspace, Str(args, "path"))));
+
+		Register(registry, "searchFiles",
+			"在工作目录中按内容搜索文本，返回命中的文件、行号与该行内容。", "safe",
+			Schema(
+				("query", "要搜索的文本（区分大小写与否由 caseSensitive 决定）", true),
+				("path", "限定搜索的子目录，省略表示整个工作目录", false),
+				("extension", "限定文件扩展名，例如 .cs；省略表示不限", false)),
+			(args, token) => Task.FromResult<object?>(SearchFiles(
+				workspace, Str(args, "query"), Str(args, "path"), Str(args, "extension"), token.CancellationToken)));
+
+		Register(registry, "writeFile",
+			"把内容写入工作目录中的文件，覆盖原有内容。父文件夹不存在时会创建。", "confirm",
+			Schema(
+				("path", "相对工作目录的文件路径", true),
+				("content", "要写入的完整文本内容", true)),
+			(args, _) => Task.FromResult<object?>(WriteFile(workspace, Str(args, "path"), Str(args, "content"))));
+	}
+
+	// ---- 实现 ----
+
+	private static object ListFiles(WorkspaceAccess workspace, string? path)
+	{
+		string resolved = workspace.Resolve(path) ?? throw OutOfBounds(path);
+		if (!Directory.Exists(resolved)) throw new InvalidOperationException($"文件夹不存在: {Show(path)}");
+
+		List<object> entries = [];
+		bool truncated = false;
+		foreach (string directory in Directory.EnumerateDirectories(resolved).Order(StringComparer.Ordinal))
+		{
+			string name = Path.GetFileName(directory);
+			if (WorkspaceAccess.IsSkipped(name)) continue;
+			if (entries.Count >= WorkspaceAccess.MaxEntries) { truncated = true; break; }
+			entries.Add(new { name, kind = "folder", path = workspace.Relative(directory) });
+		}
+
+		if (!truncated)
+		{
+			foreach (string file in Directory.EnumerateFiles(resolved).Order(StringComparer.Ordinal))
+			{
+				if (entries.Count >= WorkspaceAccess.MaxEntries) { truncated = true; break; }
+				entries.Add(new
+				{
+					name = Path.GetFileName(file),
+					kind = "file",
+					path = workspace.Relative(file),
+					bytes = new FileInfo(file).Length,
+				});
+			}
+		}
+
+		return new { path = workspace.Relative(resolved), entries, truncated };
+	}
+
+	private static object ReadFile(WorkspaceAccess workspace, string? path)
+	{
+		string resolved = workspace.Resolve(path) ?? throw OutOfBounds(path);
+		if (!File.Exists(resolved)) throw new InvalidOperationException($"文件不存在: {Show(path)}");
+
+		(string text, bool truncated) = WorkspaceAccess.ReadText(resolved);
+		string relative = workspace.Relative(resolved);
+		return FitWithin(
+			text,
+			(content, cut) => new { path = relative, content, truncated = truncated || cut });
+	}
+
+	/// <summary>
+	/// 将正文裁剪至工具结果长度上限之内，保证返回值仍为对象而非截断后的字符串。
+	///
+	/// 否则 <see cref="ToolLimits.MaxResultCharacters"/> 生效时会把超限结果序列化后整体截断，
+	/// 调用方收到的是不完整的 JSON 文本，既无法取出 `path` 也无法取全 `content`，且无从判断
+	/// 发生了截断。
+	///
+	/// 采用逐级减半而非一次估算：JSON 转义的膨胀系数随内容而变（非 ASCII 字符转义为 6 个
+	/// 字符），按字节预估会显著偏离，实测序列化长度是唯一可靠判据。
+	/// </summary>
+	private static object FitWithin(string text, Func<string, bool, object> build)
+	{
+		string candidate = text;
+		bool cut = false;
+		for (int attempt = 0; attempt < 24; attempt++)
+		{
+			object result = build(candidate, cut);
+			if (ToolLimits.SerializedLength(JsonSerializer.SerializeToNode(result)) <= ToolLimits.MaxResultCharacters)
+			{
+				return result;
+			}
+
+			if (candidate.Length == 0) break;
+			candidate = candidate[..(candidate.Length / 2)];
+			cut = true;
+		}
+
+		return build("", true);
+	}
+
+	private static object SearchFiles(
+		WorkspaceAccess workspace,
+		string? query,
+		string? path,
+		string? extension,
+		CancellationToken cancellationToken)
+	{
+		string needle = (query ?? string.Empty).Trim();
+		if (needle.Length == 0) throw new InvalidOperationException("搜索内容不能为空");
+
+		string root = workspace.Resolve(path) ?? throw OutOfBounds(path);
+		if (!Directory.Exists(root)) throw new InvalidOperationException($"文件夹不存在: {Show(path)}");
+
+		string? suffix = string.IsNullOrWhiteSpace(extension)
+			? null
+			: extension.Trim().StartsWith('.') ? extension.Trim() : "." + extension.Trim();
+
+		List<object> hits = [];
+		bool truncated = false;
+		foreach (string file in Walk(root, cancellationToken))
+		{
+			if (hits.Count >= WorkspaceAccess.MaxEntries) { truncated = true; break; }
+			if (suffix is not null && !file.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)) continue;
+
+			foreach ((int number, string line) in MatchingLines(file, needle))
+			{
+				if (hits.Count >= WorkspaceAccess.MaxEntries) { truncated = true; break; }
+				hits.Add(new
+				{
+					path = workspace.Relative(file),
+					line = number,
+					// 单行可能极长（压缩后的 js 为单行），按上限截断。
+					text = ToolLimits.CapText(line.Trim(), 300),
+				});
+			}
+		}
+
+		// 命中数超限时从尾部移除，而非触发整体截断：靠前的命中相关度通常更高。
+		while (hits.Count > 0 &&
+			ToolLimits.SerializedLength(JsonSerializer.SerializeToNode(new { query = needle, hits, truncated = true }))
+				> ToolLimits.MaxResultCharacters)
+		{
+			hits.RemoveAt(hits.Count - 1);
+			truncated = true;
+		}
+
+		return new { query = needle, hits, truncated };
+	}
+
+	private static object WriteFile(WorkspaceAccess workspace, string? path, string? content)
+	{
+		string resolved = workspace.Resolve(path) ?? throw OutOfBounds(path);
+		if (Directory.Exists(resolved)) throw new InvalidOperationException($"这是一个文件夹，不能写: {Show(path)}");
+
+		string text = content ?? string.Empty;
+		byte[] bytes = new UTF8Encoding(false).GetBytes(text);
+		if (bytes.Length > WorkspaceAccess.MaxWriteBytes)
+		{
+			throw new InvalidOperationException(
+				$"内容超过 {WorkspaceAccess.MaxWriteBytes / 1024} KB 上限，拒绝写入");
+		}
+
+		string? parent = Path.GetDirectoryName(resolved);
+		if (parent is not null && !Directory.Exists(parent)) Directory.CreateDirectory(parent);
+
+		bool existed = File.Exists(resolved);
+		File.WriteAllBytes(resolved, bytes);
+		return new { path = workspace.Relative(resolved), bytes = bytes.Length, overwritten = existed };
+	}
+
+	/// <summary>递归遍历，跳过排除目录；无访问权限的目录跳过，不使整次搜索失败。</summary>
+	private static IEnumerable<string> Walk(string root, CancellationToken cancellationToken)
+	{
+		Stack<string> pending = new();
+		pending.Push(root);
+		while (pending.Count > 0)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			string current = pending.Pop();
+
+			string[] directories;
+			string[] files;
+			try
+			{
+				directories = Directory.GetDirectories(current);
+				files = Directory.GetFiles(current);
+			}
+			catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
+			{
+				continue;
+			}
+
+			foreach (string directory in directories)
+			{
+				if (!WorkspaceAccess.IsSkipped(Path.GetFileName(directory))) pending.Push(directory);
+			}
+
+			foreach (string file in files.Order(StringComparer.Ordinal)) yield return file;
+		}
+	}
+
+	private static IEnumerable<(int Number, string Line)> MatchingLines(string file, string needle)
+	{
+		byte[] head;
+		try
+		{
+			using FileStream stream = File.OpenRead(file);
+			int length = (int)Math.Min(stream.Length, WorkspaceAccess.MaxScanBytes);
+			head = new byte[length];
+			stream.ReadExactly(head, 0, length);
+		}
+		catch (Exception exception) when (exception is UnauthorizedAccessException or IOException)
+		{
+			yield break;
+		}
+
+		if (WorkspaceAccess.LooksBinary(head)) yield break;
+
+		string text = new UTF8Encoding(false, false).GetString(head);
+		int number = 0;
+		foreach (string line in text.Split('\n'))
+		{
+			number++;
+			if (line.Contains(needle, StringComparison.OrdinalIgnoreCase))
+			{
+				yield return (number, line.TrimEnd('\r'));
+			}
+		}
+	}
+
+	// ---- 小工具 ----
+
+	private static InvalidOperationException OutOfBounds(string? path) =>
+		new($"路径超出工作目录范围: {Show(path)}");
+
+	private static string Show(string? path) => string.IsNullOrWhiteSpace(path) ? "(空)" : path;
+
+	private static string? Str(JsonNode? args, string name) =>
+		args?[name]?.GetValue<string>();
+
+	private static JsonObject Schema(params (string Name, string Description, bool Required)[] properties)
+	{
+		JsonObject props = new();
+		JsonArray required = [];
+		foreach ((string name, string description, bool isRequired) in properties)
+		{
+			props[name] = new JsonObject { ["type"] = "string", ["description"] = description };
+			if (isRequired) required.Add(name);
+		}
+
+		return new JsonObject { ["type"] = "object", ["properties"] = props, ["required"] = required };
+	}
+
+	private static void Register(
+		ToolRegistry registry,
+		string name,
+		string description,
+		string permissionLevel,
+		JsonObject parameters,
+		Func<JsonNode?, ToolContext, Task<object?>> execute) =>
+		registry.Register(new RegisteredTool
+		{
+			Name = name,
+			Description = description,
+			Parameters = parameters,
+			PermissionLevel = permissionLevel,
+			Execute = execute,
+		});
+}

--- a/app/desktop/Nori.Desktop.Tests/BridgeCommandsTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/BridgeCommandsTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Nori.Core.Automation;
 using Nori.Core.Chat;
+using Nori.Core.Chat.LuoLiCore;
 using Nori.Core.Configuration;
 using Nori.Core.Data;
 using Nori.Core.Logging;
@@ -648,6 +649,77 @@ public class BridgeCommandsTests : IDisposable
 
 		Assert.Equal($"未在市场中找到技能 ID: {skillId}", error.Message);
 		Assert.DoesNotContain(_runtime.Skills.GetInstalled(), skill => skill.Id == skillId);
+	}
+
+
+	/// <summary>
+	/// 把 LuoLiCore 配成「已启用、已有会话、地址指向一个没人监听的端口」。
+	///
+	/// 端口选 1 是因为它不会有人在听：非安全模式下真去调那个重置端点必然连接失败，安全模式下
+	/// 必须压根不发这次请求 —— 两条用例靠这个差别互为对照。
+	/// </summary>
+	private void ConfigureUnreachableLuoLiCore()
+	{
+		_config.Set(LuoLiCoreSettingsStore.KeyEnabled, new ConfigValue.Boolean(true));
+		_config.Set(LuoLiCoreSettingsStore.KeyBaseUrl, new ConfigValue.Text("http://127.0.0.1:1"));
+		_config.Set(LuoLiCoreSettingsStore.KeyApiKey, new ConfigValue.Text("sk-unreachable"));
+		_config.Set(LuoLiCoreSettingsStore.KeySessionId, new ConfigValue.Text("sess_fixed"));
+	}
+
+	/// <summary>
+	/// 安全模式禁用一切外部调用（AGENTS.md §1），重置远端会话是一次真正的出网请求。
+	///
+	/// 但清空本地记录本身是纯本地操作，不该被一起禁掉 —— 排障的时候连清个记录都做不到是过度
+	/// 收紧。所以这一条要的是：跳过远端、本地照清、并且把「远端没清」如实报给调用方。
+	/// </summary>
+	[Fact]
+	public async Task 安全模式下清空聊天记录不去碰远端()
+	{
+		using BridgeCommandsTests fixture = new(safeMode: true);
+		fixture.ConfigureUnreachableLuoLiCore();
+		fixture._services.Chat.SaveMessage("user", "在吗");
+		fixture._services.Chat.SaveMessage("assistant", "在的");
+
+		object? result = await fixture.CreateCommands().InvokeAsync(
+			new FakeBridgeSource(WindowLabels.Main), "chat_clear", Args(new { }));
+
+		// 连不上那个端口的话这里会抛，能返回就说明确实没发那次请求。
+		string json = JsonSerializer.Serialize(result, BridgeJson.Options);
+		Assert.Contains("\"remoteReset\":false", json, StringComparison.Ordinal);
+		Assert.Contains("安全模式", json, StringComparison.Ordinal);
+		Assert.Empty(fixture._services.Chat.GetHistory());
+	}
+
+	/// <summary>
+	/// 非安全模式下这条命令**必须**真的去调远端 —— 否则上一条用例是恒真的。
+	///
+	/// 远端不可达时整条命令失败、本地记录原样留着：两边宁可都不清，也不能一边清了一边没清。
+	/// </summary>
+	[Fact]
+	public async Task 非安全模式下清空会真的去调远端()
+	{
+		ConfigureUnreachableLuoLiCore();
+		_services.Chat.SaveMessage("user", "在吗");
+
+		await Assert.ThrowsAnyAsync<Exception>(() => CreateCommands().InvokeAsync(
+			new FakeBridgeSource(WindowLabels.Main), "chat_clear", Args(new { })));
+
+		Assert.NotEmpty(_services.Chat.GetHistory());
+	}
+
+	/// <summary>没接外部后端时不该给出那句提示 —— 它只会让人以为有什么东西没清干净。</summary>
+	[Fact]
+	public async Task 没接外部后端时安全模式下照常清空且不提示()
+	{
+		using BridgeCommandsTests fixture = new(safeMode: true);
+		fixture._services.Chat.SaveMessage("user", "在吗");
+
+		object? result = await fixture.CreateCommands().InvokeAsync(
+			new FakeBridgeSource(WindowLabels.Main), "chat_clear", Args(new { }));
+
+		string json = JsonSerializer.Serialize(result, BridgeJson.Options);
+		Assert.DoesNotContain("安全模式", json, StringComparison.Ordinal);
+		Assert.Empty(fixture._services.Chat.GetHistory());
 	}
 
 	[Fact]

--- a/app/desktop/Nori.Desktop.Tests/BridgeCommandsTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/BridgeCommandsTests.cs
@@ -686,6 +686,132 @@ public class BridgeCommandsTests : IDisposable
 		_config.Set(LuoLiCoreSettingsStore.KeySessionId, new ConfigValue.Text("sess_fixed"));
 	}
 
+	// ---- 文件访问设置页（工作目录 + 工具轮数）----
+
+	[Fact]
+	public async Task 设置工作目录之后文件工具才出现()
+	{
+		string folder = Path.Combine(_tempDir, "工作区");
+		Directory.CreateDirectory(folder);
+		BridgeCommands commands = CreateCommands();
+
+		// 没配之前一件都没有 —— 让模型看见一件永远失败的工具只会让它反复试。
+		Assert.Null(_runtime.Tools.Get("readFile"));
+
+		await commands.InvokeAsync(
+			new FakeBridgeSource(WindowLabels.Main), "settings_update_workspace", Args(new { root = folder }));
+
+		Assert.NotNull(_runtime.Tools.Get("readFile"));
+		Assert.NotNull(_runtime.Tools.Get("writeFile"));
+	}
+
+	/// <summary>
+	/// 清空之后必须真的消失。
+	///
+	/// 工具在注册时把工作目录焊进了闭包，只靠「不再注册」的话旧工具还挂着、还指着旧目录 ——
+	/// 用户在界面上清空了，她却照样读得到，这种不一致很难查。
+	/// </summary>
+	[Fact]
+	public async Task 清空工作目录之后文件工具消失()
+	{
+		string folder = Path.Combine(_tempDir, "工作区");
+		Directory.CreateDirectory(folder);
+		BridgeCommands commands = CreateCommands();
+		FakeBridgeSource main = new(WindowLabels.Main);
+
+		await commands.InvokeAsync(main, "settings_update_workspace", Args(new { root = folder }));
+		Assert.NotNull(_runtime.Tools.Get("readFile"));
+
+		await commands.InvokeAsync(main, "settings_update_workspace", Args(new { root = "" }));
+
+		Assert.Null(_runtime.Tools.Get("readFile"));
+		Assert.Null(_runtime.Tools.Get("writeFile"));
+	}
+
+	/// <summary>
+	/// 存一个不存在的路径不会报错，但那一族工具会静默不注册 —— 用户看到自己填了值、她却说
+	/// 「我看不到文件」。就地拒绝比事后排查便宜得多。
+	/// </summary>
+	[Fact]
+	public async Task 不存在的文件夹被就地拒绝()
+	{
+		BridgeCommands commands = CreateCommands();
+
+		InvalidOperationException error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			commands.InvokeAsync(
+				new FakeBridgeSource(WindowLabels.Main),
+				"settings_update_workspace",
+				Args(new { root = Path.Combine(_tempDir, "并不存在") })));
+
+		Assert.Contains("不存在", error.Message, StringComparison.Ordinal);
+		Assert.Equal("", _config.GetStringOr(ConfigStore.KeyWorkspaceRoot, ""));
+	}
+
+	[Fact]
+	public async Task 工具轮数存成整数并被夹回范围()
+	{
+		BridgeCommands commands = CreateCommands();
+		FakeBridgeSource main = new(WindowLabels.Main);
+
+		await commands.InvokeAsync(main, "settings_update_workspace", Args(new { maxToolIterations = 20 }));
+		Assert.Equal(20, _runtime.Engine.ConfiguredToolIterations);
+
+		await commands.InvokeAsync(main, "settings_update_workspace", Args(new { maxToolIterations = 999 }));
+		Assert.Equal(Nori.Core.Agent.AgentEngine.MaxToolIterationsLimit, _runtime.Engine.ConfiguredToolIterations);
+
+		// 存的是 Integer 而不是 Text：文本那条路上 "0"/"1" 会被解析成布尔再渲染成 "false"/"true"。
+		await commands.InvokeAsync(main, "settings_update_workspace", Args(new { maxToolIterations = 1 }));
+		Assert.Equal(1, _runtime.Engine.ConfiguredToolIterations);
+	}
+
+	[Fact]
+	public async Task 快照把工作目录与轮数报给界面()
+	{
+		string folder = Path.Combine(_tempDir, "工作区");
+		Directory.CreateDirectory(folder);
+		BridgeCommands commands = CreateCommands();
+		await commands.InvokeAsync(
+			new FakeBridgeSource(WindowLabels.Main),
+			"settings_update_workspace",
+			Args(new { root = folder, maxToolIterations = 9 }));
+
+		JsonElement snapshot = JsonSerializer.SerializeToElement(_runtime.BuildSnapshot(), BridgeJson.Options);
+		JsonElement workspace = snapshot.GetProperty("workspace");
+
+		Assert.Equal(folder, workspace.GetProperty("root").GetString());
+		Assert.True(workspace.GetProperty("available").GetBoolean());
+		Assert.Equal(9, workspace.GetProperty("maxToolIterations").GetInt32());
+	}
+
+	/// <summary>目录被删掉之后配置还在，但工具已经不注册了 —— 界面要能说出这个差别。</summary>
+	[Fact]
+	public async Task 目录事后被删掉时快照报告不可用()
+	{
+		string folder = Path.Combine(_tempDir, "会被删掉");
+		Directory.CreateDirectory(folder);
+		await CreateCommands().InvokeAsync(
+			new FakeBridgeSource(WindowLabels.Main), "settings_update_workspace", Args(new { root = folder }));
+
+		Directory.Delete(folder);
+		_runtime.InvalidateSnapshot("workspace");
+
+		JsonElement snapshot = JsonSerializer.SerializeToElement(_runtime.BuildSnapshot(), BridgeJson.Options);
+		JsonElement workspace = snapshot.GetProperty("workspace");
+
+		Assert.Equal(folder, workspace.GetProperty("root").GetString());
+		Assert.False(workspace.GetProperty("available").GetBoolean());
+	}
+
+	[Fact]
+	public async Task 设置窗口可以执行这两条命令()
+	{
+		// 原生设置页不走 WebView invoke，命令必须在 SettingsService 的白名单里，否则界面上
+		// 的按钮点了会报「不允许执行」。
+		Assert.Contains("settings_update_workspace", SettingsService.Commands);
+		Assert.Contains("settings_pick_workspace", SettingsService.Commands);
+		await Task.CompletedTask;
+	}
+
 	/// <summary>
 	/// 安全模式禁用一切外部调用（AGENTS.md §1），重置远端会话是一次真正的出网请求。
 	///

--- a/app/desktop/Nori.Desktop.Tests/BridgeCommandsTests.cs
+++ b/app/desktop/Nori.Desktop.Tests/BridgeCommandsTests.cs
@@ -653,6 +653,26 @@ public class BridgeCommandsTests : IDisposable
 
 
 	/// <summary>
+	/// 安全模式跳过的是**出网那一步**，不是「什么都不做」。
+	///
+	/// 本地记着的会话必须作废，否则退出安全模式之后那段「已经清掉」的上下文会原样回来。
+	/// </summary>
+	[Fact]
+	public async Task 安全模式下清空同时作废本地会话()
+	{
+		using BridgeCommandsTests fixture = new(safeMode: true);
+		fixture.ConfigureUnreachableLuoLiCore();
+		Assert.Equal("sess_fixed", fixture._config.GetStringOr(LuoLiCoreSettingsStore.KeySessionId, ""));
+
+		await fixture.CreateCommands().InvokeAsync(
+			new FakeBridgeSource(WindowLabels.Main), "chat_clear", Args(new { }));
+
+		// 连不上那个端口的话上面那一句会抛，能走到这里就说明没发请求。
+		Assert.Equal("", fixture._config.GetStringOr(LuoLiCoreSettingsStore.KeySessionId, ""));
+		Assert.Equal("", fixture._config.GetStringOr(LuoLiCoreSettingsStore.KeySessionOwner, ""));
+	}
+
+	/// <summary>
 	/// 把 LuoLiCore 配成「已启用、已有会话、地址指向一个没人监听的端口」。
 	///
 	/// 端口选 1 是因为它不会有人在听：非安全模式下真去调那个重置端点必然连接失败，安全模式下

--- a/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
+++ b/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
@@ -928,11 +928,37 @@ public sealed class BridgeCommands
 	private async Task<object?> ClearChatAsync(IBridgeSource source, CancellationToken cancellationToken) =>
 		await RequireMainAsync(source, async () =>
 		{
-			await Runtime.Engine.ResetRemoteContextAsync(cancellationToken);
+			// 安全模式禁用一切外部调用（AGENTS.md §1「Safe Mode」），重置远端会话是一次
+			// 真正的出网请求，所以这里跳过它。
+			//
+			// 不把 chat_clear 整条加进 IsNetworkCommand：清空本地聊天记录本身是纯本地操作，
+			// 安全模式没有理由连它一起禁掉 —— 那会让人在排障时连清个记录都做不到。
+			//
+			// 代价是两边会不一致：安全模式下对话本来就不走远端（chat_start 已被挡），远端的
+			// 上下文停在进入安全模式那一刻，清完本地它还记着。因此把这件事**报给调用方**，
+			// 由界面提示一句，而不是让用户以为清干净了 —— 这种不一致查起来比清不掉贵得多。
+			bool remoteReset = false;
+			if (!_services.SafeMode)
+			{
+				remoteReset = await Runtime.Engine.ResetRemoteContextAsync(cancellationToken);
+			}
+
 			_services.Chat.ClearHistory();
 			Runtime.InvalidateSnapshot("chat");
-			return null;
+			return new ClearChatResult(
+				remoteReset,
+				_services.SafeMode && Runtime.Engine.HasRemoteContext
+					? "安全模式下未重置外部会话，退出安全模式后再清空一次"
+					: null);
 		});
+
+	/// <summary>
+	/// 清空聊天记录的结果。
+	///
+	/// <paramref name="RemoteReset"/> 为 false 有两种原因：没接外部后端（无事可做），或者安全
+	/// 模式跳过了那次调用（<paramref name="Note"/> 会说明）。两者对界面的意义不同。
+	/// </summary>
+	private sealed record ClearChatResult(bool RemoteReset, string? Note);
 
 	private async Task<object?> MemoryAddAsync(IBridgeSource source, JsonElement args)
 	{

--- a/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
+++ b/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
@@ -247,10 +247,16 @@ public sealed class BridgeCommands
 				Runtime.InvalidateSnapshot("general", "telemetry");
 			})),
 
-		// invoke("settings_update_workspace", {root?, maxToolIterations?})
+		/// <summary>
+		/// 更新文件工具的工作目录与单轮工具次数上限。
+		/// 前端调用：invoke("settings_update_workspace", {root?: string, maxToolIterations?: number})
+		/// </summary>
 		"settings_update_workspace" => RequireMain(source, () => Run(() => UpdateWorkspaceSettings(args))),
 
-		// invoke("settings_pick_workspace") → {root} | null（用户取消时 null）
+		/// <summary>
+		/// 打开系统文件夹选择对话框，返回选中路径；用户取消时返回 null。
+		/// 前端调用：invoke("settings_pick_workspace")
+		/// </summary>
 		"settings_pick_workspace" => await PickWorkspaceAsync(source),
 
 		// ---- 自动更新 ----

--- a/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
+++ b/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
@@ -937,8 +937,16 @@ public sealed class BridgeCommands
 			// 代价是两边会不一致：安全模式下对话本来就不走远端（chat_start 已被挡），远端的
 			// 上下文停在进入安全模式那一刻，清完本地它还记着。因此把这件事**报给调用方**，
 			// 由界面提示一句，而不是让用户以为清干净了 —— 这种不一致查起来比清不掉贵得多。
+			// 判据要在动手之前取：作废之后再问「有没有远端会话」恒为否。
+			bool hadRemoteSession = Runtime.Engine.HasRemoteContext;
 			bool remoteReset = false;
-			if (!_services.SafeMode)
+			if (_services.SafeMode)
+			{
+				// 安全模式不出网，但本地记着的会话必须作废 —— 否则退出安全模式之后那段「已经
+				// 清掉」的上下文会原样回来。这一步不联网。
+				Runtime.Engine.ForgetRemoteSession();
+			}
+			else
 			{
 				remoteReset = await Runtime.Engine.ResetRemoteContextAsync(cancellationToken);
 			}
@@ -947,8 +955,10 @@ public sealed class BridgeCommands
 			Runtime.InvalidateSnapshot("chat");
 			return new ClearChatResult(
 				remoteReset,
-				_services.SafeMode && Runtime.Engine.HasRemoteContext
-					? "安全模式下未重置外部会话，退出安全模式后再清空一次"
+				_services.SafeMode && hadRemoteSession
+					// 用户这一侧已经干净了：本地空了，那段会话也不会再被用到。留着说一句是因为
+					// 旧会话的内容仍留在对端服务器上 —— 删它需要联网，而安全模式的前提是不联网。
+					? "安全模式下未联系外部服务；本地会话已作废，重新启用后会开一段新的对话"
 					: null);
 		});
 

--- a/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
+++ b/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
@@ -431,11 +431,7 @@ public sealed class BridgeCommands
 			(long)(OptionalDouble(args, "beforeId") ?? 0))),
 
 		// invoke("chat_clear")
-		"chat_clear" => RequireMain(source, () => Run(() =>
-		{
-			_services.Chat.ClearHistory();
-			Runtime.InvalidateSnapshot("chat");
-		})),
+		"chat_clear" => await ClearChatAsync(source, cancellationToken),
 
 		// ---- 记忆库 ----
 		/// invoke("memory_add", {content, type?, importance?, tags?})
@@ -918,6 +914,25 @@ public sealed class BridgeCommands
 		await RequireVisibleMainVoidAsync(source);
 		return await Automation.StopAllAsync(cancellationToken).ConfigureAwait(false);
 	}
+
+	/// <summary>
+	/// 清空聊天记录。
+	///
+	/// 对话交给 LuoLiCore 时，上下文记在对端，本地表只是一份副本。**先重置远端、成功了才删
+	/// 本地**：反过来的话，删完本地远端却没清，她下一句仍然接得上前面聊过的内容，而界面上
+	/// 什么都没有了，用户只会以为清空没生效 —— 这种不一致比清不掉难查得多。
+	///
+	/// 因此远端重置失败时整条命令失败，本地记录原样留着，两边仍然一致。连不上对端又确实要
+	/// 清本地的话，关掉 LuoLiCore 再清。
+	/// </summary>
+	private async Task<object?> ClearChatAsync(IBridgeSource source, CancellationToken cancellationToken) =>
+		await RequireMainAsync(source, async () =>
+		{
+			await Runtime.Engine.ResetRemoteContextAsync(cancellationToken);
+			_services.Chat.ClearHistory();
+			Runtime.InvalidateSnapshot("chat");
+			return null;
+		});
 
 	private async Task<object?> MemoryAddAsync(IBridgeSource source, JsonElement args)
 	{

--- a/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
+++ b/app/desktop/Nori.Desktop/Bridge/BridgeCommands.cs
@@ -247,6 +247,12 @@ public sealed class BridgeCommands
 				Runtime.InvalidateSnapshot("general", "telemetry");
 			})),
 
+		// invoke("settings_update_workspace", {root?, maxToolIterations?})
+		"settings_update_workspace" => RequireMain(source, () => Run(() => UpdateWorkspaceSettings(args))),
+
+		// invoke("settings_pick_workspace") → {root} | null（用户取消时 null）
+		"settings_pick_workspace" => await PickWorkspaceAsync(source),
+
 		// ---- 自动更新 ----
 		/// <summary>
 		/// 检查是否有可用软件更新。
@@ -1728,6 +1734,68 @@ public sealed class BridgeCommands
 	// ===================================================================
 	// 配置写入 (内部直写, 不再暴露给前端通用入口)
 	// ===================================================================
+
+	/// <summary>
+	/// 文件工具的工作目录与工具轮数上限。
+	///
+	/// 目录在此处即时校验是否存在。写入不存在的路径不会报错，但该组工具会静默不注册，表现为
+	/// 配置项有值而工具不可用，排查成本高。空串为合法取值，表示禁用该功能。
+	/// </summary>
+	private void UpdateWorkspaceSettings(JsonElement args)
+	{
+		if (args.ValueKind == JsonValueKind.Object
+			&& args.TryGetProperty("root", out JsonElement rootValue)
+			&& rootValue.ValueKind == JsonValueKind.String)
+		{
+			string root = (rootValue.GetString() ?? "").Trim();
+			if (root.Length > 0 && !Directory.Exists(root))
+			{
+				throw new InvalidOperationException("这个文件夹不存在，换一个吧");
+			}
+
+			_services.Config.Set(ConfigStore.KeyWorkspaceRoot, new ConfigValue.Text(root));
+		}
+
+		if (args.ValueKind == JsonValueKind.Object
+			&& args.TryGetProperty("maxToolIterations", out JsonElement iterations)
+			&& iterations.ValueKind == JsonValueKind.Number
+			&& iterations.TryGetInt32(out int parsed))
+		{
+			// 存为 Integer 而非 Text：文本路径上 "0"/"1" 会被解析为布尔并渲染为 "false"/"true"。
+			_services.Config.Set(
+				ConfigStore.KeyAgentMaxToolIterations,
+				new ConfigValue.Integer(Math.Clamp(
+					parsed,
+					Nori.Core.Agent.AgentEngine.MinToolIterations,
+					Nori.Core.Agent.AgentEngine.MaxToolIterationsLimit)));
+		}
+
+		// 工具注册表依赖工作目录构建，变更后必须重建，否则要到下次启动才生效。
+		Runtime.RebuildTools();
+		Runtime.InvalidateSnapshot("workspace", "tools");
+	}
+
+	/// <summary>
+	/// 选文件夹。返回选中的路径，用户取消时返回 null。
+	///
+	/// 仅返回选择结果，不写配置：写入仍由 `settings_update_workspace` 承担，配置只有一个写入点。
+	/// </summary>
+	private async Task<object?> PickWorkspaceAsync(IBridgeSource source)
+	{
+		RequireMainVoid(source);
+		Avalonia.Controls.Window? self = source.Self ?? throw new InvalidOperationException("来源窗口不可用");
+		string? picked = await _uiDispatcher.InvokeTaskAsync(async () =>
+		{
+			IReadOnlyList<IStorageFolder> folders = await self.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+			{
+				Title = "选择可访问的文件夹",
+				AllowMultiple = false,
+			});
+			return folders.Count > 0 ? folders[0].Path.LocalPath : null;
+		});
+
+		return picked is null ? null : new { root = picked };
+	}
 
 	private void UpdateConfigDirect(string key, string value) =>
 		_services.Config.Set(key, new ConfigValue.Text(value));

--- a/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
+++ b/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
@@ -214,7 +214,9 @@ public sealed class AppRuntime : IAsyncDisposable
 			// 未启用时这条路完全不参与，桌宠照旧走本机 agent。
 			luoLiCore: new Nori.Core.Chat.LuoLiCore.LuoLiCoreConversation(
 				new Nori.Core.Chat.LuoLiCore.LuoLiCoreSettingsStore(config),
-				options => new Nori.Core.Chat.LuoLiCore.LuoLiCoreSdkClient(services.Http, options)));
+				options => new Nori.Core.Chat.LuoLiCore.LuoLiCoreSdkClient(services.Http, options)),
+			// 走 LuoLiCore 时远端只给文本，表情动作在本地挑。
+			replyReaction: new ReplyReactionService(services.Http, config));
 
 		// 窗口显隐变化 (含托盘切换伴侣) 直接作废快照, 主界面的伴侣状态因此不会陈旧
 		if (services.Windows is not null)

--- a/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
+++ b/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
@@ -791,12 +791,18 @@ public sealed class AppRuntime : IAsyncDisposable
 	/// 文件工具在注册时将工作目录捕获进闭包，不重建则配置变更要到下次启动才生效，表现为保存
 	/// 未成功。MCP 与插件工具按各自分类原子替换，本方法不涉及。
 	/// </summary>
-	public void RebuildTools()
-	{
-		WorkspaceTools.RegisterAll(
-			Tools,
-			new WorkspaceAccess(Services.Config.GetStringOr(ConfigStore.KeyWorkspaceRoot, "")));
-	}
+	public void RebuildTools() => WorkspaceTools.RegisterAll(Tools, ResolveWorkspace());
+
+	/// <summary>
+	/// 当前该给文件工具哪个工作目录。构建与重建共用这一处判据。
+	///
+	/// 安全模式返回未配置：该组工具虽不产生网络请求，但具备对宿主文件系统的读写能力。只在
+	/// 构建时判、不在重建时判的话，安全模式下改一次设置就会把工具注册回来。
+	/// </summary>
+	private WorkspaceAccess ResolveWorkspace() =>
+		Services.SafeMode
+			? new WorkspaceAccess("")
+			: new WorkspaceAccess(Services.Config.GetStringOr(ConfigStore.KeyWorkspaceRoot, ""));
 
 	private ToolRegistry BuildToolRegistry(bool audioAvailable)
 	{
@@ -816,14 +822,8 @@ public sealed class AppRuntime : IAsyncDisposable
 		});
 
 		// 文件工具仅在配置了工作目录时注册。安全模式下一并跳过：该组工具虽不产生网络请求，
-		// 但具备对宿主文件系统的读写能力，属于安全模式要禁用的范围。
-		if (!Services.SafeMode)
-		{
-			WorkspaceTools.RegisterAll(
-				registry,
-				new WorkspaceAccess(Services.Config.GetStringOr(ConfigStore.KeyWorkspaceRoot, "")));
-		}
-
+		// 但具备对宿主文件系统的读写能力，属于安全模式要禁用的范围。判据与 RebuildTools 共用。
+		WorkspaceTools.RegisterAll(registry, ResolveWorkspace());
 		return registry;
 	}
 

--- a/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
+++ b/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
@@ -210,7 +210,11 @@ public sealed class AppRuntime : IAsyncDisposable
 			pet: new PetActionsAdapter(() => services.PetRuntime),
 			motionNames: () => FlattenMotionNames(),
 			expressionNames: () => services.PetRuntime?.Expressions ?? [],
-			trace: services.AgentTrace);
+			trace: services.AgentTrace,
+			// 未启用时这条路完全不参与，桌宠照旧走本机 agent。
+			luoLiCore: new Nori.Core.Chat.LuoLiCore.LuoLiCoreConversation(
+				new Nori.Core.Chat.LuoLiCore.LuoLiCoreSettingsStore(config),
+				options => new Nori.Core.Chat.LuoLiCore.LuoLiCoreSdkClient(services.Http, options)));
 
 		// 窗口显隐变化 (含托盘切换伴侣) 直接作废快照, 主界面的伴侣状态因此不会陈旧
 		if (services.Windows is not null)

--- a/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
+++ b/app/desktop/Nori.Desktop/Runtime/AppRuntime.cs
@@ -785,6 +785,19 @@ public sealed class AppRuntime : IAsyncDisposable
 		}
 	}
 
+	/// <summary>
+	/// 改完工作目录之后重建内建工具。
+	///
+	/// 文件工具在注册时将工作目录捕获进闭包，不重建则配置变更要到下次启动才生效，表现为保存
+	/// 未成功。MCP 与插件工具按各自分类原子替换，本方法不涉及。
+	/// </summary>
+	public void RebuildTools()
+	{
+		WorkspaceTools.RegisterAll(
+			Tools,
+			new WorkspaceAccess(Services.Config.GetStringOr(ConfigStore.KeyWorkspaceRoot, "")));
+	}
+
 	private ToolRegistry BuildToolRegistry(bool audioAvailable)
 	{
 		ToolRegistry registry = new();
@@ -801,6 +814,16 @@ public sealed class AppRuntime : IAsyncDisposable
 			Config = Services.Config,
 			OpenUrl = url => ShellOpen.OpenUrl(url),
 		});
+
+		// 文件工具仅在配置了工作目录时注册。安全模式下一并跳过：该组工具虽不产生网络请求，
+		// 但具备对宿主文件系统的读写能力，属于安全模式要禁用的范围。
+		if (!Services.SafeMode)
+		{
+			WorkspaceTools.RegisterAll(
+				registry,
+				new WorkspaceAccess(Services.Config.GetStringOr(ConfigStore.KeyWorkspaceRoot, "")));
+		}
+
 		return registry;
 	}
 
@@ -1228,6 +1251,14 @@ public sealed class AppRuntime : IAsyncDisposable
 				petAutoSummon = ParseBoolFlag(config.GetStringOr("pet_auto_summon", "true")) ?? true,
 				sidebarCollapsed = ParseBoolFlag(config.GetStringOr("ui_sidebar_collapsed", "")) ?? false,
 				autoCheckUpdates = config.GetBoolOr("auto_check_updates", true),
+			},
+			// 文件工具那一族的配置。`workspaceRoot` 为空即整族不注册，界面据此显示「未启用」。
+			workspace = new
+			{
+				root = config.GetStringOr(ConfigStore.KeyWorkspaceRoot, ""),
+				// 目录被删除或移动后配置仍在，但工具已不再注册，界面需要区分这两种状态。
+				available = new WorkspaceAccess(config.GetStringOr(ConfigStore.KeyWorkspaceRoot, "")).IsConfigured,
+				maxToolIterations = Engine.ConfiguredToolIterations,
 			},
 			telemetry = new
 			{

--- a/app/desktop/Nori.Desktop/Settings/SettingsService.cs
+++ b/app/desktop/Nori.Desktop/Settings/SettingsService.cs
@@ -37,6 +37,8 @@ public sealed class SettingsService : IDisposable
 		"tts_stop",
 		"stt_start",
 		"stt_stop",
+		"settings_update_workspace",
+		"settings_pick_workspace",
 		"settings_update_proactive",
 		"reminder_add",
 		"reminder_cancel",

--- a/app/desktop/Nori.Desktop/Settings/SettingsViewModel.cs
+++ b/app/desktop/Nori.Desktop/Settings/SettingsViewModel.cs
@@ -40,6 +40,7 @@ public sealed class SettingsViewModel : SettingsObservableObject, IDisposable
 
 		NavigateCommand = new SettingsCommand(parameter => Navigate(parameter as string));
 		AddPage(new AiSettingsPage(_service, _lifetimeCts.Token));
+		AddPage(new WorkspaceSettingsPage(_service, _lifetimeCts.Token));
 		AddPage(new VoiceSettingsPage(_service, _lifetimeCts.Token));
 		AddPage(new ProactiveSettingsPage(_service, _lifetimeCts.Token));
 		AddPage(new GeneralSettingsPage(_service, _lifetimeCts.Token));

--- a/app/desktop/Nori.Desktop/Settings/WorkspaceSettingsPage.cs
+++ b/app/desktop/Nori.Desktop/Settings/WorkspaceSettingsPage.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+
+namespace Nori.Desktop.Settings;
+
+/// <summary>
+/// 文件访问设置页：她能看哪个文件夹，以及一轮里最多连续用多少次工具。
+///
+/// 归入 `core` 组，与「AI 大脑」相邻：前者决定模型与推理配置，本页决定可访问的资源范围。
+/// </summary>
+public sealed class WorkspaceSettingsPage : SettingsPageBase
+{
+	/// <summary>创建文件访问设置页。</summary>
+	public WorkspaceSettingsPage(SettingsService service, CancellationToken lifetimeToken = default)
+		: base(
+			service,
+			"workspace",
+			"core",
+			new("文件访问", "File access"),
+			new("选择她可以查看和修改的文件夹，并控制单轮工具次数。", "Choose the folder she may read and edit, and cap tool calls per turn."),
+			lifetimeToken)
+	{
+		SettingsSectionViewModel folder = AddSection(new("工作文件夹", "Working folder"));
+
+		// 选择按钮排在输入框之前：多数用户使用选择对话框，手工输入路径是次要入口。
+		AddAction(
+			folder,
+			"pickWorkspace",
+			new("选择文件夹…", "Choose folder…"),
+			new("留空表示不授予本地文件访问权限。", "Leave empty to grant no local file access."),
+			new SettingsCommand(async _ => await PickAsync()));
+
+		AddField(
+			folder,
+			"workspaceRoot",
+			new("文件夹路径", "Folder path"),
+			new(
+				"文件的查看、搜索与修改均限定在该文件夹内，超出范围的路径一律拒绝。修改文件逐次请求确认。",
+				"Reading, searching and editing are limited to this folder; paths outside it are refused. Edits request confirmation each time."),
+			SettingsEditorKind.Text,
+			snapshot => SettingsSnapshotReader.String(snapshot, "", "workspace", "root"),
+			"",
+			(value, token) => ExecuteAsync(
+				"settings_update_workspace",
+				new { root = Convert.ToString(value) ?? "" },
+				token));
+
+		SettingsSectionViewModel limits = AddSection(new("工具次数", "Tool calls"));
+		AddField(
+			limits,
+			"maxToolIterations",
+			new("单轮最多用几次工具", "Tool calls per turn"),
+			new(
+				"单轮回复中连续调用工具的次数上限。调高不影响不使用工具的对话：循环在模型停止调用工具时结束。",
+				"Maximum consecutive tool calls in one reply. Raising it does not affect turns without tool use; the loop ends when the model stops calling tools."),
+			// 使用数字框而非滑块：当前呈现层的滑块不显示数值，而该设置项的判读依赖具体数字。
+			SettingsEditorKind.Number,
+			snapshot => SettingsSnapshotReader.Number(
+				snapshot,
+				Core.Agent.AgentEngine.DefaultToolIterations,
+				"workspace",
+				"maxToolIterations"),
+			(double)Core.Agent.AgentEngine.DefaultToolIterations,
+			(value, token) => ExecuteAsync(
+				"settings_update_workspace",
+				new { maxToolIterations = (int)Convert.ToDouble(value) },
+				token),
+			minimum: Core.Agent.AgentEngine.MinToolIterations,
+			maximum: Core.Agent.AgentEngine.MaxToolIterationsLimit,
+			increment: 1);
+	}
+
+	/// <summary>
+	/// 打开系统文件夹选择对话框，选定后写回配置。
+	///
+	/// 用户取消时不做任何变更，特别是不清空已有配置。
+	/// </summary>
+	private async Task PickAsync()
+	{
+		JsonElement picked = await ExecuteAsync("settings_pick_workspace");
+		if (picked.ValueKind != JsonValueKind.Object
+			|| !picked.TryGetProperty("root", out JsonElement root)
+			|| root.ValueKind != JsonValueKind.String)
+		{
+			return;
+		}
+
+		await ExecuteAsync("settings_update_workspace", new { root = root.GetString() ?? "" });
+	}
+}

--- a/app/desktop/Nori.Desktop/Settings/WorkspaceSettingsPage.cs
+++ b/app/desktop/Nori.Desktop/Settings/WorkspaceSettingsPage.cs
@@ -27,7 +27,10 @@ public sealed class WorkspaceSettingsPage : SettingsPageBase
 			"pickWorkspace",
 			new("选择文件夹…", "Choose folder…"),
 			new("留空表示不授予本地文件访问权限。", "Leave empty to grant no local file access."),
-			new SettingsCommand(async _ => await PickAsync()));
+			// 不写成 `async _ => await ...`：那会被转成 Action<object?>，即 async void，
+			// 抛出的异常逃到 UI 线程成为未处理异常。与其余各页一致，交给一个返回 Task 的
+			// 方法并在其中 catch，失败走状态栏。
+			new SettingsCommand(_ => _ = PickAsync()));
 
 		AddField(
 			folder,
@@ -76,14 +79,31 @@ public sealed class WorkspaceSettingsPage : SettingsPageBase
 	/// </summary>
 	private async Task PickAsync()
 	{
-		JsonElement picked = await ExecuteAsync("settings_pick_workspace");
-		if (picked.ValueKind != JsonValueKind.Object
-			|| !picked.TryGetProperty("root", out JsonElement root)
-			|| root.ValueKind != JsonValueKind.String)
+		try
 		{
-			return;
-		}
+			JsonElement picked = await ExecuteAsync(
+				"settings_pick_workspace", cancellationToken: LifetimeToken).ConfigureAwait(false);
+			if (picked.ValueKind != JsonValueKind.Object
+				|| !picked.TryGetProperty("root", out JsonElement root)
+				|| root.ValueKind != JsonValueKind.String)
+			{
+				return;
+			}
 
-		await ExecuteAsync("settings_update_workspace", new { root = root.GetString() ?? "" });
+			await ExecuteAsync(
+				"settings_update_workspace",
+				new { root = root.GetString() ?? "" },
+				LifetimeToken).ConfigureAwait(false);
+			// 不在此处刷新页面：`settings_update_workspace` 已经作废快照，
+			// 设置服务的 StateChanged 会驱动重新读取。
+		}
+		catch (OperationCanceledException)
+		{
+			// 设置窗口关闭时正常取消，不报错。
+		}
+		catch (Exception exception)
+		{
+			SetStatus(exception.Message);
+		}
 	}
 }

--- a/app/desktop/src/services/host/commands.ts
+++ b/app/desktop/src/services/host/commands.ts
@@ -53,6 +53,19 @@ import type {PluginInfo, PluginInstallResult, PluginUninstallResult} from "../pl
 export type CommandArgs = JsonObject
 export type EmptyCommandArgs = undefined
 
+/** `settings_update_workspace` 的返回：写入后的工作目录状态。 */
+export interface WorkspaceSettingsResult {
+	/** 当前工作目录的绝对路径；空串表示未启用文件工具。 */
+	root: string
+	/** 该目录当前是否可用。与 `root` 分开：目录被删除或移动后配置仍在，但工具已不再注册。 */
+	available: boolean
+	/** 单轮回复中连续调用工具的次数上限。 */
+	maxToolIterations: number
+}
+
+/** `settings_pick_workspace` 的返回；用户取消选择时为 `null`。 */
+export type WorkspacePickResult = {root: string} | null
+
 /** 前端实际使用的宿主命令契约。C# 仍会再次校验参数和来源窗口。 */
 export interface BridgeCommandMap {
 	ui_get_snapshot: {args: EmptyCommandArgs; result: UiSnapshot}
@@ -91,6 +104,8 @@ export interface BridgeCommandMap {
 	settings_update_voice: {args: CommandArgs; result: void}
 	settings_update_general: {args: CommandArgs; result: void}
 	settings_update_proactive: {args: CommandArgs; result: void}
+	settings_update_workspace: {args: Partial<{root: string; maxToolIterations: number}>; result: WorkspaceSettingsResult}
+	settings_pick_workspace: {args: EmptyCommandArgs; result: WorkspacePickResult}
 	settings_update_automation: {args: Partial<{enabled: boolean; desktopEnabled: boolean; browserEnabled: boolean}>; result: AutomationSettingsDto}
 	automation_get_snapshot: {args: EmptyCommandArgs; result: UiSnapshot["automation"]}
 	automation_update_settings: {args: Partial<{enabled: boolean; allowPointer: boolean; allowKeyboard: boolean; allowScroll: boolean; browserEnabled: boolean}>; result: AutomationSettingsDto}

--- a/app/desktop/src/services/runtime/index.ts
+++ b/app/desktop/src/services/runtime/index.ts
@@ -6,6 +6,7 @@
  */
 import {ref} from "vue"
 import {invoke} from "../host/invoke"
+import type {WorkspacePickResult, WorkspaceSettingsResult} from "../host/commands"
 import {listen, type UnlistenFn} from "../host/event"
 import {feedback} from "../feedback"
 import type {
@@ -426,6 +427,14 @@ export const RUNTIME = {
 	},
 	updateProactive(patch: Partial<{idleEnabled: boolean; idleMinutes: number; dailyGreeting: boolean}>): Promise<void> {
 		return invoke("settings_update_proactive", patch)
+	},
+	/** 更新文件工具的工作目录与单轮工具次数上限。传空串的 root 表示停用文件工具。 */
+	updateWorkspace(patch: Partial<{root: string; maxToolIterations: number}>): Promise<WorkspaceSettingsResult> {
+		return invoke("settings_update_workspace", patch)
+	},
+	/** 打开系统文件夹选择对话框；用户取消时返回 null，调用方应保持原有配置不变。 */
+	pickWorkspace(): Promise<WorkspacePickResult> {
+		return invoke("settings_pick_workspace")
 	},
 	updateAutomation(patch: Partial<{enabled: boolean; desktopEnabled: boolean; browserEnabled: boolean}>): Promise<AutomationSettingsDto> {
 		return invoke("settings_update_automation", patch)


### PR DESCRIPTION
## 这个 PR 做什么

给内建工具补一组本地文件访问能力，并配一个原生设置页。

**依赖 #39**：分支基于它，diff 里包含那 8 个提交。本 PR 自身的改动是
`feat(tools): 工作目录文件访问` 这一个。#39 合并后我 rebase 一次。

## 为什么

现有 19 件内建工具均不具备本地文件访问能力。模型能抓网页、能读写长期记忆，但读不到用户当前
正在处理的文件 —— 「看一下这个项目」这类请求无法完成。

## 四件工具

| 工具 | 权限 | 说明 |
|---|---|---|
| `listFiles` | safe | 列目录，跳过 `node_modules` / `.git` / `bin` 等目录 |
| `readFile` | safe | 读文本，二进制内容不进上下文 |
| `searchFiles` | safe | 按内容搜索，返回文件、行号与该行 |
| `writeFile` | confirm | 写入，逐次请求确认 |

不提供删除工具：删除的收益低于风险，清空内容可由写入空文件实现。

**权限分档的依据**：工作目录由用户显式配置，该配置动作即为授权。若每次读取都触发授权对话框，
一次代码浏览会产生数十次确认，实际效果是用户关闭该功能。写入修改用户数据，逐次确认。

**默认关闭**：`workspace_root` 默认空，整组不注册。不设默认目录 —— 那相当于代替用户做出未经
同意的决定。安全模式下同样不注册：该组工具虽不产生网络请求，但具备对宿主文件系统的读写能力。

## 边界判据

集中在 `WorkspaceAccess.Resolve`，四件工具共用一份，三层缺一不可：

1. 拒绝绝对路径
2. `GetFullPath` 规范化后前缀比较，拦截 `../` 回溯
3. **逐段解引用符号链接后再比较**

第三层的首个实现只解析末段，存在越界缺陷：工作目录内存在指向外部的目录链接 `escape` 时，
`escape/secret.txt` 自身不是链接，解析返回原值，前缀比较通过 —— 构成任意文件读取。改为逐段
解析并比较。该缺陷由用例「指向目录外的符号链接被拦下」发现。

## 结果长度约束

工具结果受 `ToolLimits.MaxResultCharacters`（48,000 字符）约束，超限时 `CapResult` 会把整个
结果序列化后截断为字符串，调用方收到的不再是 `{path, content}` 对象，既取不出 `path` 也取不全
`content`，且无从判断发生了截断。

因此读取按实测序列化长度逐级减半裁剪，搜索命中超限时从尾部移除，两者都保证返回值仍为对象。
非 ASCII 字符转义为 6 个字符，按字节预估会显著偏离，实测长度是唯一可靠判据。

## 工具轮数上限

由写死的 5 改为可配（`agent_max_tool_iterations`，默认 12，范围 1–32）。

「搜索 → 读取 → 修改 → 验证」类任务在第五轮处于验证之前即被截断，表现为任务完成一半且无
提示。放宽不增加无工具调用对话的开销：循环在模型停止调用工具时结束，上限只决定可达的最大
步数。

## 设置页

`WorkspaceSettingsPage`，**原生 Avalonia，未涉及 WebView**。页面只声明字段
（`AddSection` / `AddField` / `AddAction`），控件由既有的 `SettingsFieldPresenter` 渲染，与
其余各页同源。归入 `core` 组、与「AI 大脑」相邻：前者决定模型与推理配置，本页决定可访问的
资源范围。

文件夹选择走 `StorageProvider.OpenFolderPickerAsync`，与既有的 Live2D 模型导入同一路径。
轮数使用数字框而非滑块：当前呈现层的滑块不显示数值，而该设置项的判读依赖具体数字。

三处配套改动：

- 变更工作目录后重建工具。文件工具在注册时将工作目录捕获进闭包，不重建则配置变更要到下次
  启动才生效。
- 注册前先注销同名项。工作目录被清空时必须真正移除：仅跳过注册的话，旧注册项仍在注册表中
  且闭包持有旧目录。
- 不存在的文件夹即时拒绝。写入不存在的路径不会报错，但该组工具会静默不注册，表现为配置项
  有值而工具不可用。

快照新增 `workspace` 段，`available` 与 `root` 分为两个字段：目录被删除或移动后配置仍在而
工具已不再注册，界面需要区分这两种状态。

## 测试

`WorkspaceToolsTests` 24 条、`AgentToolIterationsTests` 8 条、`BridgeCommandsTests` 新增 7 条。
变异验证：移除注册前的注销步骤，「清空工作目录之后文件工具消失」失败。

`dotnet build` 0 警告 0 错误（`TreatWarningsAsErrors` 开启）。`dotnet test` 失败集与 `main`
基线逐条按测试名一致 —— `AssetServerTests` ×2 与插件路由的 Host 头保护在本分支之前即失败。

## 与代码执行的关系

本 PR 不引入 `bash` / `python`。那需要沙箱，是另一个量级的工作（Codex 为此在三个平台各写了
一套：macOS Seatbelt、Linux bubblewrap、Windows AppContainer/MXC）。文件读写不需要沙箱，
`confirm` 档的逐次确认已经是边界。
